### PR TITLE
Mock Date.now

### DIFF
--- a/test/setup/date.js
+++ b/test/setup/date.js
@@ -1,0 +1,2 @@
+const now = new Date('2017-11-27T14:33:42Z');
+Date.now = jest.fn().mockReturnValue(now);

--- a/test/setup/index.js
+++ b/test/setup/index.js
@@ -1,6 +1,7 @@
 const { exec } = require('child_process');
 require('./env');
 require('./nock');
+require('./date');
 
 // @todo: Should create and destroy database for each test suite
 exec('./node_modules/.bin/sequelize db:migrate', (err, stdout, stderr) => {


### PR DESCRIPTION
This is an alternative to #166. This mocks `Date.now` to be a fixed time, as suggested in [this jest discussion](https://github.com/facebook/jest/issues/2234#issuecomment-323341454).