### PR TITLE
[WIP] unfurl Slack links in comments

### DIFF
--- a/lib/activity/comments.js
+++ b/lib/activity/comments.js
@@ -1,5 +1,9 @@
+const { JSDOM } = require('jsdom');
 const cache = require('../cache');
 const { Comment } = require('../messages/comment');
+
+// Extract just the hostname out of SLACK_ROOT_URL
+const slackDomain = JSDOM.fragment(`<a href="${process.env.SLACK_ROOT_URL}">test</a>`).firstChild.hostname;
 
 module.exports = async (context, subscription, slack) => {
   const { repository } = context.payload;
@@ -20,6 +24,66 @@ module.exports = async (context, subscription, slack) => {
     if (err.code !== 403) {
       throw err;
     }
+  }
+
+  // HACK: Only unfurl on new comments (so we do not keep unfurling)
+  if (context.payload.action === 'created') {
+    // Check if the comment contains a Slack Link.
+    // Slack links are of the form `https://{team}.slack.com/archives/{channel}/p##########000000`
+    const slackLinks = [];
+    const frag = JSDOM.fragment(comment.body_html);
+    frag.querySelectorAll('a').forEach((a) => {
+      if (a.hostname.endsWith(slackDomain)) {
+        const [channelId, ts] = a.pathname.split('/').slice(2);
+        slackLinks.push({ channelId, ts, href: a.href });
+      }
+    });
+    slackLinks.forEach(({ channelId, ts, href }) => {
+      // Post a message asking the channel to confirm unfurling
+      // TODO: use slack.chat.postEphemeral if we can authenticate
+      // the Slack User and they are in the channel
+      const attachments = [
+        {
+          text: 'Should the link be unfurled?',
+          fallback: 'Slack link unfurling on GitHub is not supported in this client',
+          color: '#3AA3E3',
+          // The Slack Message link is encoded with hyphens here
+          callback_id: `slackunfurl-${channelId}-${ts}`,
+          attachment_type: 'default',
+          actions: [
+            {
+              type: 'button',
+              name: 'slackunfurl-slack-message-accept',
+              text: 'Accept',
+              // The GitHub information for the comment is encoded here
+              value: JSON.stringify({
+                githubId: subscription.Installation.githubId,
+                issueCommentUrl: comment.url,
+              }),
+              confirm: {
+                title: 'Are you sure?',
+                text: 'It will be visible to people that are not memebers of this Slack Channel',
+                ok_text: 'Yes',
+                dismiss_text: 'No',
+              },
+            },
+            {
+              type: 'button',
+              name: 'slackunfurl-slack-message-reject',
+              text: 'Reject',
+              value: 'slackunfurl-slack-message-reject-yes',
+            },
+          ],
+        },
+      ];
+      slack.chat.postMessage({
+        channel: channelId,
+        text: `${comment.user.login} posted a comment at <${comment.html_url}|${context.payload.repository.full_name}#${context.payload.issue.number}> that links to a <${href}|Slack message> in this channel.\n*Note:* The message will become visible on GitHub`,
+        unfurl_links: false,
+        unfurl_media: false,
+        attachments,
+      });
+    });
   }
 
   const attachments = [

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const sslify = require('express-sslify');
 
 const setupSlack = require('./slack');
 const setupGitHub = require('./github');
+const { hackSetupSlackUnfurl } = require('./slackunfurl');
 const frontend = require('./frontend');
 const errorHandler = require('./error-handler');
 
@@ -32,6 +33,7 @@ module.exports = (robot) => {
 
   setupSlack(robot);
   setupGitHub(robot);
+  hackSetupSlackUnfurl(robot);
 
   errorHandler.teardown(app);
 

--- a/lib/slack/index.js
+++ b/lib/slack/index.js
@@ -6,6 +6,7 @@ const oauth = require('./oauth');
 const importer = require('./importer');
 const uninstall = require('./uninstall');
 const middleware = require('./../middleware');
+const { slackUnfurlAction } = require('../slackunfurl');
 
 module.exports = (robot) => {
   const router = robot.route('/slack');
@@ -39,5 +40,6 @@ module.exports = (robot) => {
   router.use('/actions', middleware.validate);
   router.use('/actions', middleware.routeAction);
 
+  router.post('/actions:slackunfurl', slackUnfurlAction);
   router.post('/actions:unfurl', unfurls.unfurlAction);
 };

--- a/lib/slack/oauth.js
+++ b/lib/slack/oauth.js
@@ -9,7 +9,7 @@ const clientId = process.env.SLACK_CLIENT_ID;
 module.exports = {
   async login(req, res) {
     // FIXME: make dynamic
-    const scope = 'links:read,links:write,commands,chat:write,team:read';
+    const scope = 'links:read,links:write,commands,chat:write,team:read,channels:history,im:history';
     const slackRootUrl = process.env.SLACK_ROOT_URL || 'https://slack.com';
     const state = crypto.randomBytes(Math.ceil(30 / 2)).toString('hex').slice(0, 30);
 

--- a/lib/slackunfurl.js
+++ b/lib/slackunfurl.js
@@ -1,0 +1,80 @@
+const { SlackWorkspace } = require('./models');
+
+let robot = null;
+
+function hackSetupSlackUnfurl(r) {
+  robot = r;
+}
+
+async function slackUnfurlAction(req, res, next) {
+  if (!req.body.callback_id.startsWith('slackunfurl-')) {
+    return next();
+  }
+
+  if (req.body.actions[0].name === 'slackunfurl-slack-message-accept') {
+    const [channelId, timestamp] = req.body.callback_id.split('-').slice(1);
+
+    // Reformat the timestamp to be of the form `1476909142.000007`
+    // It is currently in the form `p1476909142000007`
+    const ts = `${timestamp.substring(1, timestamp.length - 6)}.${timestamp.substring(timestamp.length - 6)}`;
+
+    // Load the Slack workspace client
+    const workspace = await SlackWorkspace.findOne({
+      where: { slackId: req.body.team.id },
+    });
+
+    // Load the Slack Message
+    const historyArgs = {
+      channel: channelId,
+      latest: ts,
+      inclusive: true,
+      count: 1,
+    };
+    let history;
+    // TODO: Surely there is a better way to determine the Slack Channel type
+    // `workspace.client.conversations.history(...)` yields a not_allowed_token_type
+    if (channelId.startsWith('D')) {
+      history = await workspace.client.im.history(historyArgs);
+    } else if (channelId.startsWith('C')) {
+      history = await workspace.client.channels.history(historyArgs);
+    } else {
+      throw new Error(`Unsupported channel type ${channelId[0]}`);
+    }
+    const { messages } = history;
+    req.log.info(messages[0], 'Found message in history');
+
+
+    // Load the GitHub client
+    const payload = JSON.parse(req.body.actions[0].value);
+    const github = await robot.auth(payload.githubId);
+
+    // Update the comment
+    if (payload.issueCommentUrl) {
+      req.log.info(payload.issueCommentUrl, 'Unfurling Slack link');
+      const comment = (await github.request({
+        method: 'GET',
+        url: payload.issueCommentUrl,
+      })).data;
+
+      const unfurled = messages[0].text.split('\n').map(line => `> ${line}`).join('\n');
+      await github.request({
+        method: 'PATCH',
+        url: payload.issueCommentUrl,
+        body: `${comment.body}\n\n${unfurled}`,
+      });
+    } else {
+      // Could also be Issue Body or Pull Request Body
+      throw new Error('Only comments are supported in Slack Unfurling for now');
+    }
+  }
+
+  // Done. Delete the prompt in the channel
+  return res.send({
+    delete_original: true,
+  });
+}
+
+module.exports = {
+  hackSetupSlackUnfurl,
+  slackUnfurlAction,
+};

--- a/lib/unfurls/index.js
+++ b/lib/unfurls/index.js
@@ -67,7 +67,10 @@ async function linkShared(req, res) {
   return res.send();
 }
 
-async function unfurlAction(req, res) {
+async function unfurlAction(req, res, next) {
+  if (!req.body.callback_id.startsWith('unfurl-')) {
+    return next();
+  }
   const storedUnfurl = await Unfurl.findById(req.body.callback_id.replace('unfurl-', ''));
 
   if (req.body.actions[0].name === 'unfurl-dismiss') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -897,6 +897,14 @@
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
       "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
     },
+    "basic-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -1776,8 +1784,7 @@
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1849,11 +1856,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
       "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
     },
-    "content-type-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
-      "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ="
-    },
     "convert-source-map": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
@@ -1894,8 +1896,7 @@
     "cookiejar": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
-      "dev": true
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
     },
     "cookies": {
       "version": "0.7.1",
@@ -2012,6 +2013,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
       "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
+    },
+    "data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "requires": {
+        "abab": "1.0.4",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.4.0"
+      }
     },
     "debug": {
       "version": "2.6.8",
@@ -2722,6 +2733,14 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.1.tgz",
       "integrity": "sha512-QOCPu979MMWX9XNlfRZoin+Wm+bK1SP7vv3NGUniYwuSJK/+cPA10blMaeRgzg31RvoSFk6FsCDVa4vNryBTGA=="
     },
+    "eventsource": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.5.tgz",
+      "integrity": "sha512-IzjLaND9GBK3+fBPhmvG/Yq3FhSDGHnucJCDWhNsneLlN+HX5jeaSpl3Folr2PipGmyUsd/T2Vrua+s6I2aTgQ==",
+      "requires": {
+        "original": "1.0.0"
+      }
+    },
     "exec-sh": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
@@ -3197,10 +3216,9 @@
       }
     },
     "formidable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.0.tgz",
