### PR TITLE
Set default LOG_LEVEL

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "setupFiles": ["./test/setup/nock.js"],
+    "setupFiles": ["./test/setup"],
     "coverageDirectory": "./coverage/",
     "collectCoverageFrom": ["lib/**/*.{js,jsx}"]
   },

--- a/test/setup/env.js
+++ b/test/setup/env.js
@@ -1,0 +1,2 @@
+// Change default LOG_LEVEL to error unless it is explicitly set
+process.env.LOG_LEVEL = process.env.LOG_LEVEL || 'error';

--- a/test/setup/index.js
+++ b/test/setup/index.js
@@ -1,0 +1,2 @@
+require('./env');
+require('./nock');


### PR DESCRIPTION
This sets a default `LOG_LEVEL` to get rid of the noise in the tests. If you want to see log output when running the tests, just set the env variable:

```
$ LOG_LEVEL=trace npm test
```