### PR TITLE
Only log SQL queries and duration

### DIFF
--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -11,7 +11,10 @@ const db = {};
 module.exports = (robot) => {
   Object.assign(config, {
     operatorsAliases: false,
-    logging: robot.log.trace.bind(robot.log),
+    benchmark: true,
+    logging: (query, ms) => {
+      robot.log.debug({ ms }, query);
+    },
   });
 
   let sequelize;


### PR DESCRIPTION
Fixes #127 

Example logs:

```
20:54:45.264Z DEBUG probot: Link eligible for unfurls (id=616ac178-0581-485e-8f17-8b7066d47092, url=https://github.com/github-slack/snappydoo, domain=github.com)
20:54:45.737Z DEBUG probot: Executed (default): SELECT "id", "slackId", "accessToken", "createdAt", "updatedAt" FROM "SlackWorkspaces" AS "SlackWorkspace" WHERE "SlackWorkspace"."slackId" = 'T74MJ8DTK' LIMIT 1; (ms=3)
20:54:45.741Z DEBUG probot: Unfurling links (id=616ac178-0581-485e-8f17-8b7066d47092)
```