### PR TITLE
Nest list to fix top-level list item numbers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,12 +65,12 @@ Following the [Probot docs for configuring up a GitHub App](https://probot.githu
 
 1. Go to the **Slash Commands** tab and click **Create New Command**:
 
-  - **Command**: `/github`
-  - **Request URL**: `https://DOMAIN/slack/command`
-  - **Short Description**: `Subscribe to notifications for an Organization or Repository`
-  - **Usage Hint**: `subscribe https://github.com/organization/repository`
-  - Click **Save**
-  - Test it out by typing `/github subscribe https://github.com/myorg/myrepo`
+    - **Command**: `/github`
+    - **Request URL**: `https://DOMAIN/slack/command`
+    - **Short Description**: `Subscribe to notifications for an Organization or Repository`
+    - **Usage Hint**: `subscribe https://github.com/organization/repository`
+    - Click **Save**
+    - Test it out by typing `/github subscribe https://github.com/myorg/myrepo`
 
 1. Congratulate yourself for following directions and clicking buttons. Take the rest of the day off because that was a lot of work.
 


### PR DESCRIPTION
Loving the new integration and the responsiveness so far. Thanks for all the hard work!

TIL nesting an unordered list inside an ordered list in Markdown requires a 4-space indent rather than 2. Otherwise, list items following the "nested" unordered list will restart at 1.