### PR TITLE
Require SSL to postgres in production

### DIFF
--- a/db/config.json
+++ b/db/config.json
@@ -13,6 +13,10 @@
   },
   "production": {
     "use_env_variable": "DATABASE_URL",
-    "operatorsAliases": false
+    "operatorsAliases": false,
+    "ssl": true,
+    "dialectOptions": {
+        "ssl": true
+    }
   }
 }


### PR DESCRIPTION
I tried upgrading the Postgres database on production from their hobby tier to the standard tier and ran into some errors. Heroku requires SSL for this tier, and Sequelize appears to not handle that well.

https://github.com/sequelize/cli/tree/master/docs#configuration-for-connecting-over-ssl
https://github.com/sequelize/sequelize/issues/956#issuecomment-147745033