### PR TITLE
Update lockfile after greenkeeper update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7705,9 +7705,9 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "newrelic": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-2.8.0.tgz",
-      "integrity": "sha1-S3LR/dVkQJKyySPvXeRTbiB71T8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-3.0.0.tgz",
+      "integrity": "sha1-2ZMGnueHfDQ+zZa2WF9NjS3WbmQ=",
       "requires": {
         "@newrelic/native-metrics": "2.2.0",
         "async": "2.6.0",


### PR DESCRIPTION
#434 updated newrelic, but I didn't notice that it didn't update the lockfile.

We need to set up https://github.com/greenkeeperio/greenkeeper-lockfile.