-      "integrity": "sha512-hr9aT30rAi7kf8Q2aaTpSP7xGMhlJ+MdrUDVZs3rxbD3L/K46A86s2VY7qC2D2kGYGBtiT/3j6wTx1eeUq5xAQ==",
-      "dev": true
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -4704,11 +4722,11 @@
       "integrity": "sha512-zXhh/DqgrTXJ7erTN6Fh5k/xjMhDGXCqdYN3wvxUvGUQvnxcFfUd8E+6vLg/nk3ss1TYMb+DhRl25fYABioTvA=="
     },
     "html-encoding-sniffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
-      "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "requires": {
-        "whatwg-encoding": "1.0.1"
+        "whatwg-encoding": "1.0.3"
       }
     },
     "html-to-mrkdwn": {
@@ -4838,9 +4856,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz",
-      "integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
         "agent-base": "4.2.0",
@@ -5748,7 +5766,7 @@
           "requires": {
             "jest-mock": "22.2.0",
             "jest-util": "22.2.2",
-            "jsdom": "11.5.1"
+            "jsdom": "11.7.0"
           }
         },
         "jest-environment-node": {
@@ -6181,7 +6199,7 @@
           "requires": {
             "jest-mock": "22.2.0",
             "jest-util": "22.2.2",
-            "jsdom": "11.5.1"
+            "jsdom": "11.7.0"
           }
         },
         "jest-environment-node": {
@@ -6674,7 +6692,7 @@
           "requires": {
             "jest-mock": "22.2.0",
             "jest-util": "22.2.2",
-            "jsdom": "11.5.1"
+            "jsdom": "11.7.0"
           }
         },
         "jest-environment-node": {
@@ -6967,7 +6985,7 @@
           "requires": {
             "jest-mock": "22.2.0",
             "jest-util": "22.2.2",
-            "jsdom": "11.5.1"
+            "jsdom": "11.7.0"
           }
         },
         "jest-environment-node": {
@@ -7185,45 +7203,47 @@
       "optional": true
     },
     "jsdom": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
