### PR TITLE
Automatically enact private unfurl if channel is subscribed to 👉 repo

### DIFF
--- a/lib/models/unfurl.js
+++ b/lib/models/unfurl.js
@@ -202,7 +202,7 @@ module.exports = (sequelize, DataTypes) => {
         const { repoIsPrivate, repoId } = await this.isPrivate(github, url);
         if (repoIsPrivate) {
           if (await Subscription.lookupOne(repoId, channel, workspace.id)) {
-            // No need to prompt because unfurl is to subscribed repo
+            // No need to prompt because unfurl is part of subscribed repo
             isPublic = false;
           } else {
             return this.create({

--- a/lib/models/unfurl.js
+++ b/lib/models/unfurl.js
@@ -22,7 +22,9 @@ const resources = {
 };
 
 module.exports = (sequelize, DataTypes) => {
-  const { SlackWorkspace, SlackUser, GitHubUser } = sequelize.models;
+  const {
+    SlackWorkspace, SlackUser, GitHubUser, Subscription,
+  } = sequelize.models;
   const Unfurl = sequelize.define('Unfurl', {
     url: {
       type: DataTypes.STRING,
@@ -167,10 +169,16 @@ module.exports = (sequelize, DataTypes) => {
       }
       // for now: if it's not part of a repo, then it can't be private
       if (!('repo' in params)) {
-        return false;
+        return {
+          repoIsPrivate: false,
+          repoId: undefined,
+        };
       }
       const repo = await github.repos.get({ owner: params.owner, repo: params.repo });
-      return repo.data.private;
+      return {
+        repoIsPrivate: repo.data.private,
+        repoId: repo.data.id,
+      };
     },
 
     async promptOrDeliver({
@@ -187,20 +195,27 @@ module.exports = (sequelize, DataTypes) => {
         },
       });
 
+      let isPublic = true;
       // Private check only carried out for unfurls in EARLY_ACCESS_CHANNELS
       if (process.env.EARLY_ACCESS_CHANNELS && process.env.EARLY_ACCESS_CHANNELS.split(',').includes(channel)) {
         const github = await this.getGitHubClient(channel, slackUser.id);
-        if (await this.isPrivate(github, url)) {
-          return this.create({
-            slackWorkspaceId: workspace.id,
-            slackUserId: slackUser.id,
-            channelSlackId: channel,
-            url,
-            isCondensed,
-            isPublic: false,
-            slackMessageTimestamp,
-            isDelivered: false,
-          });
+        const { repoIsPrivate, repoId } = await this.isPrivate(github, url);
+        if (repoIsPrivate) {
+          if (await Subscription.lookupOne(repoId, channel, workspace.id)) {
+            // No need to prompt because unfurl is to subscribed repo
+            isPublic = false;
+          } else {
+            return this.create({
+              slackWorkspaceId: workspace.id,
+              slackUserId: slackUser.id,
+              channelSlackId: channel,
+              url,
+              isCondensed,
+              isPublic: false,
+              slackMessageTimestamp,
+              isDelivered: false,
+            });
+          }
         }
       }
 
@@ -210,11 +225,11 @@ module.exports = (sequelize, DataTypes) => {
         channelSlackId: channel,
         url,
         isCondensed,
-        isPublic: true,
+        isPublic,
         isDelivered: false,
         slackMessageTimestamp,
       });
-      // Not private, so deliver immediately
+      // Deliver immediately
       await unfurl.deliver();
       return unfurl;
     },

--- a/test/integration/unfurl.test.js
+++ b/test/integration/unfurl.test.js
@@ -434,7 +434,7 @@ describe('Integration: unfurls', () => {
         .expect(200);
     });
 
-    test('automatically unfurls private resources if they are part of subscribed reop', async () => {
+    test('automatically unfurls private resources if they are part of subscribed repo', async () => {
       const installation = await Installation.create({
         githubId: 1,
         ownerId: 1337,

--- a/test/integration/unfurl.test.js
+++ b/test/integration/unfurl.test.js
@@ -434,7 +434,7 @@ describe('Integration: unfurls', () => {
         .expect(200);
     });
 
-    test.only('automatically unfurls private resources if they are part of subscribed reop', async () => {
+    test('automatically unfurls private resources if they are part of subscribed reop', async () => {
       const installation = await Installation.create({
         githubId: 1,
         ownerId: 1337,


### PR DESCRIPTION
This PR adds a change so that when you paste a private link which is part of a repo that the channel is subscribed to, then the private unfurl will happen automatically (without prompt).


Todo
- [x] Modify relevant tests
~- [ ] Make this workspace shippable~