### PR TITLE
/github unsubscribe

### DIFF
--- a/lib/slack/commands/subscribe.js
+++ b/lib/slack/commands/subscribe.js
@@ -32,10 +32,11 @@ module.exports = async (command, { robot }) => {
     return Installation.getForOwner(owner.id);
   }
 
-  const match = command.args.match(/^subscribe (.*)$/);
+  const [, subcommand, url] = command.args.match(/^((?:un)?subscribe) (.*)$/);
 
   // Turn the argument into a resource
-  const params = githubUrl(match[1]);
+  const params = githubUrl(url);
+
   if (params && params.type === 'repo') {
     // FIXME: catch 404
     const installation = await getInstallation(params.owner);
@@ -50,21 +51,33 @@ module.exports = async (command, { robot }) => {
     const from = (await github.repos.get({ owner: params.owner, repo: params.repo })).data;
     const to = command.context.channel_id;
 
-    await robot.models.Subscription.subscribe(from.id, to);
+    if (subcommand === 'subscribe') {
+      await robot.models.Subscription.subscribe(from.id, to);
 
-    // @TODO: Move to renderer
-    return {
-      response_type: 'in_channel',
-      attachments: [{
-        text: `Subscribed <#${to}> to <${from.html_url}|${from.full_name}>`,
-      }],
-    };
+      // @TODO: Move to renderer
+      return {
+        response_type: 'in_channel',
+        attachments: [{
+          text: `Subscribed <#${to}> to <${from.html_url}|${from.full_name}>`,
+        }],
+      };
+    } else if (subcommand === 'unsubscribe') {
+      await robot.models.Subscription.unsubscribe(from.id, to);
+
+      // @TODO: Move to renderer
+      return {
+        response_type: 'in_channel',
+        attachments: [{
+          text: `Unubscribed <#${to}> from <${from.html_url}|${from.full_name}>`,
+        }],
+      };
+    }
   }
   // @TODO: Move to renderer
   return {
     attachments: [{
       color: 'danger',
-      text: `\`${match[1]}\` does not appear to be a GitHub link.`,
+      text: `\`${url}\` does not appear to be a GitHub link.`,
       mrkdwn_in: ['text'],
     }],
   };

--- a/test/integration/__snapshots__/subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/subscriptions.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration: subscriptions subsscribing with a bad url 1`] = `
+exports[`Integration: subscriptions subscribing with a bad url 1`] = `
 Object {
   "attachments": Array [
     Object {
@@ -14,11 +14,22 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions successfully subscribing to a repository 1`] = `
+exports[`Integration: subscriptions successfully subscribing and unsubscribing to a repository 1`] = `
 Object {
   "attachments": Array [
     Object {
       "text": "Subscribed <#C2147483705> to <https://github.com/bkeepers/dotenv|bkeepers/dotenv>",
+    },
+  ],
+  "response_type": "in_channel",
+}
+`;
+
+exports[`Integration: subscriptions successfully subscribing and unsubscribing to a repository 2`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "text": "Unubscribed <#C2147483705> from <https://github.com/bkeepers/dotenv|bkeepers/dotenv>",
     },
   ],
   "response_type": "in_channel",


### PR DESCRIPTION
This implements `/github unsubscribe url`. Note that it currently shares all of the logic with `/subscribe`, with just a conditional for adding/removing the subscription.

Fixes #57