-      "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.7.0.tgz",
+      "integrity": "sha512-9NzSc4Iz4gN9p4uoPbBUzro21QdgL32swaWIaWS8eEVQ2I69fRJAy/MKyvlEIk0V7HtKgfMbbOKyTZUrzR2Hsw==",
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.3.0",
+        "acorn": "5.5.3",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
-        "browser-process-hrtime": "0.1.2",
-        "content-type-parser": "1.0.1",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
+        "data-urls": "1.0.0",
         "domexception": "1.0.0",
         "escodegen": "1.9.0",
-        "html-encoding-sniffer": "1.0.1",
+        "html-encoding-sniffer": "1.0.2",
         "left-pad": "1.2.0",
         "nwmatcher": "1.4.3",
-        "parse5": "3.0.3",
-        "pn": "1.0.0",
+        "parse5": "4.0.0",
+        "pn": "1.1.0",
         "request": "2.83.0",
         "request-promise-native": "1.0.5",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.3",
+        "tough-cookie": "2.3.4",
+        "w3c-hr-time": "1.0.1",
         "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.1",
+        "whatwg-encoding": "1.0.3",
+        "whatwg-mimetype": "2.1.0",
         "whatwg-url": "6.4.0",
-        "xml-name-validator": "2.0.1"
+        "ws": "4.1.0",
+        "xml-name-validator": "3.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
         },
         "tough-cookie": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "requires": {
             "punycode": "1.4.1"
           }
