### PR TITLE
Update @keyv/redis to fix Redis out of memory issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,7 @@
       }
     },
     "@keyv/redis": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@keyv/redis/-/redis-1.3.8.tgz",
-      "integrity": "sha1-BJq8b4ZGYpHbc4gHF0mv57db998=",
+      "version": "github:integrations/keyv-redis#050e26c4a6e3cc26ca5db4b8e19ff3cd994029be",
       "requires": {
         "pify": "3.0.0",
         "redis": "2.8.0"
@@ -9061,14 +9059,14 @@
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
       "requires": {
         "double-ended-queue": "2.1.0-0",
-        "redis-commands": "1.3.1",
+        "redis-commands": "1.3.5",
         "redis-parser": "2.6.0"
       }
     },
     "redis-commands": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
-      "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz",
+      "integrity": "sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA=="
     },
     "redis-parser": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "migrate": "sequelize db:migrate"
   },
   "dependencies": {
-    "@keyv/redis": "^1.3.8",
+    "@keyv/redis": "github:integrations/keyv-redis#use-keys",
     "@slack/client": "^3.16.0",
     "axios": "^0.18.0",
     "body-parser": "^1.17.2",


### PR DESCRIPTION
We've twice now run into issues with Redis hitting an OOM error:

```
ReplyError: OOM command not allowed when used memory > 'maxmemory'.
```

The cause appears to be `@keyv/redis` using a `namespace:keyv` set to store every key that has ever been written to Redis, which is used to get a list of keys when for `cache.clear()`. I opened https://github.com/lukechilds/keyv-redis/pull/15 to change the behavior to use the built-in `LIST keyv:*` command.