### PR TITLE
Bump timeout to 10s

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -11,7 +11,7 @@ module.exports = {
     }).install();
 
     app.use(Raven.requestHandler());
-    app.use(timeout('5s'));
+    app.use(timeout('10s'));
     app.use((req, res, next) => {
       req.on('timeout', () => {
         req.log.warn('Request timeout');


### PR DESCRIPTION
Some legit requests occasionally take this long due to waiting for API responses. For example the `/github subscribe` command when it has to migrate a lot of subscriptions occasionally can take 5-10 seconds.