@@ -7775,8 +7795,7 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.29.0",
@@ -7854,6 +7873,28 @@
       "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
       "requires": {
         "moment": "2.21.0"
+      }
+    },
+    "morgan": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "requires": {
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "ms": {
@@ -8353,6 +8394,14 @@
         "wordwrap": "1.0.0"
       }
     },
+    "original": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+      "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+      "requires": {
+        "url-parse": "1.0.5"
+      }
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -8466,12 +8515,9 @@
       }
     },
     "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "requires": {
-        "@types/node": "8.0.53"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
     },
     "parseurl": {
       "version": "1.3.2",
@@ -8708,9 +8754,9 @@
       "dev": true
     },
     "pn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.0.0.tgz",
-      "integrity": "sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -9108,7 +9154,7 @@
       "requires": {
         "debug": "2.6.8",
         "extract-zip": "1.6.6",
-        "https-proxy-agent": "2.2.0",
+        "https-proxy-agent": "2.2.1",
         "mime": "1.6.0",
         "progress": "2.0.0",
         "proxy-from-env": "1.0.0",
@@ -9172,6 +9218,11 @@
           "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         }
       }
+    },
+    "querystringify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+      "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
     },
     "randomatic": {
       "version": "1.1.7",
@@ -9631,6 +9682,11 @@
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
       }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.5.0",
@@ -10097,6 +10153,24 @@
         }
       }
     },
+    "smee-client": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/smee-client/-/smee-client-1.0.1.tgz",
+      "integrity": "sha512-porkZGtw7sHPuS5w6LW5FX7JY3JQuR52Y1cZoXHMmCzz3JKlFPkFZ3db6sXU+5iTTvexcUZ3U/bGWOMZECev/w==",
+      "requires": {
+        "commander": "2.15.1",
+        "eventsource": "1.0.5",
+        "morgan": "1.9.0",
+        "superagent": "3.8.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+        }
+      }
+    },
     "snapdragon": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
@@ -10214,7 +10288,7 @@
       "dev": true,
       "requires": {
         "bottleneck": "1.16.0",
-        "commander": "2.15.0",
+        "commander": "2.15.1",
         "fs-path": "0.0.23",
         "puppeteer": "0.13.0",
         "recursive-readdir": "2.2.2",
@@ -10228,9 +10302,9 @@
           "dev": true
         },
         "commander": {
-          "version": "2.15.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-          "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         }
       }
