### PR TITLE
Mitigate replication lag for issues and PRs

### DIFF
--- a/lib/activity/issues.js
+++ b/lib/activity/issues.js
@@ -1,5 +1,9 @@
+const { promisify } = require('util');
+
 const cache = require('../cache');
 const { Issue } = require('../messages/issue');
+
+const sleep = promisify(setTimeout);
 
 async function updateIssueMessage(messageMetaData, context, subscription, slack) {
   // Fetch updated version of issue to retrieve accurate comment count and body_html
@@ -31,12 +35,19 @@ async function matchMetaDataStatetoIssueMessage(context, subscription, slack) {
 }
 
 async function issueEvent(context, subscription, slack) {
-  const eventType = `${context.event}.${context.payload.action}`;
+  let issue = {
+    ...context.payload.issue,
+  };
+  if (context.payload.action === 'opened') {
+    await sleep(1000);
 
-  // Fetch updated version of issue to retrieve body_html
-  const issue = (await context.github.issues.get(context.issue({
-    headers: { accept: 'application/vnd.github.html+json' },
-  }))).data;
+    // Fetch updated version of issue to retrieve body_html
+    issue = (await context.github.issues.get(context.issue({
+      headers: { accept: 'application/vnd.github.html+json' },
+    }))).data;
+  }
+
+  const eventType = `${context.event}.${context.payload.action}`;
 
   const issueMessage = new Issue({
     issue,

--- a/lib/activity/issues.js
+++ b/lib/activity/issues.js
@@ -1,9 +1,5 @@
-const { promisify } = require('util');
-
 const cache = require('../cache');
 const { Issue } = require('../messages/issue');
-
-const sleep = promisify(setTimeout);
 
 async function updateIssueMessage(messageMetaData, context, subscription, slack) {
   // Fetch updated version of issue to retrieve accurate comment count and body_html
@@ -39,8 +35,6 @@ async function issueEvent(context, subscription, slack) {
     ...context.payload.issue,
   };
   if (context.payload.action === 'opened') {
-    await sleep(1000);
-
     // Fetch updated version of issue to retrieve body_html
     issue = (await context.github.issues.get(context.issue({
       headers: { accept: 'application/vnd.github.html+json' },

--- a/lib/activity/pull-requests.js
+++ b/lib/activity/pull-requests.js
@@ -1,18 +1,12 @@
-const { promisify } = require('util');
-
 const { PullRequest } = require('../messages/pull-request');
 
 const cache = require('../cache');
-
-const sleep = promisify(setTimeout);
 
 async function pullRequestEvent(context, subscription, slack) {
   let pullRequest = {
     ...context.payload.pull_request,
   };
   if (context.payload.action === 'opened') {
-    await sleep(1000);
-
     // need seperate api request to get labels and body_html
     const issue = (await context.github.issues.get(context.issue({
       headers: { accept: 'application/vnd.github.html+json' },

--- a/lib/activity/pull-requests.js
+++ b/lib/activity/pull-requests.js
@@ -1,19 +1,31 @@
+const { promisify } = require('util');
+
 const { PullRequest } = require('../messages/pull-request');
 
 const cache = require('../cache');
 
-async function pullRequestEvent(context, subscription, slack) {
-  const eventType = `${context.event}.${context.payload.action}`;
-  // need seperate api request to get labels and body_html
-  const issue = (await context.github.issues.get(context.issue({
-    headers: { accept: 'application/vnd.github.html+json' },
-  }))).data;
+const sleep = promisify(setTimeout);
 
-  const pullRequest = {
+async function pullRequestEvent(context, subscription, slack) {
+  let pullRequest = {
     ...context.payload.pull_request,
-    labels: issue.labels,
-    body_html: issue.body_html,
   };
+  if (context.payload.action === 'opened') {
+    await sleep(1000);
+
+    // need seperate api request to get labels and body_html
+    const issue = (await context.github.issues.get(context.issue({
+      headers: { accept: 'application/vnd.github.html+json' },
+    }))).data;
+
+    pullRequest = {
+      ...pullRequest,
+      labels: issue.labels,
+      body_html: issue.body_html,
+    };
+  }
+
+  const eventType = `${context.event}.${context.payload.action}`;
 
   const prMessage = new PullRequest({
     pullRequest,

--- a/lib/activity/router.js
+++ b/lib/activity/router.js
@@ -1,4 +1,5 @@
 const { ReEnableSubscription } = require('../messages/flow');
+const avoidReplicationLag = require('../github/avoid-replication-lag');
 
 // Temporary "middleware" hack to look up routing before delivering event
 module.exports = ({ models }) => {
@@ -15,6 +16,9 @@ module.exports = ({ models }) => {
           if (!subscription.isEnabledForGitHubEvent(context.event)) {
             return;
           }
+
+          // Delay GitHub API calls to avoid replication lag
+          context.github.hook.before('request', avoidReplicationLag());
 
           // Create clack client with workspace token
           const slack = subscription.SlackWorkspace.client;

--- a/lib/activity/router.js
+++ b/lib/activity/router.js
@@ -17,12 +17,11 @@ module.exports = ({ models }) => {
             return;
           }
 
-          // Delay GitHub API calls to avoid replication lag
-          context.github.hook.before('request', avoidReplicationLag());
-
           // Create clack client with workspace token
           const slack = subscription.SlackWorkspace.client;
           if (!subscription.creatorId) {
+            // Delay GitHub API calls to avoid replication lag
+            context.github.hook.before('request', avoidReplicationLag());
             return callback(context, subscription, slack);
           }
 
@@ -58,6 +57,9 @@ module.exports = ({ models }) => {
             ]);
             return;
           }
+
+          // Delay GitHub API calls to avoid replication lag
+          context.github.hook.before('request', avoidReplicationLag());
 
           return callback(context, subscription, slack);
         }));

--- a/lib/activity/router.js
+++ b/lib/activity/router.js
@@ -17,45 +17,37 @@ module.exports = ({ models }) => {
             return;
           }
 
-          // Create clack client with workspace token
-          const slack = subscription.SlackWorkspace.client;
-          if (!subscription.creatorId) {
-            // Delay GitHub API calls to avoid replication lag
-            context.github.hook.before('request', avoidReplicationLag());
-            return callback(context, subscription, slack);
-          }
-
-          // Verify that subscription creator still has access to the resource
-          const creator = await SlackUser.findById(subscription.creatorId, {
-            include: [GitHubUser],
-          });
-
           const eventType = `${context.event}.${context.payload.action}`;
 
-          // Can't check for repo access because repo has been deleted
-          if (eventType === 'repository.deleted') {
-            return callback(context, subscription, slack);
-          }
+          // Create clack client with workspace token
+          const slack = subscription.SlackWorkspace.client;
 
-          if (!await creator.GitHubUser.hasRepoAccess(subscription.githubId)) {
-            context.log.debug({
-              subscription: {
-                channelId: subscription.channelId,
-                creatorId: subscription.creatorId,
-                githubId: subscription.githubId,
-                workspaceId: subscription.SlackWorkspace.slackId,
-              },
-            }, 'User lost access to resource. Deleting subscription.');
+          if (subscription.creatorId && eventType !== 'repository.deleted') {
+            // Verify that subscription creator still has access to the resource
+            const creator = await SlackUser.findById(subscription.creatorId, {
+              include: [GitHubUser],
+            });
 
-            await Promise.all([
-              // @todo: deactive this subscription instead of deleting the db record
-              await subscription.destroy(),
-              await slack.chat.postMessage({
-                channel: subscription.channelId,
-                ...new ReEnableSubscription(context.payload.repository, creator.slackId).toJSON(),
-              }),
-            ]);
-            return;
+            if (!await creator.GitHubUser.hasRepoAccess(subscription.githubId)) {
+              context.log.debug({
+                subscription: {
+                  channelId: subscription.channelId,
+                  creatorId: subscription.creatorId,
+                  githubId: subscription.githubId,
+                  workspaceId: subscription.SlackWorkspace.slackId,
+                },
+              }, 'User lost access to resource. Deleting subscription.');
+
+              await Promise.all([
+                // @todo: deactive this subscription instead of deleting the db record
+                await subscription.destroy(),
+                await slack.chat.postMessage({
+                  channel: subscription.channelId,
+                  ...new ReEnableSubscription(context.payload.repository, creator.slackId).toJSON(),
+                }),
+              ]);
+              return;
+            }
           }
 
           // Delay GitHub API calls to avoid replication lag

--- a/lib/github/avoid-replication-lag.js
+++ b/lib/github/avoid-replication-lag.js
@@ -1,6 +1,6 @@
-const { promisify } = require('util');
-
-const sleep = promisify(setTimeout);
+// util.promsify won't work here:
+// https://github.com/integrations/slack/pull/494#issuecomment-376735607
+const sleep = timeout => new Promise(resolve => setTimeout(resolve, timeout));
 
 module.exports = function avoidReplicationLag() {
   let shouldSleep = true;

--- a/lib/github/avoid-replication-lag.js
+++ b/lib/github/avoid-replication-lag.js
@@ -1,0 +1,15 @@
+const { promisify } = require('util');
+
+const sleep = promisify(setTimeout);
+
+module.exports = function avoidReplicationLag() {
+  let shouldSleep = true;
+
+  return async (options) => {
+    // Only GET requests are affected by replication lag
+    if (shouldSleep && options.method === 'GET') {
+      await sleep(1000);
+    }
+    shouldSleep = false;
+  };
+};

--- a/test/integration/__snapshots__/notifications.test.js.snap
+++ b/test/integration/__snapshots__/notifications.test.js.snap
@@ -46,6 +46,22 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel issues closed does not make an API call to issues endpoint 1`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#36a64f\\",\\"footer\\":\\"<https://github.com/github-slack/public-test|github-slack/public-test>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1508171038,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#1 Needs content\\",\\"title_link\\":\\"https://github.com/github-slack/public-test/issues/1\\",\\"fallback\\":\\"Issue closed by wilhelmklopp\\",\\"pretext\\":\\"Issue closed by wilhelmklopp\\"}]",
+  "channel": "C001",
+  "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issues reopened does not make an API call to issues endpoint 1`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#36a64f\\",\\"footer\\":\\"<https://github.com/github-slack/public-test|github-slack/public-test>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1508171038,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#1 Needs content\\",\\"title_link\\":\\"https://github.com/github-slack/public-test/issues/1\\",\\"fallback\\":\\"Issue reopened by wilhelmklopp\\",\\"pretext\\":\\"Issue reopened by wilhelmklopp\\"}]",
+  "channel": "C001",
+  "token": "test",
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 1`] = `
 Object {
   "attachments": "[{\\"fields\\":[{\\"title\\":\\"Comments\\",\\"value\\":126,\\"short\\":true}],\\"color\\":\\"#cb2431\\",\\"footer\\":\\"<https://github.com/github-slack/public-test|github-slack/public-test>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1500156238,\\"mrkdwn_in\\":[\\"text\\"],\\"author_name\\":\\"wohali\\",\\"author_link\\":\\"https://github.com/wohali\\",\\"author_icon\\":\\"https://avatars2.githubusercontent.com/u/112292?v=4\\",\\"title\\":\\"#10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\",\\"title_link\\":\\"https://github.com/facebook/react/issues/10191\\",\\"fallback\\":\\"Issue opened by wohali\\",\\"text\\":\\"Hi there,\\\\r\\\\n\\\\r\\\\nThe Apache Software Foundation Legal Affairs Committee [has announced][1] that the so-called 'Facebook BSD+Patents License' is no longer allowed to be used as a direct dependency in Apache projects.\\\\r\\\\n\\\\r\\\\nThis has lead to a lot of upset and frustration in the Apache community, especially from projects requiring similarly-licensed code as direct dependencies - the chief of these being RocksDB.\\\\r\\\\n\\\\r\\\\nHowever, we (the Apache Software Foundation) have just received word that [RocksDB will be re-licensing their code under the dual Apache License v2.0 and GPL 2 licenses][2]. \\\\r\\\\n\\\\r\\\\nAs a user of React.JS in an ASF top-level project (Apache CouchDB), please consider re-licensing React.JS under similar terms. Otherwise, many ASF projects such as our own will have to stop relying on and building with React.\\\\r\\\\n\\\\r\\\\nA previous bug (#9760) suggested I mention @lacker in this issue when asking licensing questions, so I'm doing so.\\\\r\\\\n\\\\r\\\\nThank you kindly for your consideration.\\\\r\\\\n\\\\r\\\\n[1]: https://issues.apache.org/jira/browse/LEGAL-303?focusedCommentId=16088663&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16088663\\\\r\\\\n[2]: https://issues.apache.org/jira/browse/LEGAL-303?focusedCommentId=16088730&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16088730\\",\\"pretext\\":\\"Issue opened by wohali\\"}]",
@@ -78,6 +94,14 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel pull request closed does not make an API call to issues endpoint 1`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#36a64f\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1506092298,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#31 Add badges to readme\\",\\"title_link\\":\\"https://github.com/github-slack/app/pull/31\\",\\"fallback\\":\\"#31 Add badges to readme\\",\\"pretext\\":\\"Pull request closed by wilhelmklopp\\"}]",
+  "channel": "C001",
+  "token": "test",
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel pull request opened 1`] = `
 Object {
   "attachments": "[{\\"fields\\":[{\\"title\\":\\"Milestone\\",\\"value\\":\\"<https://github.com/github-slack/app/milestone/1|Staff Ship>\\",\\"short\\":true}],\\"color\\":\\"#36a64f\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1506092298,\\"mrkdwn_in\\":[\\"text\\"],\\"author_name\\":\\"wilhelmklopp\\",\\"author_link\\":\\"https://github.com/wilhelmklopp\\",\\"author_icon\\":\\"https://avatars1.githubusercontent.com/u/7718702?v=4\\",\\"title\\":\\"#31 Add badges to readme\\",\\"title_link\\":\\"https://github.com/github-slack/app/pull/31\\",\\"fallback\\":\\"#31 Add badges to readme\\",\\"text\\":\\"![image](https://user-images.githubusercontent.com/7718702/30750617-39e2fb52-9fb7-11e7-8da1-d6542317bee2.png)\\\\r\\\\n\\",\\"pretext\\":\\"Pull request opened by wilhelmklopp\\"}]",
@@ -97,6 +121,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel pull request opened followed by status 2`] = `
 Object {
   "attachments": "[{\\"fields\\":[{\\"title\\":\\"Comments\\",\\"value\\":3,\\"short\\":true}],\\"color\\":\\"#6f42c1\\",\\"footer\\":\\"<https://github.com/github/hub|github/hub>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1502411430,\\"mrkdwn_in\\":[\\"text\\"],\\"author_name\\":\\"e-beach\\",\\"author_link\\":\\"https://github.com/e-beach\\",\\"author_icon\\":\\"https://avatars1.githubusercontent.com/u/13651458?v=4\\",\\"title\\":\\"#1535 Make fork command idempotent\\",\\"title_link\\":\\"https://github.com/github/hub/pull/1535\\",\\"fallback\\":\\"#1535 Make fork command idempotent\\",\\"text\\":\\"Fixes #1499.\\\\r\\\\n\\\\r\\\\nThis PR makes \`hub fork\` succeed, with no operation, if a remote pointing to the forked repository already exists.\\\\r\\\\n \\",\\"pretext\\":\\"Pull request merged by e-beach\\"},{\\"fallback\\":\\"codecov/patch: Coverage not affected when comparing 0143c3c...68c2ef0\\",\\"author_name\\":\\"codecov/patch: Coverage not affected when comparing 0143c3c...68c2ef0\\",\\"author_icon\\":\\"https://avatars2.githubusercontent.com/in/254?v=4\\",\\"author_link\\":\\"https://codecov.io/gh/github-slack/app/compare/0143c3cd70052e00bb07dc09229b261b3afd807d...68c2ef08b77a144aeaa69b601ecbacb979e3a8fd\\",\\"color\\":\\"#cb2431\\",\\"mrkdwn_in\\":[\\"text\\"]},{\\"fallback\\":\\"codecov/project: 98.37% remains the same compared to 0143c3c\\",\\"author_name\\":\\"codecov/project: 98.37% remains the same compared to 0143c3c\\",\\"author_icon\\":\\"https://avatars2.githubusercontent.com/in/254?v=4\\",\\"author_link\\":\\"https://codecov.io/gh/github-slack/app/compare/0143c3cd70052e00bb07dc09229b261b3afd807d...68c2ef08b77a144aeaa69b601ecbacb979e3a8fd\\",\\"color\\":\\"#dbab09\\",\\"mrkdwn_in\\":[\\"text\\"]},{\\"color\\":\\"#28a745\\",\\"fallback\\":\\"2 other checks have passed\\",\\"text\\":\\":white_check_mark: 2 other checks have passed\\",\\"footer\\":\\"2/4 successful checks\\"}]",
+  "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 1`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#36a64f\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1506092298,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#31 Add badges to readme\\",\\"title_link\\":\\"https://github.com/github-slack/app/pull/31\\",\\"fallback\\":\\"#31 Add badges to readme\\",\\"pretext\\":\\"Pull request reopened by wilhelmklopp\\"}]",
+  "channel": "C001",
   "token": "test",
 }
 `;

--- a/test/integration/notifications.test.js
+++ b/test/integration/notifications.test.js
@@ -130,6 +130,60 @@ describe('Integration: notifications', () => {
       });
     });
 
+    test('issues closed does not make an API call to issues endpoint', async () => {
+      await Subscription.subscribe({
+        githubId: issuePayload.repository.id,
+        channelId: 'C001',
+        slackWorkspaceId: workspace.id,
+        installationId: installation.id,
+        creatorId: slackUser.id,
+      });
+
+      nock('https://api.github.com').get(`/repositories/${issuePayload.repository.id}`).reply(200, {
+        full_name: issuePayload.repository.full_name,
+      });
+
+      nock('https://slack.com').post('/api/chat.postMessage', (body) => {
+        expect(body).toMatchSnapshot();
+        return true;
+      }).reply(200, { ok: true });
+
+      await probot.receive({
+        event: 'issues',
+        payload: {
+          ...issuePayload,
+          action: 'closed',
+        },
+      });
+    });
+
+    test('issues reopened does not make an API call to issues endpoint', async () => {
+      await Subscription.subscribe({
+        githubId: issuePayload.repository.id,
+        channelId: 'C001',
+        slackWorkspaceId: workspace.id,
+        installationId: installation.id,
+        creatorId: slackUser.id,
+      });
+
+      nock('https://api.github.com').get(`/repositories/${issuePayload.repository.id}`).reply(200, {
+        full_name: issuePayload.repository.full_name,
+      });
+
+      nock('https://slack.com').post('/api/chat.postMessage', (body) => {
+        expect(body).toMatchSnapshot();
+        return true;
+      }).reply(200, { ok: true });
+
+      await probot.receive({
+        event: 'issues',
+        payload: {
+          ...issuePayload,
+          action: 'reopened',
+        },
+      });
+    });
+
     test('pull request opened', async () => {
       await Subscription.subscribe({
         githubId: pullRequestPayload.repository.id,
@@ -154,6 +208,56 @@ describe('Integration: notifications', () => {
       await probot.receive({
         event: 'pull_request',
         payload: pullRequestPayload,
+      });
+    });
+
+    test('pull request closed does not make an API call to issues endpoint', async () => {
+      await Subscription.subscribe({
+        githubId: pullRequestPayload.repository.id,
+        channelId: 'C001',
+        slackWorkspaceId: workspace.id,
+        installationId: installation.id,
+        creatorId: slackUser.id,
+      });
+
+      nock('https://api.github.com').get(`/repositories/${pullRequestPayload.repository.id}`).reply(200);
+
+      nock('https://slack.com').post('/api/chat.postMessage', (body) => {
+        expect(body).toMatchSnapshot();
+        return true;
+      }).reply(200, { ok: true });
+
+      await probot.receive({
+        event: 'pull_request',
+        payload: {
+          ...pullRequestPayload,
+          action: 'closed',
+        },
+      });
+    });
+
+    test('pull request reopened does not make an API call to issues endpoint', async () => {
+      await Subscription.subscribe({
+        githubId: pullRequestPayload.repository.id,
+        channelId: 'C001',
+        slackWorkspaceId: workspace.id,
+        installationId: installation.id,
+        creatorId: slackUser.id,
+      });
+
+      nock('https://api.github.com').get(`/repositories/${pullRequestPayload.repository.id}`).reply(200);
+
+      nock('https://slack.com').post('/api/chat.postMessage', (body) => {
+        expect(body).toMatchSnapshot();
+        return true;
+      }).reply(200, { ok: true });
+
+      await probot.receive({
+        event: 'pull_request',
+        payload: {
+          ...pullRequestPayload,
+          action: 'reopened',
+        },
       });
     });
 


### PR DESCRIPTION
- Implements some logic that delays some GitHub API requests so that we're less likely to run into problems relating to replication lag
- Removes the API requests completely for issue and pr events where we don't need to make a separate API call. (All relevant data is included in the webhook)