### PR TITLE
Document when links won't unfurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ On repositories, the app notifies of `open`, `close`, and `re-open` events on pu
 #### Types of Public Link Unfurls
 When a user posts a GitHub link in Slack for a public repository, the app is designed to unfurl **issues and pull requests**, directly linked **comments**, code **blobs** with line numbers, as well as **organizations, repositories, and users**.
 
+Links won't be unfurled if:
+
+- the repository is private (support for private links is coming soon!)
+- link previews for `github.com` have been [disabled for your workspace](https://get.slack.help/hc/en-us/articles/204399343-Share-links-in-Slack#turn-off-link-previews-for-specific-sites)
+- the link was shared in the last 30 minutes in the same channel
+- 3 or more links are shared in the same chat message
+
 ### Configuration
 You can customize your notifications by subscribing to activity that is relevant to your Slack channel, and unsubscribing from activity that is less helpful to your project.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Links won't be unfurled if:
 
 - the repository is private (support for private links is coming soon!)
 - link previews for `github.com` have been [disabled for your workspace](https://get.slack.help/hc/en-us/articles/204399343-Share-links-in-Slack#turn-off-link-previews-for-specific-sites)
-- the link was shared in the last 30 minutes in the same channel
+- the same link was already shared in the last 30 minutes in the same channel
 - 3 or more links are shared in the same chat message
 
 ### Configuration


### PR DESCRIPTION
Since this has come up a few times via support, wanted to add something that we could link to in response to users.

cc @izuzak @francisfuzz @wilhelmklopp 