### PR TITLE
Set Redis key expiry to 30min

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -25,7 +25,8 @@ function get(id) {
 }
 
 function set(id, metaData) {
-  redisClient.set(id, JSON.stringify(metaData), redis.print);
+  // set expiry to 30min (30 * 60 = 1800)
+  redisClient.set(id, JSON.stringify(metaData), 'EX', 1800, redis.print);
 }
 
 module.exports = {


### PR DESCRIPTION
issue messages, PRs, deployments and statuses won't be updated if they're more than 30min old