### PR TITLE
Pre-populate subject in Support form

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ And to turn it back off:
 ```
 
 ## Questions? Need help?
-Please fill out GitHub's [Support form](https://github.com/contact) and your request will be routed to the right team at GitHub. 
+Please fill out GitHub's [Support form](https://github.com/contact?form%5Bsubject%5D=Re:+GitHub%2BSlack+Integration) and your request will be routed to the right team at GitHub. 
 
 ## Contributing
 Want to help improve the integration between GitHub and Slack? Check out the [contributing docs](CONTRIBUTING.md) to get involved.


### PR DESCRIPTION
Hi @bkeepers @wilhelmklopp @sbarnekow 👋 
cc/ @izuzak for awareness

This pull request updates the link to the `Support Form` so that anyone that clicks it will include the following pre-populated subject: 

> Re: GitHub+Slack Integration

This would be helpful for members of GitHub Support to look at when answering related requests.

Thanks ya'll! ✨ 