### PR TITLE
Authenticated client for public unfurls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,6 @@ SLACK_ACCESS_TOKEN=
 # SUBDOMAIN=
 
 APP_HOST=
+
+# Token for unfurling public URLs
+GITHUB_TOKEN=

--- a/lib/github/oauth.js
+++ b/lib/github/oauth.js
@@ -7,7 +7,6 @@ const { promisify } = require('util');
 const github = new GitHubApi();
 
 module.exports = (robot) => {
-  // @todo: @wilhelmklopp to open security review issue about this
   robot.route().get('/github/oauth/login', (req, res) => {
     // should persist state in persistent session store
     const state = req.query.state;
@@ -21,8 +20,6 @@ module.exports = (robot) => {
   });
 
   robot.route().get('/github/oauth/callback', async (req, res) => {
-    // verify state here, if it doesn't match, 400: Bad Request
-
     // complete OAuth dance
     const accessTokenResponse = await axios.post(
       'https://github.com/login/oauth/access_token',
@@ -44,7 +41,7 @@ module.exports = (robot) => {
     const user = (await github.users.get({})).data;
     const githubUserId = user.id;
 
-    // sign with default (HMAC SHA256)
+    // @todo: handle condition where state is expired or has been tampered with
     const state = await promisify(jwt.verify)(req.query.state, process.env.GITHUB_CLIENT_SECRET);
     const slackTeamId = state.teamId;
     const slackUserId = state.userId;

--- a/lib/slack/index.js
+++ b/lib/slack/index.js
@@ -8,6 +8,14 @@ const { get, set } = require('../storage');
 
 const github = new GitHubApi();
 
+// @todo: Temporary workaround for unfurling public links
+if (process.env.GITHUB_TOKEN) {
+  github.authenticate({
+    type: 'token',
+    token: process.env.GITHUB_TOKEN,
+  });
+}
+
 module.exports = (robot) => {
   const router = robot.route('/slack');
 


### PR DESCRIPTION
This temporarily adds a `GITHUB_TOKEN` environment variable that is used to fetch unauthenticated unfurls.

This should be removed when #52 is implemented, which will use the access of the user posting the link.

Fixes #150