### PR TITLE
Add debug command

### DIFF
--- a/lib/commands/debug.js
+++ b/lib/commands/debug.js
@@ -1,0 +1,29 @@
+module.exports = async (req, res) => {
+  const { command } = res.locals;
+  const {
+    team_id,
+    team_domain,
+    user_id,
+    channel_id,
+    channel_name,
+    text,
+    enterprise_id,
+    enterprise_name,
+  } = req.body;
+  await command.respond({
+    response_type: 'ephemeral',
+    attachments: [{
+      title: 'Debug information',
+      text: `\`\`\`${JSON.stringify({
+        team_id,
+        team_domain,
+        user_id,
+        channel_id,
+        channel_name,
+        text,
+        enterprise_id,
+        enterprise_name,
+      }, null, 2)}\`\`\``,
+    }],
+  });
+};

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -5,6 +5,7 @@ const subscribe = require('./subscribe');
 const signin = require('./signin');
 const listSubscriptions = require('./list-subscriptions');
 const help = require('./help');
+const debug = require('./debug');
 
 module.exports = (robot) => {
   const app = robot.route('/slack/command');
@@ -32,6 +33,8 @@ module.exports = (robot) => {
   );
 
   app.post('/signin', signin);
+
+  app.post('/debug', debug);
 
   app.post(/.*/, help);
 

--- a/test/integration/__snapshots__/debug.test.js.snap
+++ b/test/integration/__snapshots__/debug.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration: debug returns debug information 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "text": "\`\`\`{
+  \\"team_id\\": \\"T0001\\",
+  \\"team_domain\\": \\"example\\",
+  \\"user_id\\": \\"U2147483697\\",
+  \\"channel_id\\": \\"C2147483705\\",
+  \\"channel_name\\": \\"test\\",
+  \\"text\\": \\"debug\\",
+  \\"enterprise_id\\": \\"E0001\\",
+  \\"enterprise_name\\": \\"Globular%20Construct%20Inc\\"
+}\`\`\`",
+      "title": "Debug information",
+    },
+  ],
+  "response_type": "ephemeral",
+}
+`;

--- a/test/integration/debug.test.js
+++ b/test/integration/debug.test.js
@@ -1,0 +1,17 @@
+const request = require('supertest');
+
+const helper = require('.');
+const fixtures = require('../fixtures');
+
+const { probot, slackbot } = helper;
+
+describe('Integration: debug', () => {
+  test('returns debug information', async () => {
+    const command = fixtures.slack.command({ text: 'debug' });
+    await request(probot.server).post('/slack/command').use(slackbot).send(command)
+      .expect(200)
+      .then((res) => {
+        expect(res.body).toMatchSnapshot();
+      });
+  });
+});


### PR DESCRIPTION
Adds a `/github debug` command that returns some information from the slash command straight to the channel

When you run `/github debug` you'll see the following output
![image](https://user-images.githubusercontent.com/7718702/38748284-86656a4a-3f45-11e8-9ee7-dc87b45f68fa.png)

This will make both debugging and potentially also troubleshooting much easier cc @izuzak 

Purposefully not included in `/github help` because this slash command is not part of the core functionality offered by our app and should only be used under some circumstances for debugging