### PR TITLE
Alphabetically order the output of /github subscribe list

### DIFF
--- a/lib/messages/subscription-list.js
+++ b/lib/messages/subscription-list.js
@@ -33,7 +33,7 @@ module.exports = class SubscriptionList extends Message {
   repositoriesToString() {
     return this.repositories
       .sort((repoA, repoB) => {
-        if (repoA.full_name > repoB.full_name) {
+        if (repoA.full_name.toLowerCase() > repoB.full_name.toLowerCase()) {
           return 1;
         }
         return -1;

--- a/lib/messages/subscription-list.js
+++ b/lib/messages/subscription-list.js
@@ -31,8 +31,20 @@ module.exports = class SubscriptionList extends Message {
   }
 
   repositoriesToString() {
-    return this.repositories.map(repository => (
-      `<${repository.html_url}|${repository.full_name}>`
-    ));
+    return this.repositories
+      .sort((repoA, repoB) => {
+        const fullNameA = repoA.full_name;
+        const fullNameB = repoB.full_name;
+        if (fullNameA > fullNameB) {
+          return 1;
+        }
+        if (fullNameA < fullNameB) {
+          return -1;
+        }
+        return 0;
+      })
+      .map(repository => (
+        `<${repository.html_url}|${repository.full_name}>`
+      ));
   }
 };

--- a/lib/messages/subscription-list.js
+++ b/lib/messages/subscription-list.js
@@ -33,15 +33,10 @@ module.exports = class SubscriptionList extends Message {
   repositoriesToString() {
     return this.repositories
       .sort((repoA, repoB) => {
-        const fullNameA = repoA.full_name;
-        const fullNameB = repoB.full_name;
-        if (fullNameA > fullNameB) {
+        if (repoA.full_name > repoB.full_name) {
           return 1;
         }
-        if (fullNameA < fullNameB) {
-          return -1;
-        }
-        return 0;
+        return -1;
       })
       .map(repository => (
         `<${repository.html_url}|${repository.full_name}>`

--- a/test/messages/SubscriptionList.test.js
+++ b/test/messages/SubscriptionList.test.js
@@ -61,4 +61,31 @@ describe('SubscriptionList', () => {
       '<https://github.com/wilhelmklopp/wilhelmklopp|wilhelmklopp/wilhelmklopp>',
     ]);
   });
+
+  test('sorts repositories alphabetically including different cases', async () => {
+    const repositories = [
+      {
+        full_name: 'wilhelmklopp/wilhelmklopp',
+        html_url: 'https://github.com/wilhelmklopp/wilhelmklopp',
+      },
+      {
+        full_name: 'bkeepers/dotenv',
+        html_url: 'https://github.com/bkeepers/dotenv',
+      },
+      {
+        full_name: 'integrations/slack',
+        html_url: 'https://github.com/integrations/slack',
+      },
+      {
+        full_name: 'JasonEtco/todo',
+        html_url: 'https://github.com/JasonEtco/todo',
+      },
+    ];
+    expect(new SubscriptionList(repositories, 'C01234').repositoriesToString()).toEqual([
+      '<https://github.com/bkeepers/dotenv|bkeepers/dotenv>',
+      '<https://github.com/integrations/slack|integrations/slack>',
+      '<https://github.com/JasonEtco/todo|JasonEtco/todo>',
+      '<https://github.com/wilhelmklopp/wilhelmklopp|wilhelmklopp/wilhelmklopp>',
+    ]);
+  });
 });

--- a/test/messages/SubscriptionList.test.js
+++ b/test/messages/SubscriptionList.test.js
@@ -39,4 +39,26 @@ describe('SubscriptionList', () => {
     ];
     expect(new SubscriptionList(repositories, 'D01234').toJSON()).toMatchSnapshot();
   });
+
+  test('sorts repositories alphabetically', async () => {
+    const repositories = [
+      {
+        full_name: 'wilhelmklopp/wilhelmklopp',
+        html_url: 'https://github.com/wilhelmklopp/wilhelmklopp',
+      },
+      {
+        full_name: 'bkeepers/dotenv',
+        html_url: 'https://github.com/bkeepers/dotenv',
+      },
+      {
+        full_name: 'integrations/slack',
+        html_url: 'https://github.com/integrations/slack',
+      },
+    ];
+    expect(new SubscriptionList(repositories, 'C01234').repositoriesToString()).toEqual([
+      '<https://github.com/bkeepers/dotenv|bkeepers/dotenv>',
+      '<https://github.com/integrations/slack|integrations/slack>',
+      '<https://github.com/wilhelmklopp/wilhelmklopp|wilhelmklopp/wilhelmklopp>',
+    ]);
+  });
 });

--- a/test/messages/__snapshots__/SubscriptionList.test.js.snap
+++ b/test/messages/__snapshots__/SubscriptionList.test.js.snap
@@ -6,8 +6,8 @@ Object {
     Object {
       "color": "#24292f",
       "fallback": "<#C01234> is subscribed to 2 repositories",
-      "text": "<https://github.com/bkeepers/dotenv|bkeepers/dotenv>
-<https://github.com/atom/atom|atom/atom>",
+      "text": "<https://github.com/atom/atom|atom/atom>
+<https://github.com/bkeepers/dotenv|bkeepers/dotenv>",
       "title": "<#C01234> is subscribed to",
     },
   ],


### PR DESCRIPTION
Currently the output of the `/github subscribe list` slash command isn't ordered at all.
This PR makes sure the output is sorted alphabetically


Closes #440
cc @TimGurney