### PR TITLE
Only post codecov comment if coverage changes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+comment:
+  # only post the comment if coverage changes
+  require_changes: true


### PR DESCRIPTION
I like the codecov report, but I've found I'm starting to ignore it since it's always the first comment on a PR.  This updates the config to only post a comment if the coverage changes.