### PR TITLE
Add connect-timeout to detect requests that are timing out

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,4 +1,5 @@
 const Raven = require('raven');
+const timeout = require('connect-timeout');
 
 const { Exception } = require('./messages/flow');
 
@@ -8,7 +9,16 @@ module.exports = {
     Raven.config(process.env.SENTRY_DSN, {
       release: process.env.HEROKU_SLUG_COMMIT,
     }).install();
+
     app.use(Raven.requestHandler());
+    app.use(timeout('5s'));
+    app.use((req, res, next) => {
+      req.on('timeout', () => {
+        req.log.warn('Request timeout');
+      });
+
+      next();
+    });
 
     // Route for testing error handling
     app.get('/boom', (req) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,6 +1699,17 @@
         "xdg-basedir": "3.0.0"
       }
     },
+    "connect-timeout": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.9.0.tgz",
+      "integrity": "sha1-vCcyaxIhA3FL6/oNlYurM/ZSLjo=",
+      "requires": {
+        "http-errors": "1.6.2",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      }
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@slack/client": "^3.16.0",
     "axios": "^0.18.0",
     "body-parser": "^1.17.2",
+    "connect-timeout": "^1.9.0",
     "cookie-session": "^2.0.0-beta.3",
     "express": "^4.16.2",
     "express-async-errors": "^2.1.1",


### PR DESCRIPTION
This adds the [connect-timeout](https://www.npmjs.com/package/connect-timeout) middleware to warn when requests are timing out.

cc #192 