### PR TITLE
Gracefully handle unfurl errors

### DIFF
--- a/lib/slack/index.js
+++ b/lib/slack/index.js
@@ -80,7 +80,11 @@ module.exports = (robot) => {
       await Promise.all(event.links.map(async (link) => {
         if (await isEligibleForUnfurl(body.team_id, event.channel, link.url)) {
           robot.log.debug({ url: link.url }, 'Link eligible for unfurls');
-          unfurls[link.url] = await unfurl(github, link.url, type);
+          try {
+            unfurls[link.url] = await unfurl(github, link.url, type);
+          } catch (err) {
+            robot.log.warn({ err, link }, 'Unable to unfurl link');
+          }
         } else {
           robot.log.debug({ url: link.url }, 'Link not eligible for unfurl');
         }

--- a/test/integration/unfurl.test.js
+++ b/test/integration/unfurl.test.js
@@ -84,4 +84,20 @@ describe('Integration: unfurls', () => {
     // No API requests should be made when this request is performed
     return request(probot.server).post('/slack/events').send(body).expect(200);
   });
+
+  test('gracefully handles not found link', async () => {
+    nock('https://api.github.com').get('/repos/bkeepers/dotenv').reply(404);
+
+    await request(probot.server).post('/slack/events')
+      .send(fixtures.slack.link_shared())
+      .expect(200);
+  });
+
+  test('gracefully handles unknown resources', async () => {
+    const payload = fixtures.slack.link_shared();
+    payload.event.links[0].url = 'https://github.com/probot/probot/issues';
+
+    await request(probot.server).post('/slack/events').send(payload)
+      .expect(200);
+  });
 });


### PR DESCRIPTION
There are a bunch of errors that arise from not being able to unfurl links (mostly 404 from private links and unsupported resources). This may also be the primary cause of #192.

This silences all those exceptions by catching and logging all errors from unfurling.

Fixes #154 
