### PR TITLE
Bump codecov thresholds and customize layout

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        # Fail the status if coverage drops by >= 2%
+        threshold: 2
+    patch:
+      default:
+        # Fail the status if coverage drops by >= 2%
+        threshold: 2
+
 comment:
-  # only post the comment if coverage changes
-  require_changes: true
+  layout: diff
+  require_changes: yes


### PR DESCRIPTION
This makes some slight tweaks to the default codecov config:

- Bump threshold for failing the build if coverage drops to 2% (default is 0ish)
- Fix the `require_changes` config so it only posts if there are changes in coverage
- Only show the `diff` layout

See https://github.com/probot/probot/pull/399#issuecomment-357769482 for an example of a similar config in practice.