@@ -10555,14 +10629,13 @@
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
       "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
-      "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "cookiejar": "2.1.1",
         "debug": "3.1.0",
         "extend": "3.0.1",
         "form-data": "2.3.2",
-        "formidable": "1.2.0",
+        "formidable": "1.2.1",
         "methods": "1.1.2",
         "mime": "1.6.0",
         "qs": "6.5.1",
@@ -10573,7 +10646,6 @@
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
@@ -10582,7 +10654,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -10591,7 +10662,6 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-          "dev": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
@@ -10601,8 +10671,7 @@
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-          "dev": true
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
         }
       }
     },
@@ -11026,7 +11095,7 @@
       "resolved": "https://registry.npmjs.org/turndown/-/turndown-4.0.1.tgz",
       "integrity": "sha512-xC83XzYm+yLuQWLBc87s63FLn4+ERdZOxDqlrlvKKWcyL9UFhwtR4hAqmFBKDUQyejRZWU9Fac4vMHomlFboyg==",
       "requires": {
-        "jsdom": "11.5.1"
+        "jsdom": "11.7.0"
       }
     },
     "turndown-plugin-gfm": {
@@ -11289,6 +11358,15 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
       "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
     },
+    "url-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+      "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+      "requires": {
+        "querystringify": "0.0.4",
+        "requires-port": "1.0.0"
+      }
+    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -11512,19 +11590,24 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "whatwg-encoding": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
-      "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
       "requires": {
-        "iconv-lite": "0.4.13"
+        "iconv-lite": "0.4.19"
       },
       "dependencies": {
         "iconv-lite": {
-          "version": "0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
         }
       }
+    },
+    "whatwg-mimetype": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew=="
     },
     "whatwg-url": {
       "version": "6.4.0",
@@ -11665,9 +11748,9 @@
       "dev": true
     },
     "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
     },
     "xtend": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express-sslify": "^1.2.0",
     "helmet": "^3.11.0",
     "html-to-mrkdwn": "^2.0.0",
+    "jsdom": "^11.7.0",
     "jsonwebtoken": "^8.1.0",
     "keyv": "^3.0.0",
     "moment": "^2.21.0",
@@ -33,7 +34,8 @@
     "request": "^2.83.0",
     "sequelize": "^4.33.4",
     "sequelize-cli": "^4.0.0",
-    "sequelize-encrypted": "^1.0.0"
+    "sequelize-encrypted": "^1.0.0",
+    "smee-client": "^1.0.1"
   },
   "devDependencies": {
     "dotenv": "^5.0.0",


### PR DESCRIPTION
When a User includes a Slack link on GitHub, this prompts users in the Slack channel to decide if they want the link unfurled and visible on GitHub or not.

Refs #477

# Screencap

![unfurl-slack-links](https://user-images.githubusercontent.com/253202/38775567-aa662af6-4053-11e8-93a5-205b393b9e2e.gif)


# Notes

This adds additional scopes in order to be able to look up the Slack message: `channels:history,im:history`. There might be a better way to look up a message but the only way I found was to use [client.channels.history(...)](https://api.slack.com/methods/channels.history#retrieving_a_single_message).


# TODO

- [ ] Send a DM to the Comment Author when the Slack Integration is not in the referenced channel
- [ ] Move the messages into `lib/messages/`
- [ ] Convert Slack's `mrkdwn` to GFM or HTML
- [ ] Add tests!
- [ ] Support unfurling in the Pull Request and Issue Body, not just in comments
- [ ] Support unfurling when a Comment is edited
- [ ] Maybe include who approved the unfurl as an HTML comment in the Issue/Comment
- [ ] Support precise unfurling (currently it puts the unfurl at the bottom of the comment)
- [ ] Remember when users `[Decline]` and do not prompt them again
