### PR TITLE
Tweak logging so errors get posted

### DIFF
--- a/lib/github/installations.js
+++ b/lib/github/installations.js
@@ -12,16 +12,15 @@ module.exports = (robot) => {
         where: { ownerId: context.payload.installation.account.id },
         defaults: { githubId: context.payload.installation.id },
       })
-      .spread((installation, created) => {
-        robot.log(installation.get({ plain: true }));
-        robot.log(created);
+      .then(([installation, created]) => {
+        context.log({ created, installation }, 'GitHub App installed');
       });
   });
 
   robot.on('installation.deleted', async (context) => {
-    await Installation
-      .destroy({
-        where: { ownerId: context.payload.installation.account.id },
-      });
+    const ownerId = context.payload.installation.account.id;
+    await Installation.destroy({ where: { ownerId } }).then((records) => {
+      context.log({ ownerId, records }, 'GitHub App uninstalled');
+    });
   });
 };

--- a/lib/github/notifications/deployments.js
+++ b/lib/github/notifications/deployments.js
@@ -19,26 +19,16 @@ async function deploymentStatus(context, channel) {
     exists = false;
   }
   if (exists) {
-    slack.web.chat.update(storedMetaData.ts, storedMetaData.channel, '', deploymentStatusMessage.getRenderedMessage(), (err, res) => {
-      if (err) {
-        console.log('Error:', err);
-      } else {
-        console.log('Message sent: ', res);
-      }
-    });
+    const res = await slack.web.chat.update(storedMetaData.ts, storedMetaData.channel, '', deploymentStatusMessage.getRenderedMessage());
+    context.log(res, 'Updated Slack message');
   } else {
-    slack.web.chat.postMessage(channel, '', deploymentStatusMessage.getRenderedMessage(), (err, res) => {
-      if (err) {
-        console.log('Error:', err);
-      } else {
-        console.log('Message sent: ', res);
-        const messageMetaData = {
-          channel: res.channel,
-          ts: res.ts,
-        };
-        set(`deployment-${id}`, messageMetaData);
-      }
-    });
+    const res = await slack.web.chat.postMessage(channel, '', deploymentStatusMessage.getRenderedMessage());
+    context.log(res, 'Posted Slack message');
+    const messageMetaData = {
+      channel: res.channel,
+      ts: res.ts,
+    };
+    set(`deployment-${id}`, messageMetaData);
   }
 }
 

--- a/lib/github/notifications/issues.js
+++ b/lib/github/notifications/issues.js
@@ -17,13 +17,8 @@ async function updateIssueMessage(messageMetaData, context) {
     eventType: 'issues.opened',
   });
   // 3rd argument is required in API wrapper, but not in API (We don't want to use it in this case)
-  slack.web.chat.update(messageMetaData.ts, messageMetaData.channel, '', issueMessage.getRenderedMessage(), (err, res) => {
-    if (err) {
-      console.log('Error:', err);
-    } else {
-      console.log('Message sent: ', res);
-    }
-  });
+  const res = await slack.web.chat.update(messageMetaData.ts, messageMetaData.channel, '', issueMessage.getRenderedMessage());
+  context.log(res, 'Updated Slack message');
 }
 
 async function matchMetaDataStatetoIssueMessage(context) {
@@ -43,23 +38,20 @@ async function issueEvent(context, channel) {
   });
 
   // 2nd argument is required in API wrapper, but not in API (We don't want to use it in this case)
-  slack.web.chat.postMessage(channel, '', issueMessage.getRenderedMessage(), async (err, res) => {
-    if (err) {
-      console.log('Error:', err);
-    } else {
-      console.log('Message sent: ', res);
-      const messageMetaData = {
-        channel: res.channel,
-        ts: res.ts,
-      };
-      if (eventType === 'issues.opened') {
-        // save major message meta data by issue id
-        set(context.payload.issue.id, messageMetaData);
-      } else {
-        matchMetaDataStatetoIssueMessage(context);
-      }
-    }
-  });
+  const res = await slack.web.chat.postMessage(channel, '', issueMessage.getRenderedMessage());
+  context.log(res, 'Posted Slack message');
+
+  const messageMetaData = {
+    channel: res.channel,
+    ts: res.ts,
+  };
+
+  if (eventType === 'issues.opened') {
+    // save major message meta data by issue id
+    set(context.payload.issue.id, messageMetaData);
+  } else {
+    matchMetaDataStatetoIssueMessage(context);
+  }
 }
 
 module.exports = {

--- a/lib/github/notifications/pullRequests.js
+++ b/lib/github/notifications/pullRequests.js
@@ -26,21 +26,17 @@ async function pullRequestEvent(context, channel) {
     sender: context.payload.sender,
   });
   // 2nd argument is required in API wrapper, but not in API (We don't want to use it in this case)
