### PR TITLE
Delayed commands

### DIFF
--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -2,5 +2,5 @@ const { Help } = require('../messages/flow');
 
 module.exports = async (req, res) => {
   const { command } = res.locals;
-  res.json(new Help(command.command));
+  await command.respond(new Help(command.command));
 };

--- a/lib/commands/list-subscriptions.js
+++ b/lib/commands/list-subscriptions.js
@@ -39,11 +39,11 @@ module.exports = async (req, res, next) => {
   repositories = repositories.filter(repo => repo);
 
   if (command.text === 'list') {
-    return res.json(new SubscriptionList(repositories, command.channel_id));
+    return command.respond(new SubscriptionList(repositories, command.channel_id));
   }
 
   const response = (new Help(command.command, command.subcommand)).toJSON();
   const list = new SubscriptionList(repositories, command.channel_id);
   response.attachments.push(list.toJSON().attachments[0]);
-  return res.json(response);
+  return command.respond(response);
 };

--- a/lib/commands/signin.js
+++ b/lib/commands/signin.js
@@ -16,5 +16,5 @@ module.exports = async (req, res) => {
   // returns slack message with link to click
   const signInLink =
     `${protocol}://${host}/github/oauth/login?state=${await state.stringify()}`;
-  res.json(new SignIn(signInLink));
+  return command.respond((new SignIn(signInLink)));
 };

--- a/lib/commands/subscribe.js
+++ b/lib/commands/subscribe.js
@@ -18,12 +18,11 @@ module.exports = async (req, res) => {
   req.log.debug({ installation, resource }, 'Lookup respository to subscribe');
 
   async function respondWith(message) {
-    if (/api\.slack\.com/.test(req.headers['user-agent'])) {
-      res.json(message);
-    } else {
-      await command.respond(message.toJSON());
+    if (!/api\.slack\.com/.test(req.headers['user-agent'])) {
       res.redirect(`https://slack.com/app_redirect?channel=${command.channel_id}&team=${command.team_id}`);
     }
+
+    return command.respond(message.toJSON());
   }
 
   // look up the resource

--- a/lib/middleware/get-installation.js
+++ b/lib/middleware/get-installation.js
@@ -40,11 +40,11 @@ module.exports = async function getInstallation(req, res, next) {
     const installLink = `${protocol}://${host}/github/install/${owner.id}/${await state.stringify()}`;
 
     if (/api\.slack\.com/.test(req.headers['user-agent'])) {
-      res.json(new InstallGitHubApp(installLink));
+      await command.respond(new InstallGitHubApp(installLink));
     } else {
       res.redirect(installLink);
     }
   } catch (err) {
-    res.json(new NotFound(command.args[0]));
+    await command.respond(new NotFound(command.args[0]));
   }
 };

--- a/lib/middleware/get-resource.js
+++ b/lib/middleware/get-resource.js
@@ -16,6 +16,6 @@ module.exports = function getResource(req, res, next) {
     res.locals.resource = resource;
     next();
   } else {
-    res.json(new InvalidUrl(url));
+    return command.respond(new InvalidUrl(url));
   }
 };

--- a/lib/middleware/route-command.js
+++ b/lib/middleware/route-command.js
@@ -6,7 +6,17 @@ const Command = require('../slack/command');
 module.exports = function route(req, res, next) {
   req.log.debug({ command: req.body }, 'Received slash command');
 
-  const command = new Command(req.body);
+  const command = new Command(req.body, res.json.bind(res));
+
+  const timeout = setTimeout(() => {
+    req.log({ command }, 'Command taking too long. Switching to delayed response.');
+
+    // Ack the command
+    res.status(200).send({ response_type: 'in_channel' });
+
+    // Any further responses should use the delayed response callback
+    command.delay();
+  }, 2500);
 
   if (command.subcommand) {
     const [url] = req.url.split('?');
@@ -16,6 +26,11 @@ module.exports = function route(req, res, next) {
   res.locals.command = command;
 
   res.on('finish', () => {
+    clearTimeout(timeout);
+
+    // Any further responses should use the delayed response callback
+    command.delay();
+
     req.log.debug({ response: res.body, command: req.body }, 'Response to command');
   });
   next();

--- a/lib/slack/command.js
+++ b/lib/slack/command.js
@@ -3,7 +3,7 @@ const axios = require('axios');
 const SUBCOMMAND = /^(\w+) *(.*)$/;
 
 module.exports = class Command {
-  constructor(body) {
+  constructor(body, callback) {
     Object.assign(this, body);
 
     // Check for subcommand in the command text
@@ -18,10 +18,20 @@ module.exports = class Command {
 
       // Save array of args
       this.args = args.split(' ');
+
+      this.callback = callback;
     }
   }
 
+  /**
+   * Use the delayed response callback URL instead of the callback provided
+   */
+  delay() {
+    this.callback = null;
+  }
+
   respond(message) {
-    return axios.post(this.response_url, message);
+    return this.callback ? this.callback(message)
+      : axios.post(this.response_url, message);
   }
 };


### PR DESCRIPTION
Slack has a 3000ms timeout for responding to commands. Since we're so highly dependent on the GitHub API and the Slack API, the response time is often out of our control.

This is an experiment to handle command timeouts automatically. If a command is responded to within the timeout, it will just be returned as an HTTP response. If it takes longer, the command will be acknowledged, and then further responses will be sent to the `response_url` callback.

The key is to just always call `command.respond` and it will do the right thing.

Fixes #352