### PR TITLE
Disable commits entirely if legacy config had them disabled

### DIFF
--- a/lib/models/legacy-subscription.js
+++ b/lib/models/legacy-subscription.js
@@ -81,7 +81,7 @@ module.exports = (sequelize, DataTypes) => {
       settings = {
         branches: settings.branches || config.do_branches,
         comments: settings.comments || config.do_issue_comments,
-        commits: settings.commits || (config.do_commits ? 'all' : true),
+        commits: settings.commits || (config.do_commits ? 'all' : false),
         deployments: settings.deployments || config.do_deployment_status,
         issues: settings.issues || config.do_issues,
         pulls: settings.pulls || config.do_pullrequest,

--- a/test/fixtures/slack/config_migration.json
+++ b/test/fixtures/slack/config_migration.json
@@ -11,7 +11,7 @@
                 "user_id": "U06AXEE2U",
                 "channel_id": "C0D70MRAL",
                 "no_auth_mode": false,
-                "do_commits": true,
+                "do_commits": false,
                 "do_commits_showsimple": false,
                 "do_commit_comments": true,
                 "do_pullrequest": true,

--- a/test/integration/subscriptions.test.js
+++ b/test/integration/subscriptions.test.js
@@ -355,7 +355,7 @@ describe('Integration: subscriptions', () => {
           expect(subscription.settings).toEqual({
             branches: true,
             comments: true,
-            commits: 'all',
+            commits: false,
             deployments: false,
             issues: true,
             pulls: true,


### PR DESCRIPTION
By default, this app only shows commits pushed to master, and has a separate setting for showing all commits pushed to any branch.

The legacy integration only had on/off, so we made the decision to interpret the legacy integration as "I disabled commits because it's annoying to see every push to every branch". 

@bradslavin and @meaganrgamache suggested today that they would prefer to see pushes disabled entirely on migrated subscriptions if they were off before. So this PR makes that change, and then updates one of the test fixtures to have commits disabled.