### PR TITLE
Respond to `link_shared` event immediately

### DIFF
--- a/lib/unfurls/index.js
+++ b/lib/unfurls/index.js
@@ -6,10 +6,12 @@ async function linkShared(req, res) {
   const { event } = req.body;
 
   req.log.debug(req.body, 'Slack event received');
+  // Acknowledge receipt of event immediately
+  res.send();
 
   // if there are 3 or more, don't unfurl at all
   if (event.links.length > 2) {
-    return res.send();
+    return;
   }
 
   let eligibleLinks = await Promise.all(event.links
@@ -25,7 +27,7 @@ async function linkShared(req, res) {
   eligibleLinks = eligibleLinks.filter(link => link);
 
   if (eligibleLinks.length === 0) {
-    return res.send();
+    return;
   }
 
   // if there's 1 link in the message, full unfurl
@@ -64,7 +66,6 @@ async function linkShared(req, res) {
       }
     }
   }));
-  return res.send();
 }
 
 async function unfurlAction(req, res) {


### PR DESCRIPTION
We currently do all of our unfurl processing before we respond to the `link_shared` event that we receive from Slack. This can sometimes take longer than 3s, which causes Slack to re-send the `link_shared` event leading to a number of race conditions.

This is only rarely visible to users, but it does lead to duplicate unfurl records in the database.

With this PR we responds to Slack's event immediately and then proceed to process the event. This pattern is also encouraged by the Slack API.

Unfortunately this pattern seems incompatible with our current integration testing setup