### PR TITLE
Fix Twitter card

### DIFF
--- a/views/index.hbs
+++ b/views/index.hbs
@@ -9,13 +9,16 @@
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,700" rel="stylesheet">
     <link rel="shortcut icon" href="/static/img/favicon.ico" />
     <meta property="og:title" content="GitHub + Slack">
+    <meta property="og:type" content="website" />
     <meta property="og:description" content="Bring your code to the conversations you care about with the GitHub and Slack integration.">
-    <meta property="og:image" content="/static/img/og-image.png">
+    <meta property="og:image" content="http://slack.github.com/static/img/og-image.png">
     <meta property="og:url" content="http://slack.github.com/">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@github">
+    <meta name="twitter:creator" content="@github">
     <meta name="twitter:title" content="GitHub + Slack">
     <meta name="twitter:description" content="Bring your code to the conversations you care about with the GitHub and Slack integration.">
-    <meta name="twitter:image" content="/static/img/og-image.png">
-    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="http://slack.github.com/static/img/og-image.png">
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-3769691-98"></script>
     <script>


### PR DESCRIPTION
Realized the social cards weren't working on Twitter (though they work well on Facebook):

![image](https://user-images.githubusercontent.com/527589/36652284-6a851538-1a73-11e8-8a0f-4ae12ba955d3.png)

This _should_ fix them ahead of the comms push tomorrow.