### PR TITLE
Remove full repository from pretext

### DIFF
--- a/lib/slack/renderer/abstract-issue.js
+++ b/lib/slack/renderer/abstract-issue.js
@@ -55,7 +55,7 @@ class AbstractIssue extends Message {
     } else {
       actor = this.abstractIssue.user.login;
     }
-    return `[${this.repository.full_name}] ${subject} ${predicate} by ${actor}`;
+    return `${subject} ${predicate} by ${actor}`;
   }
 
   getCore() {

--- a/test/slack/renderer/AbstractIssue.test.js
+++ b/test/slack/renderer/AbstractIssue.test.js
@@ -30,7 +30,7 @@ describe('AbstractIssue rendering', () => {
 
   test('works for getPreText', async () => {
     expect(abstractIssueMessage.getPreText('Issue')).toEqual(
-      '[github-slack/public-test] Issue opened by wilhelmklopp',
+      'Issue opened by wilhelmklopp',
     );
   });
 
@@ -41,7 +41,7 @@ describe('AbstractIssue rendering', () => {
       eventType: 'issues.opened',
     });
     expect(abstractIssueMessage.getPreText('Issue')).toEqual(
-      '[github-slack/public-test] Issue opened by wilhelmklopp',
+      'Issue opened by wilhelmklopp',
     );
   });
 

--- a/test/slack/renderer/__snapshots__/Issue.test.js.snap
+++ b/test/slack/renderer/__snapshots__/Issue.test.js.snap
@@ -65,13 +65,13 @@ Object {
       "author_link": "https://github.com/wilhelmklopp",
       "author_name": "wilhelmklopp",
       "color": "#cb2431",
-      "fallback": "[github-slack/public-test] Issue closed by bkeepers",
+      "fallback": "Issue closed by bkeepers",
       "footer": "<https://github.com/github-slack/public-test|github-slack/public-test>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "mrkdwn_in": Array [
         "text",
       ],
-      "pretext": "[github-slack/public-test] Issue closed by bkeepers",
+      "pretext": "Issue closed by bkeepers",
       "title": "#1 Needs content",
       "title_link": "https://github.com/github-slack/public-test/issues/1",
       "ts": 1508171038,
@@ -88,7 +88,7 @@ Object {
       "author_link": "https://github.com/wilhelmklopp",
       "author_name": "wilhelmklopp",
       "color": "#36a64f",
-      "fallback": "[github-slack/public-test] Issue opened by wilhelmklopp",
+      "fallback": "Issue opened by wilhelmklopp",
       "fields": Array [
         Object {
           "short": true,
@@ -106,7 +106,7 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "pretext": "[github-slack/public-test] Issue opened by wilhelmklopp",
+      "pretext": "Issue opened by wilhelmklopp",
       "text": "This repo needs some content, as currently, it does not have **any**.",
       "title": "#1 Needs content",
       "title_link": "https://github.com/github-slack/public-test/issues/1",

--- a/test/slack/renderer/__snapshots__/PullRequest.test.js.snap
+++ b/test/slack/renderer/__snapshots__/PullRequest.test.js.snap
@@ -59,7 +59,7 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "pretext": "[github-slack/app] Pull request merged by bkeepers",
+      "pretext": "Pull request merged by bkeepers",
       "title": "#36 Rearrange logic",
       "title_link": "https://github.com/github-slack/app/pull/36",
       "ts": 1506619320,
@@ -73,11 +73,11 @@ Object {
   "attachments": Array [
     Object {
       "color": "#36a64f",
-      "fallback": "[github-slack/app] Pull request opened by wilhelmklopp",
+      "fallback": "Pull request opened by wilhelmklopp",
       "mrkdwn_in": Array [
         "text",
       ],
-      "pretext": "[github-slack/app] Pull request opened by wilhelmklopp",
+      "pretext": "Pull request opened by wilhelmklopp",
       "text": "1 commit into \`github-slack:master\` from \`github-slack:wilhelmklopp/add-readme-badges\`",
     },
     Object {
@@ -113,11 +113,11 @@ Object {
   "attachments": Array [
     Object {
       "color": "#36a64f",
-      "fallback": "[github-slack/app] Pull request opened by wilhelmklopp",
+      "fallback": "Pull request opened by wilhelmklopp",
       "mrkdwn_in": Array [
         "text",
       ],
-      "pretext": "[github-slack/app] Pull request opened by wilhelmklopp",
+      "pretext": "Pull request opened by wilhelmklopp",
       "text": "1 commit into \`github-slack:master\` from \`github-slack:wilhelmklopp/add-readme-badges\`",
     },
     Object {
@@ -159,11 +159,11 @@ Object {
   "attachments": Array [
     Object {
       "color": "#36a64f",
-      "fallback": "[github-slack/app] Pull request opened by wilhelmklopp",
+      "fallback": "Pull request opened by wilhelmklopp",
       "mrkdwn_in": Array [
         "text",
       ],
-      "pretext": "[github-slack/app] Pull request opened by wilhelmklopp",
+      "pretext": "Pull request opened by wilhelmklopp",
       "text": "1 commit into \`github-slack:master\` from \`github-slack:wilhelmklopp/add-readme-badges\`",
     },
     Object {
@@ -225,11 +225,11 @@ Object {
   "attachments": Array [
     Object {
       "color": "#36a64f",
-      "fallback": "[github-slack/app] Pull request opened by wilhelmklopp",
+      "fallback": "Pull request opened by wilhelmklopp",
       "mrkdwn_in": Array [
         "text",
       ],
-      "pretext": "[github-slack/app] Pull request opened by wilhelmklopp",
+      "pretext": "Pull request opened by wilhelmklopp",
       "text": "1 commit into \`github-slack:master\` from \`github-slack:wilhelmklopp/add-readme-badges\`",
     },
     Object {


### PR DESCRIPTION
Clean up pretext by removing the full repository name from the pretext, as this is now consistently shown in the footer.

Before
![image](https://user-images.githubusercontent.com/7718702/33452912-b36ab2be-d60b-11e7-8686-7b22b75ae0bf.png)


After
![image](https://user-images.githubusercontent.com/7718702/33452889-96731b10-d60b-11e7-8365-7309a506347d.png)