-  slack.web.chat.postMessage(channel, '', prMessage.getRenderedMessage(), (err, res) => {
-    if (err) {
-      console.log('Error:', err);
-    } else {
-      console.log('Message sent: ', res);
-      const messageMetaData = {
-        channel: res.channel,
-        ts: res.ts,
-        context: context.issue(),
-      };
-      if (eventType === 'pull_request.opened') {
-        set(`pull-${context.payload.pull_request.id}`, messageMetaData); // store PR id so that the PR can be mapped to the slack message
-      }
-    }
-  });
+  const res = await slack.web.chat.postMessage(channel, '', prMessage.getRenderedMessage());
+  context.log(res, 'Posted Slack message');
+
+  const messageMetaData = {
+    channel: res.channel,
+    ts: res.ts,
+    context: context.issue(),
+  };
+  if (eventType === 'pull_request.opened') {
+    set(`pull-${context.payload.pull_request.id}`, messageMetaData); // store PR id so that the PR can be mapped to the slack message
+  }
 }
 
 function storePRMapping(context) {
@@ -71,13 +67,8 @@ async function onStatus(context) {
   });
 
   // 2nd argument is required in API wrapper, but not in API (We don't want to use it in this case)
-  slack.web.chat.update(message.ts, message.channel, '', prMessage.getRenderedMessage(), (err, res) => {
-    if (err) {
-      console.log('Error:', err);
-    } else {
-      console.log('Message sent: ', res);
-    }
-  });
+  const res = await slack.web.chat.update(message.ts, message.channel, '', prMessage.getRenderedMessage());
+  context.log(res, 'Updated Slack message');
 }
 
 module.exports = {

--- a/lib/github/notifications/push.js
+++ b/lib/github/notifications/push.js
@@ -11,13 +11,8 @@ async function push(context, channel) {
       push: context.payload,
     });
 
-    slack.web.chat.postMessage(channel, '', pushMessage.getRenderedMessage(), async (err, res) => {
-      if (err) {
-        console.log('Error:', err);
-      } else {
-        console.log('Message sent: ', res);
-      }
-    });
+    const res = await slack.web.chat.postMessage(channel, '', pushMessage.getRenderedMessage());
+    context.log(res, 'Posted Slack message');
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2060,6 +2060,7 @@
       "version": "4.15.4",
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
       "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
+      "optional": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
@@ -2094,7 +2095,8 @@
         "qs": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
+          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
+          "optional": true
         }
       }
     },
@@ -2199,6 +2201,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
       "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+      "optional": true,
       "requires": {
         "debug": "2.6.8",
         "encodeurl": "1.0.1",
@@ -2286,7 +2289,8 @@
     "forwarded": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M=",
+      "optional": true
     },
     "fresh": {
       "version": "0.5.0",
@@ -3161,6 +3165,13 @@
         "netrc": "0.1.4"
       }
     },
+    "github-webhook-handler": {
+      "version": "github:rvagg/github-webhook-handler#7cfcb5b724a7735f132778cf15245cac8547ff60",
+      "requires": {
+        "bl": "1.1.2",
+        "buffer-equal-constant-time": "1.0.1"
+      }
+    },
     "glob": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
@@ -3484,7 +3495,8 @@
     "ipaddr.js": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
+      "optional": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -4624,6 +4636,30 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.1.0.tgz",
+      "integrity": "sha1-xjl80uX9WD1lwAeoPce7eOaYK4M=",
+      "requires": {
+        "jws": "3.1.4",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.0.0",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5746,7 +5782,7 @@
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "probot": {
-      "version": "github:probot/probot#a1831021ec638854de8238365dd4a9bd51151220",
+      "version": "github:probot/probot#27b7c8d406073f926052f3a7cb8466b5792b1cc5",
       "requires": {
         "bottleneck": "1.16.0",
         "bunyan": "1.8.12",
@@ -5755,8 +5791,8 @@
         "cache-manager": "2.5.0",
         "commander": "2.11.0",
         "dotenv": "4.0.0",
-        "express": "4.15.4",
-        "github": "12.0.5",
+        "express": "4.16.2",
+        "github": "12.0.7",
         "github-webhook-handler": "github:rvagg/github-webhook-handler#7cfcb5b724a7735f132778cf15245cac8547ff60",
         "hbs": "4.0.1",
         "jest": "21.2.1",
@@ -5777,12 +5813,95 @@
             "es6-promisify": "5.0.0"
           }
         },
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.15"
+          }
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+        },
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "etag": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+        },
+        "express": {
+          "version": "4.16.2",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+          "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+          "requires": {
+            "accepts": "1.3.4",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.2",
+            "content-disposition": "0.5.2",
+            "content-type": "1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "finalhandler": "1.1.0",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "1.1.2",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "2.0.2",
+            "qs": "6.5.1",
+            "range-parser": "1.2.0",
+            "safe-buffer": "5.1.1",
+            "send": "0.16.1",
+            "serve-static": "1.13.1",
+            "setprototypeof": "1.1.0",
+            "statuses": "1.3.1",
+            "type-is": "1.6.15",
+            "utils-merge": "1.0.1",
+            "vary": "1.1.2"
+          }
+        },
+        "finalhandler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+          "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
           }
         },
         "follow-redirects": {
@@ -5791,12 +5910,32 @@
           "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
           "requires": {
             "debug": "3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
           }
         },
