### PR TITLE
Tweak coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   "jest": {
     "testEnvironment": "node",
     "coverageDirectory": "./coverage/",
-    "collectCoverageFrom" : ["lib/**/*.{js,jsx}"]
+    "collectCoverageFrom": ["lib/**/*.{js,jsx}"]
   }
 }


### PR DESCRIPTION
- Check coverage for all of `lib/`
- Only show coverage when running `npm test`. This allows you to run `jest --watch` without the coverage report taking up so much of the display