### PR TITLE
Hack to improve efficiency of checking for access

### DIFF
--- a/lib/slack/commands/subscribe.js
+++ b/lib/slack/commands/subscribe.js
@@ -79,13 +79,6 @@ module.exports = async (command, { robot }) => {
       token: gitHubUser.accessToken,
     });
 
-    const installationRepos = (await userAuthedGithub.users.getInstallationRepos({
-      installation_id: installation.githubId,
-      headers: {
-        accept: 'application/vnd.github.machine-man-preview+json',
-      },
-    })).data.repositories;
-
     const installationAuthedGitHub = await robot.auth(installation.githubId);
 
     // look up the resource
@@ -100,7 +93,12 @@ module.exports = async (command, { robot }) => {
     const to = command.channel_id;
 
     if (subcommand === 'subscribe') {
-      const userHasAccess = from && installationRepos.find(repo => repo.id === from.id);
+      const userHasAccess = from &&
+        // Hack to check if user can access the repository
+        await userAuthedGithub.pullRequests.getAll(
+          { owner: params.owner, repo: params.repo, per_page: 1 },
+        ).then(() => true).catch(() => false);
+
 
       if (!userHasAccess) {
         return {

--- a/test/integration/subscriptions.test.js
+++ b/test/integration/subscriptions.test.js
@@ -94,13 +94,7 @@ describe('Integration: subscriptions', () => {
       test('successfully subscribing and unsubscribing to a repository', async () => {
         nock('https://api.github.com').get('/orgs/kubernetes').times(2).reply(200, fixtures.org);
         nock('https://api.github.com').get('/repos/kubernetes/kubernetes').times(2).reply(200, fixtures.repo);
-        nock('https://api.github.com').get('/user/installations/1/repositories').times(2).reply(
-          200, {
-            repositories: [{
-              id: fixtures.repo.id,
-            }],
-          },
-        );
+        nock('https://api.github.com').get('/repos/kubernetes/kubernetes/pulls?per_page=1').reply(200, {});
 
         const command = fixtures.slack.command({
           text: 'subscribe https://github.com/kubernetes/kubernetes',
@@ -126,13 +120,7 @@ describe('Integration: subscriptions', () => {
       test('successfully subscribing with repository shorthand', async () => {
         nock('https://api.github.com').get('/orgs/atom').reply(200, fixtures.org);
         nock('https://api.github.com').get('/repos/atom/atom').reply(200, fixtures.repo);
-        nock('https://api.github.com').get('/user/installations/1/repositories').reply(
-          200, {
-            repositories: [{
-              id: fixtures.repo.id,
-            }],
-          },
-        );
+        nock('https://api.github.com').get('/repos/atom/atom/pulls?per_page=1').reply(200, {});
 
         const command = fixtures.slack.command({ text: 'subscribe atom/atom' });
 


### PR DESCRIPTION
Use listing of pull requests to determine if a user has access to a repo 🙈 

Quicker to implement than using pagination for `/user/installations/:installation_id/repositories`, which we were using before