### PR TITLE
More logging for failed access checks

### DIFF
--- a/lib/models/githubuser.js
+++ b/lib/models/githubuser.js
@@ -33,7 +33,7 @@ module.exports = (sequelize, DataTypes) => {
           if (err.code === 404) {
             return false;
           }
-          logger.warn({ error: err }, 'GitHub returned neither 200 nor 404');
+          logger.warn({ err, repoId, userId: this.id }, 'GitHub returned neither 200 nor 404');
           return true;
         });
     },


### PR DESCRIPTION
We're experiencing a lot of `401 Bad Credentials` errors from GitHub when performing this access check. This adds a little more logging so we can see who exactly this is affecting and dig into what might be causing it, and renames the error param to `err`, which is given special treatment by the the bunyan logger and thus sentry.


cc #388