### PR TITLE
Potential fix for smee

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "start": "probot run --webhook-path=/github/events ./lib",
+    "start": "probot run ./lib",
     "test": "jest --coverage --runInBand --forceExit",
     "posttest": "npm run lint",
     "lint": "eslint lib test",


### PR DESCRIPTION
(Disclaimer, after enough time I just switched to ngrok (which I know well) so I didn't get all the way using smee, but spotted this.)

This is a bit more of a question PR, but I don't think smee is set up right for this project. 

Smee would get set up with a root like this:

<img width="724" alt="screen shot 2018-04-09 at 5 16 19 pm" src="https://user-images.githubusercontent.com/49038/38554983-954b1132-3c92-11e8-8f0a-8551e94f4f9a.png">

Which would work fine for a plain old probot - but this isn't a plain old probot, this repo needs other webhooks. So you have no way of going to the project root to do the GH oauth stuff, nor any way to hook up the slack calls. 

This PR moves the root back to the root.

<img width="712" alt="screen shot 2018-04-09 at 5 34 26 pm" src="https://user-images.githubusercontent.com/49038/38555054-cafe93da-3c92-11e8-8e73-7edcad00a2b0.png">