### PR TITLE
Add notes on opening issues for bugs and features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Hi there! We're thrilled that you'd like to contribute to this project. Your hel
 ## Contents
 
 - [Notices](#notices)
+- [Requesting New Features and Reporting Bugs](#requesting-new-features-and-reporting-bugs)
 - [Getting started](#getting-started)
 - [Submitting a pull request](#submitting-a-pull-request)
 - [Resources](#resources)
@@ -21,6 +22,25 @@ Hi there! We're thrilled that you'd like to contribute to this project. Your hel
 Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.md).
 
 Please note that this project is released with a [Contributor Code of Conduct][code-of-conduct]. By participating in this project you agree to abide by its terms.
+
+## Requesting New Features and Reporting Bugs
+
+Bugs and feature requests are tracked as issues in this repository.
+
+Before opening a new issue:
+* **check [the README](https://github.com/integrations/slack/blob/master/README.md)** to see if the behavior you observed might be expected and if configuration options are available to provide you with the desired behavior.
+* **perform a cursory search** to see if there's [an existing issue](https://github.com/integrations/slack/issues) covering your feedback. If there is one and the issue is still open, **add a :+1: reaction** on the issue to express interest in the issue being resolved. That will help the team gauge interest without the noise of comments which trigger notifications to all watchers. Comments should be used only if you have new and useful information to share.
+* **consider if you're giving feedback which involves sharing sensitive information** (e.g. the name of your private repository). If you're concerned about sharing such information in a public repository, please reach out via [GitHub Support](https://github.com/contact?form%5Bsubject%5D=Re:+GitHub%2BSlack+Integration) instead to provide that feedback.
+
+When opening an issue for a feature request:
+* **use a clear and descriptive title** for the issue to identify the problem.
+* **include as many details as possible in the body**. Explain your use-case, the problems you're hitting and the solutions you'd like to see to address those problems.
+
+When opening an issue for a bug report, explain the problem and include additional details to help maintainers reproduce the problem:
+* **describe the exact steps which reproduce the problem** in as many details as possible. When listing steps, don't just say what you did, but explain how you did it.
+* **provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use Markdown code blocks.
+* **describe the behavior you observed** after following the steps and point out what exactly is the problem with that behavior.
+* **explain which behavior you expected to see instead** and why.
 
 ## Getting Started
 


### PR DESCRIPTION
This updates the CONTRIBUTING guide with some notes on opening issues for bug reports and feature requests. :v: 