### PR TITLE
Skip push notification if no new commits

### DIFF
--- a/lib/activity/push.js
+++ b/lib/activity/push.js
@@ -1,11 +1,12 @@
 const { Push } = require('../messages/push');
 
 async function push(context, subscription, slack) {
-  if (
-    context.payload.repository.default_branch ===
-      context.payload.ref.replace('refs/heads/', '') ||
-      subscription.settings.commits === 'all'
-  ) {
+  const isDefaultBranch = context.payload.repository.default_branch ===
+    context.payload.ref.replace('refs/heads/', '');
+  const allEnabled = subscription.settings.commits === 'all';
+  const hasCommits = context.payload.commits.length > 0;
+
+  if (hasCommits && (allEnabled || isDefaultBranch)) {
     const pushMessage = new Push({
       push: context.payload,
     });


### PR DESCRIPTION
This skips the notification if there are no new commits.

This happens in a few situations:
- when you fast-forward a branch to a commit that was previously pushed
- when you create a new ref from a previously pushed ref (like creating a tag)
- when you delete a branch (because technically it's a push to a null reference)

The fast forward scenario is the only one that we should probably still post a notification for, since that doesn't get covered by any other notifications.

Fixes #375 