### PR TITLE
Update access token for existing workspaces

### DIFF
--- a/lib/slack/oauth.js
+++ b/lib/slack/oauth.js
@@ -36,6 +36,10 @@ module.exports = {
         defaults: { accessToken: access.access_token },
       });
 
+      if (!created) {
+        await workspace.update({ accessToken: access.access_token });
+      }
+
       req.log.debug({ created, workspace }, 'Authorized slack workspace');
 
       res.redirect(

--- a/test/integration/slack-oauth.test.js
+++ b/test/integration/slack-oauth.test.js
@@ -32,4 +32,19 @@ describe('Integration: slack authentication', () => {
     const workspace = await SlackWorkspace.findOne({ where: { slackId: access.team_id } });
     expect(workspace.accessToken).toEqual(access.access_token);
   });
+
+  test('updates the access token', async () => {
+    const { SlackWorkspace } = helper.robot.models;
+
+    const workspace = await SlackWorkspace.create({ slackId: access.team_id, accessToken: 'old' });
+
+    nock('https://slack.com').post('/api/oauth.token').reply(200, access);
+
+    await request(probot.server).get('/slack/oauth/callback').expect(302);
+
+    await workspace.reload();
+
+    expect(workspace.accessToken).not.toEqual('old');
+    expect(workspace.accessToken).toEqual(access.access_token);
+  });
 });


### PR DESCRIPTION
If a workspace already exists and the app is re-installed, we want to update the access token for the new installation.