### PR TITLE
Return true and output warning when GitHub returns 500

### DIFF
--- a/lib/models/githubuser.js
+++ b/lib/models/githubuser.js
@@ -33,7 +33,7 @@ module.exports = (sequelize, DataTypes) => {
           if (err.code === 404) {
             return false;
           }
-          logger.warn('GitHub returned neither 200 nor 404', { error: err });
+          logger.warn({ error: err }, 'GitHub returned neither 200 nor 404');
           return true;
         });
     },

--- a/lib/models/githubuser.js
+++ b/lib/models/githubuser.js
@@ -33,7 +33,8 @@ module.exports = (sequelize, DataTypes) => {
           if (err.code === 404) {
             return false;
           }
-          throw err;
+          logger.warn('GitHub returned neither 200 nor 404', { error: err });
+          return true;
         });
     },
   });

--- a/test/models/github-user.test.js
+++ b/test/models/github-user.test.js
@@ -16,9 +16,9 @@ describe('GitHubUser', () => {
       nock('https://api.github.com').get('/repositories/1').reply(200);
       await expect(user.hasRepoAccess(1)).resolves.toBe(true);
     });
-    test('throws error for unexpected status codes', async () => {
+    test('returns true for unexpected status codes', async () => {
       nock('https://api.github.com').get('/repositories/1').reply(500);
-      await expect(user.hasRepoAccess(1)).rejects.toThrow();
+      await expect(user.hasRepoAccess(1)).resolves.toBe(true);
     });
     test('returns false for user without access', async () => {
       nock('https://api.github.com').get('/repositories/1').reply(404);


### PR DESCRIPTION
Related to the ongoing incident (#387 and https://sentry.io/github-integrations/slack/issues/473125081/)

When GitHub fails with a 500 (or 502) to our check of whether the user still has repo access, we throw an error, which aborts the requests.
This PR modifies that behaviour slightly, so that we log a warning, but still let the request proceed as if we received a 200.

At the very least this PR should temporarily fix the problems we're having with the ongoing incident.