### PR TITLE
Use probot 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7581,7 +7581,9 @@
       "dev": true
     },
     "probot": {
-      "version": "github:probot/probot#0a4b297757e11050067a28f044e8369f3adcf7d0",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-5.0.0.tgz",
+      "integrity": "sha512-/idAAkDJguZWoW2G5lgo9Q2632eG/2wjGcbauqpECAfv9Iyng7qDhfb94PjOYR4w86xE6gOineUJ07TQHIZwpA==",
       "requires": {
         "bottleneck": "1.16.0",
         "bunyan": "1.8.12",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "moment": "^2.18.1",
     "named-regexp": "^0.1.1",
     "pg": "^6.4.2",
-    "probot": "github:probot/probot",
+    "probot": "^5.0.0",
     "query-string": "^5.0.1",
     "request": "^2.83.0",
     "sequelize": "^4.29.0",


### PR DESCRIPTION
This fixed our current ongoing incident related to this bug: https://sentry.io/github-integrations/slack/issues/446016390

Quite possibly related to the change from `github` -> `@octokit/rest` in probot/probot