### PR TITLE
Fix review casing

### DIFF
--- a/lib/activity/review.js
+++ b/lib/activity/review.js
@@ -3,7 +3,7 @@ const { Review } = require('../messages/review');
 
 module.exports = async (context, subscription, slack) => {
   if (
-    context.payload.review.state === 'commented' &&
+    context.payload.review.state.toLowerCase() === 'commented' &&
     context.payload.review.body === null
   ) {
     return;

--- a/lib/messages/review.js
+++ b/lib/messages/review.js
@@ -23,10 +23,10 @@ class Review extends Message {
     this.sender = sender;
     this.repository = repository;
 
-    if (this.review.state === 'approved') {
+    if (this.review.state.toLowerCase() === 'approved') {
       this.color = constants.OPEN_GREEN;
       this.middle = 'approved';
-    } else if (this.review.state === 'changes_requested') {
+    } else if (this.review.state.toLowerCase() === 'changes_requested') {
       this.color = constants.CLOSED_RED;
       this.middle = 'requested changes on';
     } else {

--- a/test/integration/notifications.test.js
+++ b/test/integration/notifications.test.js
@@ -391,7 +391,7 @@ describe('Integration: notifications', () => {
 
       nock('https://api.github.com')
         .get('/repos/github-slack/public-test/pulls/19/reviews/97014958')
-        .reply(200, { ...reviewApproved.review, body_html: 'rendered html' });
+        .reply(200, { ...reviewApproved.review, body_html: 'rendered html', state: 'APPROVED' });
 
       nock('https://slack.com').post('/api/chat.postMessage', (body) => {
         expect(body).toMatchSnapshot();


### PR DESCRIPTION
The `GET /repos/:owner/:repo/pulls/:number/reviews/:id` endpoint returns the `state` of a review in uppercase whereas the review webhooks show the `state` in lowercase.  As of recently we are making a request to this endpoint in order to fetch the `body_html` (#481). This has broken the way some review messages show up in Slack.

This PR makes the state checks case-insensitive

Closes #512