### PR TITLE
Allow early access for an entire workspace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@ STORAGE_SECRET=
 
 # Comma separated list of channel ids with early access to new features
 EARLY_ACCESS_CHANNELS=
+
+# Comma separated list of team ids with early access to new features
+EARLY_ACCESS_WORKSPACES=

--- a/lib/models/unfurl.js
+++ b/lib/models/unfurl.js
@@ -3,6 +3,7 @@ const GitHubApi = require('probot/lib/github');
 
 const cache = require('../cache');
 const githubUrl = require('../github-url');
+const hasEarlyAccess = require('../slack/has-early-access');
 
 class UnsupportedResource extends Error {
   constructor(url) {
@@ -76,7 +77,12 @@ module.exports = (sequelize, DataTypes) => {
     },
 
     async deliver() {
-      const github = await this.constructor.getGitHubClient(this.channelSlackId, this.slackUserId);
+      const slackWorkspace = await SlackWorkspace.findById(this.slackWorkspaceId);
+      const github = await this.constructor.getGitHubClient(
+        this.channelSlackId,
+        slackWorkspace.slackId,
+        this.slackUserId,
+      );
       const {
         attachment,
         githubType,
@@ -85,7 +91,6 @@ module.exports = (sequelize, DataTypes) => {
         [this.url]: attachment,
       };
       logger.debug(unfurls, 'Unfurling links');
-      const slackWorkspace = await SlackWorkspace.findById(this.slackWorkspaceId);
       const slackRes = await slackWorkspace.client.chat.unfurl({
         ts: this.slackMessageTimestamp,
         channel: this.channelSlackId,
@@ -100,10 +105,10 @@ module.exports = (sequelize, DataTypes) => {
   });
 
   Object.assign(Unfurl, {
-    async getGitHubClient(channelId, slackUserId) {
+    async getGitHubClient(channelId, teamId, slackUserId) {
       const github = new GitHubApi({ logger });
 
-      if (!process.env.EARLY_ACCESS_CHANNELS || !process.env.EARLY_ACCESS_CHANNELS.split(',').includes(channelId)) {
+      if (!hasEarlyAccess({ channelId, teamId })) {
         // keep the old way of doing things working
         if (process.env.GITHUB_TOKEN) {
           github.authenticate({
@@ -196,9 +201,9 @@ module.exports = (sequelize, DataTypes) => {
       });
 
       let isPublic = true;
-      // Private check only carried out for unfurls in EARLY_ACCESS_CHANNELS
-      if (process.env.EARLY_ACCESS_CHANNELS && process.env.EARLY_ACCESS_CHANNELS.split(',').includes(channel)) {
-        const github = await this.getGitHubClient(channel, slackUser.id);
+      // Private check only carried out for channels/teams with early access
+      if (hasEarlyAccess({ channelId: channel, teamId })) {
+        const github = await this.getGitHubClient(channel, teamId, slackUser.id);
         const { repoIsPrivate, repoId } = await this.isPrivate(github, url);
         if (repoIsPrivate) {
           if (await Subscription.lookupOne(repoId, channel, workspace.id)) {

--- a/lib/slack/has-early-access.js
+++ b/lib/slack/has-early-access.js
@@ -1,0 +1,13 @@
+module.exports = function hasEarlyAccess({ channelId, teamId }) {
+  if (channelId && process.env.EARLY_ACCESS_CHANNELS) {
+    if (channelId && process.env.EARLY_ACCESS_CHANNELS.split(',').includes(channelId)) {
+      return true;
+    }
+  }
+  if (teamId && process.env.EARLY_ACCESS_WORKSPACES) {
+    if (teamId && process.env.EARLY_ACCESS_WORKSPACES.split(',').includes(teamId)) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/lib/unfurls/index.js
+++ b/lib/unfurls/index.js
@@ -1,6 +1,7 @@
 const { SlackWorkspace, Unfurl } = require('../models');
 
 const PrivateUnfurlPrompt = require('../messages/unfurls/private-unfurl-prompt');
+const hasEarlyAccess = require('../slack/has-early-access');
 
 async function linkShared(req, res) {
   const { event } = req.body;
@@ -54,7 +55,7 @@ async function linkShared(req, res) {
       }
       throw err;
     }
-    if (process.env.EARLY_ACCESS_CHANNELS && process.env.EARLY_ACCESS_CHANNELS.split(',').includes(event.channel)) {
+    if (hasEarlyAccess({ channelId: event.channel, teamId: req.body.team_id })) {
       if (newUnfurl && !newUnfurl.isDelivered) {
         await workspace.client.chat.postEphemeral({
           channel: event.channel,

--- a/test/integration/__snapshots__/unfurl.test.js.snap
+++ b/test/integration/__snapshots__/unfurl.test.js.snap
@@ -21,6 +21,15 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls private unfurls sending prompt works when only the workspace has early access 1`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"title\\":\\"Do you want to show a rich preview for https://github.com/bkeepers/dotenv?\\",\\"text\\":\\"The link you shared is private, so not everyone in this workspace may have access to it.\\",\\"callback_id\\":\\"unfurl-123\\",\\"actions\\":[{\\"name\\":\\"unfurl\\",\\"text\\":\\"Show rich preview\\",\\"type\\":\\"button\\",\\"style\\":\\"primary\\"},{\\"name\\":\\"unfurl-dismiss\\",\\"text\\":\\"Dismiss\\",\\"type\\":\\"button\\"}]}]",
+  "channel": "C0Other",
+  "token": "xoxa-token",
+  "user": "U88HS",
+}
+`;
+
 exports[`Integration: unfurls private unfurls sends prompt for private resource that can be unfurled 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"title\\":\\"Do you want to show a rich preview for https://github.com/bkeepers/dotenv?\\",\\"text\\":\\"The link you shared is private, so not everyone in this workspace may have access to it.\\",\\"callback_id\\":\\"unfurl-123\\",\\"actions\\":[{\\"name\\":\\"unfurl\\",\\"text\\":\\"Show rich preview\\",\\"type\\":\\"button\\",\\"style\\":\\"primary\\"},{\\"name\\":\\"unfurl-dismiss\\",\\"text\\":\\"Dismiss\\",\\"type\\":\\"button\\"}]}]",

--- a/test/slack/has-early-access.test.js
+++ b/test/slack/has-early-access.test.js
@@ -1,0 +1,40 @@
+const hasEarlyAccess = require('../../lib/slack/has-early-access');
+
+describe('has early access', () => {
+  test('returns false when neither EARLY_ACCESS_CHANNELS nor EARLY_ACCESS_WORKSPACES is set', () => {
+    expect(hasEarlyAccess({ channelId: 'C054321' })).toBe(false);
+  });
+  test('works for one channel', () => {
+    process.env.EARLY_ACCESS_CHANNELS = 'C01234';
+    expect(hasEarlyAccess({ channelId: 'C01234' })).toBe(true);
+  });
+
+  test('works for multiple channels', () => {
+    process.env.EARLY_ACCESS_CHANNELS = 'C01234,C054321';
+    expect(hasEarlyAccess({ channelId: 'C01234' })).toBe(true);
+    expect(hasEarlyAccess({ channelId: 'C054321' })).toBe(true);
+  });
+
+  test('works for one workspace', () => {
+    process.env.EARLY_ACCESS_WORKSPACES = 'T01234';
+    expect(hasEarlyAccess({ teamId: 'T01234' })).toBe(true);
+  });
+
+  test('works for multiple workspaces', () => {
+    process.env.EARLY_ACCESS_WORKSPACES = 'T01234,T054321';
+    expect(hasEarlyAccess({ teamId: 'T01234' })).toBe(true);
+    expect(hasEarlyAccess({ teamId: 'T054321' })).toBe(true);
+  });
+
+  test('returns true when workspace has early access but channel does not', () => {
+    process.env.EARLY_ACCESS_WORKSPACES = 'T01234';
+    process.env.EARLY_ACCESS_CHANNELS = 'C01234';
+    expect(hasEarlyAccess({ channelId: 'C01111', teamId: 'T01234' })).toBe(true);
+  });
+
+  test('returns true when channel has early access but workspace does not', () => {
+    process.env.EARLY_ACCESS_WORKSPACES = 'T01234';
+    process.env.EARLY_ACCESS_CHANNELS = 'C01234';
+    expect(hasEarlyAccess({ teamId: 'T099999', channelId: 'C01234' })).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR makes it possible to early access ship private unfurls to an entire workspace as opposed to just individual channels.