### PR TITLE
Improve redis error noise

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -14,9 +14,7 @@ function get(id) {
         reject(new Error(err));
       } else if (!value) {
         reject(
-          new Error(
-            `Could not find the supplied id in the database. Maybe probot wasn't running during previous event delivery?\nValue is ${value}`,
-          ),
+          `Could not find the supplied id in the database. Maybe probot wasn't running during previous event delivery?\nValue is ${value}`,
         );
       } else {
         resolve(JSON.parse(value));


### PR DESCRIPTION
@bkeepers any idea how we can improve this further?

My initial thought was to just robot.log.trace this, but we don't have access to robot in this module. Not finding the id in redis seems like a normal part of control flow for us, so it shouldn't really throw an exception

As it stands:
**Before**
![image](https://user-images.githubusercontent.com/7718702/33448985-53f29f24-d5ff-11e7-961c-d9476d08c588.png)
**After**
![image](https://user-images.githubusercontent.com/7718702/33449015-6ab2cc34-d5ff-11e7-9a09-4467f5105178.png)
