### PR TITLE
Avoid linking to page that 404s

### DIFF
--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -22,7 +22,7 @@ module.exports = (robot) => {
     const info = await robot.info();
 
     req.log({ trigger_id, owner_id: req.params.id }, 'Redirecting to install GitHub APP');
-    res.redirect(`${info.html_url}/installations/new/permissions?target_id=${req.params.id}`);
+    res.redirect(`${info.html_url}/installations/new`);
   });
 
   const slackAppUrl = `https://slack.com/app_redirect?app=${process.env.SLACK_APP_ID}`;

--- a/test/integration/signin.test.js
+++ b/test/integration/signin.test.js
@@ -115,7 +115,7 @@ describe('Integration: signin', () => {
 
       await agent.get(installLink)
         .expect(302)
-        .expect('Location', 'https://github.com/apps/slack-bkeepers/installations/new/permissions?target_id=13629408');
+        .expect('Location', 'https://github.com/apps/slack-bkeepers/installations/new');
 
       // Pretend the user goes and installs the GitHub app, and then is
       // redirected back to /setup.


### PR DESCRIPTION
GitHub Apps currently return a 404 when linking directly to the new installation page for an organization that you don't have owner permissions on. This updates the link to link to the new installation page, where a user can then select the organization that they have permissions on.

Fixes #316 

Note that this will likely lead to more reports of #389. I expect users won't have permission to install the app on the organization, so they'll install it on their own user account, which is always the first in the list, and then get redirected back to the new installation page when we try to run the subscribe command again.