### PR TITLE
Fix response to subscribe command

### DIFF
--- a/lib/slack/commands/index.js
+++ b/lib/slack/commands/index.js
@@ -19,7 +19,7 @@ module.exports = (robot) => {
 
     robot.log.debug({ response, command: req.body }, 'Response from command');
 
-    res.status(200).json({ attachments: [response] });
+    res.status(200).json(response);
   });
 
   robot.log.trace('Loaded commands');

--- a/lib/slack/commands/subscribe.js
+++ b/lib/slack/commands/subscribe.js
@@ -55,13 +55,17 @@ module.exports = async (command, { robot, router }) => {
     // @TODO: Move to renderer
     return {
       response_type: 'in_channel',
-      text: `Subscribed <#${to}> to <${from.html_url}|${from.full_name}>`,
+      attachments: [{
+        text: `Subscribed <#${to}> to <${from.html_url}|${from.full_name}>`,
+      }],
     };
   }
   // @TODO: Move to renderer
   return {
-    color: 'danger',
-    text: `\`${match[1]}\` does not appear to be a GitHub link.`,
-    mrkdwn_in: ['text'],
+    attachments: [{
+      color: 'danger',
+      text: `\`${match[1]}\` does not appear to be a GitHub link.`,
+      mrkdwn_in: ['text'],
+    }],
   };
 };

--- a/test/integration/__snapshots__/subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/subscriptions.test.js.snap
@@ -18,9 +18,9 @@ exports[`Integration: subscriptions successfully subscribing to a repository 1`]
 Object {
   "attachments": Array [
     Object {
-      "response_type": "in_channel",
       "text": "Subscribed <#C2147483705> to <https://github.com/bkeepers/dotenv|bkeepers/dotenv>",
     },
   ],
+  "response_type": "in_channel",
 }
 `;


### PR DESCRIPTION
`response_type: "in_channel"` needs to be in top-level of response.

@wilhelmklopp I'm going to go ahead and merge this once the tests pass instead of waiting for a review since we noticed this while we were pairing earlier.