### PR TITLE
Load models directly

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,5 +1,5 @@
 const Keyv = require('keyv');
-const logger = require('probot/lib/logger');
+const logger = require('./logger');
 
 const keyv = new Keyv({
   uri: process.env.REDIS_URL,

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ const errorHandler = require('./error-handler');
 
 module.exports = (robot) => {
   /* eslint-disable no-param-reassign */
-  robot.models = models({ logger: robot.log });
+  robot.models = models;
 
   const app = robot.route();
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,3 @@
+const logger = require('probot/lib/logger');
+
+module.exports = logger;

--- a/lib/models/githubuser.js
+++ b/lib/models/githubuser.js
@@ -1,6 +1,6 @@
 // FIXME: Update probot to expose public APIs for this
 const GitHub = require('probot/lib/github');
-const logger = require('probot/lib/logger');
+const logger = require('../logger');
 const Sequelize = require('sequelize');
 const EncryptedField = require('sequelize-encrypted');
 

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -6,43 +6,43 @@ const basename = path.basename(module.filename);
 const env = process.env.NODE_ENV || 'development';
 const config = require('../../db/config.json')[env];
 
-module.exports = ({ logger }) => {
-  const db = { logger };
+const logger = require('../logger');
 
-  Object.assign(config, {
-    operatorsAliases: false,
-    benchmark: true,
-    logging: (query, ms) => {
-      logger.debug({ ms }, query);
-    },
+const db = { logger };
+
+Object.assign(config, {
+  operatorsAliases: false,
+  benchmark: true,
+  logging: (query, ms) => {
+    logger.debug({ ms }, query);
+  },
+});
+
+let sequelize;
+if (config.use_env_variable) {
+  sequelize = new Sequelize(process.env[config.use_env_variable], config);
+} else {
+  sequelize = new Sequelize(config);
+}
+
+fs
+  .readdirSync(__dirname)
+  .filter(file =>
+    (file.indexOf('.') !== 0) &&
+    (file !== basename) &&
+    (file.slice(-3) === '.js'))
+  .forEach((file) => {
+    const model = sequelize.import(path.join(__dirname, file));
+    db[model.name] = model;
   });
 
-  let sequelize;
-  if (config.use_env_variable) {
-    sequelize = new Sequelize(process.env[config.use_env_variable], config);
-  } else {
-    sequelize = new Sequelize(config);
+Object.keys(db).forEach((modelName) => {
+  if (db[modelName].associate) {
+    db[modelName].associate(db);
   }
+});
 
-  fs
-    .readdirSync(__dirname)
-    .filter(file =>
-      (file.indexOf('.') !== 0) &&
-      (file !== basename) &&
-      (file.slice(-3) === '.js'))
-    .forEach((file) => {
-      const model = sequelize.import(path.join(__dirname, file));
-      db[model.name] = model;
-    });
+db.sequelize = sequelize;
+db.Sequelize = Sequelize;
 
-  Object.keys(db).forEach((modelName) => {
-    if (db[modelName].associate) {
-      db[modelName].associate(db);
-    }
-  });
-
-  db.sequelize = sequelize;
-  db.Sequelize = Sequelize;
-
-  return db;
-};
+module.exports = db;

--- a/lib/slack/client.js
+++ b/lib/slack/client.js
@@ -1,7 +1,7 @@
 const { WebClient } = require('@slack/client');
 // FIXME: this shouldn't be required directly. This client needs refactored to
 //        be passed `robot` at runtime an get the logger from `robot.log`
-const logger = require('probot/lib/logger');
+const logger = require('../logger');
 
 const webClientOptions = {
   logger: (level, ...args) => {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,6 +1,6 @@
 const createProbot = require('probot');
 const GitHub = require('probot/lib/github');
-const logger = require('probot/lib/logger');
+const logger = require('../../lib/logger');
 const nock = require('nock');
 
 const slackbot = require('../slackbot');

--- a/test/models/index.js
+++ b/test/models/index.js
@@ -1,7 +1,5 @@
-const loadModels = require('../../lib/models');
+const models = require('../../lib/models');
 const logger = require('probot/lib/logger');
-
-const models = loadModels({ logger });
 
 beforeAll(async () => {
   // Ensure there is a connection established

--- a/test/models/index.js
+++ b/test/models/index.js
@@ -1,5 +1,5 @@
 const models = require('../../lib/models');
-const logger = require('probot/lib/logger');
+const logger = require('../../lib/logger');
 
 beforeAll(async () => {
   // Ensure there is a connection established

--- a/test/models/installation.test.js
+++ b/test/models/installation.test.js
@@ -1,6 +1,6 @@
 const { Installation } = require('.');
 const GitHub = require('probot/lib/github');
-const logger = require('probot/lib/logger');
+const logger = require('../../lib/logger');
 const createdEvent = require('../fixtures/webhooks/installation.created');
 
 const nock = require('nock');


### PR DESCRIPTION
This PR makes it so we can just require `models` instead of having to call a function to initialize it. It also adds `lib/logger.js`, which just loads Probot's logger, but isolates it to one spot since the way Probot exposes a logger may likely change soon.

Before:

```js
const { Subscription } = require('models')({ logger });
```


```js
const { Subscription } = require('models');
```