### PR TITLE
Only prompt to migrate the first time a configuration is imported

### DIFF
--- a/lib/models/legacy-subscription.js
+++ b/lib/models/legacy-subscription.js
@@ -34,32 +34,54 @@ module.exports = (sequelize, DataTypes) => {
     },
   });
 
-  LegacySubscription.import = (configuration) => {
+  LegacySubscription.importAll = async configs => (
+    // Return one flattened list of all the imported subscriptions
+    [].concat(...await Promise.all(configs.map(LegacySubscription.import)))
+  );
+
+  LegacySubscription.import = async (configuration) => {
     if (configuration.repos) {
-      return Promise.all(configuration.repos.map(async (repo) => {
-        const existingLegacySubscription = await LegacySubscription.findOne({
+      const subscriptions = await Promise.all(configuration.repos.map(async (repo) => {
+        const [subscription, created] = await LegacySubscription.findOrCreate({
           where: {
             channelSlackId: configuration.channel_id,
             workspaceSlackId: configuration.team_id,
             serviceSlackId: configuration.id,
             repoGitHubId: repo.id,
           },
+          defaults: {
+            authorSlackId: configuration.user_id,
+            repoFullName: repo.full_name,
+            originalSlackConfiguration: configuration,
+          },
         });
-        if (existingLegacySubscription) {
-          return Promise.resolve();
-        }
-        return LegacySubscription.create({
-          channelSlackId: configuration.channel_id,
-          authorSlackId: configuration.user_id,
-          workspaceSlackId: configuration.team_id,
-          repoGitHubId: repo.id,
-          repoFullName: repo.full_name,
-          originalSlackConfiguration: configuration,
-          serviceSlackId: configuration.id,
-        });
+
+        return created ? subscription : false;
       }));
+
+      return subscriptions.filter(subscription => subscription);
     }
   };
+
+  LegacySubscription.groupByChannel = subscriptions => (
+    subscriptions.reduce((byChannel, subscription) => {
+      if (!byChannel[subscription.channelSlackId]) {
+        // eslint-disable-next-line no-param-reassign
+        byChannel[subscription.channelSlackId] = [];
+      }
+
+      // Check for duplicates
+      const exists = byChannel[subscription.channelSlackId]
+        .find(s => s.authorSlackId === subscription.authorSlackId &&
+            s.repoFullName === subscription.repoFullName);
+
+      if (!exists) {
+        byChannel[subscription.channelSlackId].push(subscription);
+      }
+
+      return byChannel;
+    }, {})
+  );
 
   LegacySubscription.migrate = async (subscription) => {
     // check if there are any legacy configurations that we can disable

--- a/lib/slack/importer.js
+++ b/lib/slack/importer.js
@@ -6,27 +6,8 @@ module.exports = async (req, res) => {
 
   req.log('Importing data', req.body);
 
-  const subscriptionsByChannel = {};
-  for (const configuration of req.body.event.configs) {
-    await LegacySubscription.import(configuration);
-    // Make sure we only send one message per channel
-    if (!subscriptionsByChannel[configuration.channel_id]) {
-      subscriptionsByChannel[configuration.channel_id] = [];
-    }
-    subscriptionsByChannel[configuration.channel_id].push(...configuration.repos.map(repo => ({
-      authorSlackId: configuration.user_id,
-      repoFullName: repo.full_name,
-    })));
-    // remove duplicate subscriptions
-    // eslint-disable-next-line max-len
-    subscriptionsByChannel[configuration.channel_id] = subscriptionsByChannel[configuration.channel_id]
-      .filter((subscription, index, self) => (
-        index === self.findIndex(s => (
-          s.authorSlackId === subscription.authorSlackId &&
-          s.repoFullName === subscription.repoFullName
-        ))
-      ));
-  }
+  const subscriptions = await LegacySubscription.importAll(req.body.event.configs);
+  const subscriptionsByChannel = LegacySubscription.groupByChannel(subscriptions);
 
   const workspace = await SlackWorkspace.findOne({
     where: { slackId: req.body.team_id },

--- a/test/integration/__snapshots__/legacy-subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/legacy-subscriptions.test.js.snap
@@ -20,16 +20,6 @@ Object {
 }
 `;
 
-exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack does not duplicate legacy configurations 2`] = `
-Object {
-  "attachments": "[{\\"color\\":\\"#24292f\\",\\"text\\":\\"Good news: an upgraded GitHub app has been installed in this workspace. Type the following slash command to keep GitHub working in this channel.\\"},{\\"color\\":\\"#24292f\\",\\"fields\\":[{\\"value\\":\\"/github subscribe berttest/testrepo1\\"}],\\"mrkdwn_in\\":[\\"fields\\"],\\"pretext\\":\\"Configuration created by <@U06AXEE2U>:\\"},{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"_Need help? Type \\\\\\"/github help\\\\\\" or <https://get.slack.help/hc/en-us/articles/232289568-GitHub-for-Slack|learn more>._\\"}]",
-  "channel": "C0D70MRAL",
-  "response_type": "in_channel",
-  "text": "",
-  "token": "xoxa-token",
-}
-`;
-
 exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack works for 34 legacy configurations 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"text\\":\\"Good news: an upgraded GitHub app has been installed in this workspace. Type the following slash commands to keep GitHub working in this channel.\\"},{\\"color\\":\\"#24292f\\",\\"fields\\":[{\\"value\\":\\"/github subscribe berttest/testrepo1\\"},{\\"value\\":\\"/github subscribe atom/atom\\"},{\\"value\\":\\"/github subscribe kubernetes/kubernetes\\"},{\\"value\\":\\"/github subscribe berttest/testrepo12\\"},{\\"value\\":\\"/github subscribe berttest/testrepo13\\"},{\\"value\\":\\"/github subscribe berttest/testrepo14\\"},{\\"value\\":\\"/github subscribe berttest/testrepo15\\"},{\\"value\\":\\"/github subscribe berttest/testrepo16\\"},{\\"value\\":\\"/github subscribe berttest/testrepo17\\"},{\\"value\\":\\"/github subscribe berttest/testrepo18\\"},{\\"value\\":\\"/github subscribe berttest/testrepo19\\"},{\\"value\\":\\"/github subscribe berttest/testrepo2\\"},{\\"value\\":\\"/github subscribe berttest/testrepo20\\"},{\\"value\\":\\"/github subscribe berttest/testrepo21\\"},{\\"value\\":\\"/github subscribe berttest/testrepo22\\"},{\\"value\\":\\"/github subscribe berttest/testrepo23\\"},{\\"value\\":\\"/github subscribe berttest/testrepo24\\"},{\\"value\\":\\"/github subscribe berttest/testrepo25\\"},{\\"value\\":\\"/github subscribe berttest/testrepo26\\"},{\\"value\\":\\"/github subscribe berttest/testrepo27\\"},{\\"value\\":\\"/github subscribe berttest/testrepo28\\"},{\\"value\\":\\"/github subscribe berttest/testrepo29\\"},{\\"value\\":\\"/github subscribe berttest/testrepo3\\"},{\\"value\\":\\"/github subscribe berttest/testrepo4\\"},{\\"value\\":\\"/github subscribe berttest/testrepo5\\"},{\\"value\\":\\"/github subscribe berttest/testrepo6\\"},{\\"value\\":\\"/github subscribe berttest/testrepo7\\"},{\\"value\\":\\"/github subscribe berttest/testrepo8\\"},{\\"value\\":\\"/github subscribe berttest/testrepo9\\"}],\\"mrkdwn_in\\":[\\"fields\\"],\\"pretext\\":\\"Configurations created by <@U06AXEE2U>:\\"},{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"_Need help? Type \\\\\\"/github help\\\\\\" or <https://get.slack.help/hc/en-us/articles/232289568-GitHub-for-Slack|learn more>._\\"}]",

--- a/test/integration/legacy-subscriptions.test.js
+++ b/test/integration/legacy-subscriptions.test.js
@@ -48,7 +48,7 @@ describe('Integration: Slack config_migration event', () => {
       nock('https://slack.com').post('/api/chat.postMessage', (body) => {
         expect(body).toMatchSnapshot();
         return true;
-      }).times(2).reply(200, { ok: true });
+      }).times(1).reply(200, { ok: true });
 
       await request(probot.server)
         .post('/slack/events')

--- a/test/models/legacy-subscription.test.js
+++ b/test/models/legacy-subscription.test.js
@@ -1,8 +1,26 @@
 const { LegacySubscription, logger } = require('.');
 const nock = require('nock');
 const client = require('../../lib/slack/client').createClient();
+const migration = require('../fixtures/slack/config_migration_single');
 
 describe('LegacySubscription', () => {
+  describe('importAll', () => {
+    test('does not return previously imported subscriptions', async () => {
+      let subscriptions = await LegacySubscription.importAll(migration.event.configs);
+
+      expect(subscriptions).toEqual([
+        expect.objectContaining({
+          channelSlackId: 'C0D70MRAL',
+          authorSlackId: 'U06AXEE2U',
+          repoFullName: 'berttest/testrepo1',
+        }),
+      ]);
+
+      subscriptions = await LegacySubscription.importAll(migration.event.configs);
+      expect(subscriptions).toEqual([]);
+    });
+  });
+
   describe('activate', () => {
     let record;
 


### PR DESCRIPTION
Fixes #396 
Fixes #353

The diff looks like a lot of changes because I had to slightly refactor how the import was being handled and moved it into the model in the process, but the gist is:

`LegacySubscription.import` now only returns _newly_ imported subscriptions, so if a configuration is sent multiple times (which sounds like happens if multiple people get the prompt to install the new GitHub app), we won't prompt multiple times.
