### PR TITLE
Rename repo to `slack`

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -2,7 +2,7 @@
 
 repository:
   # The name of the repository. Changing this will rename the repository
-  name: app
+  name: slack
 
   # A short description of the repository that will show up on GitHub
   description: Bring your code to the conversations you care about with the GitHub and Slack integration


### PR DESCRIPTION
The `@github-slack` org has been renamed to @integrations, and along with it, this repository is being renamed to `slack`.

All links should properly redirect after the rename, and I'll verify that deployment pipeline continues to work.