+        "forwarded": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+        },
         "github": {
-          "version": "12.0.5",
-          "resolved": "https://registry.npmjs.org/github/-/github-12.0.5.tgz",
-          "integrity": "sha512-4U81TDODHt6RcbuRGwKYmdCmiV4PfnR0NWRIyiZdBoYYGZCRav+KiL45XMueJW8EU5FBiZ2Ox9RoPz1iQUmlJQ==",
+          "version": "12.0.7",
+          "resolved": "https://registry.npmjs.org/github/-/github-12.0.7.tgz",
+          "integrity": "sha512-m2lDLc7pA8WRWYGHTwXIZr9SlekWLzer5gVp4os37BkbChb9SW+1XEA77zHfzD6f8szdCYK1cxxu/rF+qBeWyA==",
           "requires": {
             "dotenv": "4.0.0",
             "follow-redirects": "1.2.6",
@@ -5804,13 +5943,13 @@
             "lodash": "4.17.4",
             "mime": "2.0.3",
             "netrc": "0.1.4"
-          }
-        },
-        "github-webhook-handler": {
-          "version": "github:rvagg/github-webhook-handler#7cfcb5b724a7735f132778cf15245cac8547ff60",
-          "requires": {
-            "bl": "1.1.2",
-            "buffer-equal-constant-time": "1.0.1"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz",
+              "integrity": "sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug=="
+            }
           }
         },
         "https-proxy-agent": {
@@ -5820,34 +5959,17 @@
           "requires": {
             "agent-base": "4.1.2",
             "debug": "2.6.9"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
           }
         },
-        "jsonwebtoken": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.1.0.tgz",
-          "integrity": "sha1-xjl80uX9WD1lwAeoPce7eOaYK4M=",
-          "requires": {
-            "jws": "3.1.4",
-            "lodash.includes": "4.3.0",
-            "lodash.isboolean": "3.0.3",
-            "lodash.isinteger": "4.0.4",
-            "lodash.isnumber": "3.0.3",
-            "lodash.isplainobject": "4.0.6",
-            "lodash.isstring": "4.0.1",
-            "lodash.once": "4.1.1",
-            "ms": "2.0.0",
-            "xtend": "4.0.1"
-          }
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+        },
+        "ipaddr.js": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+          "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
         },
         "lodash": {
           "version": "4.17.4",
@@ -5855,14 +5977,85 @@
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         },
         "mime": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz",
-          "integrity": "sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug=="
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        "parseurl": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+          "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+        },
+        "proxy-addr": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+          "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+          "requires": {
+            "forwarded": "0.1.2",
+            "ipaddr.js": "1.5.2"
+          }
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          }
+        },
+        "send": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
+          }
+        },
+        "serve-static": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+          "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+          "requires": {
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.2",
+            "send": "0.16.1"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+        },
+        "vary": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
         }
       }
     },
@@ -5897,6 +6090,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
       "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "optional": true,
       "requires": {
         "forwarded": "0.1.0",
         "ipaddr.js": "1.4.0"
@@ -6513,6 +6707,7 @@
       "version": "1.12.4",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
       "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
+      "optional": true,
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
@@ -7278,7 +7473,8 @@
     "utils-merge": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "optional": true
     },
     "uuid": {
       "version": "3.0.0",
@@ -7302,7 +7498,8 @@
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
+      "optional": true
     },
     "verror": {
       "version": "1.10.0",


### PR DESCRIPTION
- Replaces most uses of `console.log` with `robot.log` or `context.log`
- Errors from posting and updating messages will now be reported to Sentry
- This fixes most of the eslint warnings about `console.log`

```
16:57:09.656Z  INFO probot: Posted Slack message (id=2bbbe270-d45d-11e7-9020-3d1f370d025c, ok=true, channel=G85HBUMMW, ts=1511888229.000220)
  message: {
    "text": "",
    "username": "bkeepers-dev",
    "bot_id": "B75E0J18D",
    "attachments": [
      {
        "author_name": "bkeepers",
        "fallback": "[github-slack/test] Issue closed by bkeepers",
        "pretext": "[github-slack/test] Issue closed by bkeepers",
        "title": "#16 Testing logging",
        "footer": "<https://github.com/github-slack/test|github-slack/test>",
        "id": 1,
        "title_link": "https://github.com/github-slack/test/issues/16",
        "author_link": "https://github.com/bkeepers",
        "author_icon": "https://avatars0.githubusercontent.com/u/173?v=4",
        "footer_icon": "https://assets-cdn.github.com/favicon.ico",
        "ts": 1511888135,
        "color": "cb2431",
        "mrkdwn_in": [
          "text"
        ]
      }
    ],
    "type": "message",
    "subtype": "bot_message",
    "ts": "1511888229.000220"
  }
  --
  scopes: [
    "identify",
    "commands",
    "chat:write:bot",
    "links:read",
    "links:write"
  ]
  --
  acceptedScopes: [
    "chat:write:bot"
  ]
```