### PR TITLE
Always use command.respond

### DIFF
--- a/lib/commands/subscribe.js
+++ b/lib/commands/subscribe.js
@@ -2,8 +2,6 @@ const {
   Subscribed, NotFound, AlreadySubscribed, NotSubscribed, UpdatedSettings,
 } = require('../messages/flow');
 
-const isRequestFromSlack = require('../is-request-from-slack');
-
 /**
  * Subscribes a slack channel to activity from an Organization or Repository
  *
@@ -19,14 +17,6 @@ module.exports = async (req, res) => {
 
   req.log.debug({ installation, resource }, 'Lookup respository to subscribe');
 
-  async function respondWith(message) {
-    if (!isRequestFromSlack(req)) {
-      res.redirect(`https://slack.com/app_redirect?channel=${command.channel_id}&team=${command.team_id}`);
-    }
-
-    return command.respond(message.toJSON());
-  }
-
   // look up the resource
   let from;
   try {
@@ -34,7 +24,7 @@ module.exports = async (req, res) => {
     ).data;
   } catch (err) {
     req.log.debug({ err }, 'Could not find repository');
-    return respondWith(new NotFound(command.args[0]));
+    return command.respond(new NotFound(command.args[0]).toJSON());
   }
   const to = command.channel_id;
 
@@ -47,10 +37,10 @@ module.exports = async (req, res) => {
         req.log.debug({ settings }, 'Subscription already exists, updating settings');
         subscription.enable(settings);
         await subscription.save();
-        return respondWith(new UpdatedSettings({ subscription, repository: from }));
+        return command.respond(new UpdatedSettings({ subscription, repository: from }).toJSON());
       }
       req.log.debug('Subscription already exists');
-      return respondWith(new AlreadySubscribed(command.args[0]));
+      return command.respond(new AlreadySubscribed(command.args[0]).toJSON());
     }
     req.log.debug('Subscription does not exist, creating.');
     subscription = await Subscription.subscribe({
@@ -64,22 +54,22 @@ module.exports = async (req, res) => {
 
     await LegacySubscription.migrate(subscription);
 
-    return respondWith(new Subscribed({ channelId: to, fromRepository: from }));
+    return command.respond(new Subscribed({ channelId: to, fromRepository: from }).toJSON());
   } else if (command.subcommand === 'unsubscribe') {
     if (subscription) {
       if (settings.length > 0) {
         subscription.disable(settings);
         await subscription.save();
 
-        return respondWith(new UpdatedSettings({ subscription, repository: from }));
+        return command.respond(new UpdatedSettings({ subscription, repository: from }).toJSON());
       }
       await Subscription.unsubscribe(from.id, to, slackWorkspace.id);
-      return respondWith(new Subscribed({
+      return command.respond(new Subscribed({
         channelId: to,
         fromRepository: from,
         unsubscribed: true,
-      }));
+      }).toJSON());
     }
-    return respondWith(new NotSubscribed(command.args[0]));
+    return command.respond(new NotSubscribed(command.args[0]).toJSON());
   }
 };

--- a/lib/middleware/get-installation.js
+++ b/lib/middleware/get-installation.js
@@ -45,9 +45,6 @@ module.exports = async function getInstallation(req, res, next) {
     }
     return res.redirect(installLink);
   } catch (err) {
-    if (!isRequestFromSlack(req)) {
-      res.redirect(`https://slack.com/app_redirect?channel=${command.channel_id}&team=${command.team_id}`);
-    }
     return command.respond(new NotFound(command.args[0]));
   }
 };

--- a/lib/middleware/route-command.js
+++ b/lib/middleware/route-command.js
@@ -9,9 +9,18 @@ module.exports = function route(req, res, next) {
   let callback;
   let command;
 
-  // Skip timeout handling if request is a pending command
+  // Handle command response if request is a pending command
   if (req.query.trigger_id) {
-    callback = null;
+    callback = (message) => {
+      // If a different response hasn't already been sent, redirect to channel
+      if (!res.headersSent) {
+        res.redirect(`https://slack.com/app_redirect?channel=${command.channel_id}&team=${command.team_id}`);
+      }
+
+      // Switch to delayed command mode and redeliver the response
+      command.delay();
+      command.respond(message);
+    };
   } else {
     let timeout;
 


### PR DESCRIPTION
#452 fixed most of the remaining timeouts in production, but there are still a few happening, and it's anywhere we're calling `command.respond` without handling the situation where a command might be called from a browser instead of from slackbot (#311).  These are only happening in edge cases where someone types the command wrong (`/github subscribe nothing`).

This removes the hacky `respondWith` that was used in the `subscribe` command, and instead adds logic to redirect back to the slack channel whenever calling `command.respond` from within a web request.

The only time we'll still need special handling for a request from the browser now is if you want to send the user somewhere besides the slack channel that they came from (e.g.  OAuth or app installation URL).

This is an incremental improvement as we work towards #433