### PR TITLE
Integration => app

### DIFF
--- a/views/index.hbs
+++ b/views/index.hbs
@@ -19,7 +19,7 @@
           </p>
           <a href="/slack/oauth/login" class="btn btn-large btn-primary f4">Add to Slack</a>
           <p class="f6 text-gray mx-auto col-sm-10 col-md-5 pt-3">
-            Using an older version of GitHub + Slack? Installing the new integration will allow you to migrate subscriptions from legacy versions.
+            Using an older version of GitHub + Slack? Installing the new app will allow you to migrate subscriptions from legacy versions.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Feedback from the Slack folks:

> There term "integration" is used on that page a few times — could you swap that out with the term "app" instead? In Slack lingo, "integration" mostly refers to the older, Slack-built apps.

I updated the one obvious place, but these two are not referring specifically to the "Slack app" or "GitHub app", but the integration of the two:

> Contribute to the integration
> Learn more about the GitHub and Slack integration

@mbcampbell @jmilas Can you take this from here and get a resolution on it?

FYI @sophshep 