### PR TITLE
Handle permanent Slack errors

### DIFF
--- a/lib/activity/router.js
+++ b/lib/activity/router.js
@@ -1,6 +1,7 @@
 const { Subscription, SlackUser, GitHubUser } = require('../models');
 const { ReEnableSubscription } = require('../messages/flow');
 const avoidReplicationLag = require('../github/avoid-replication-lag');
+const isPermanentError = require('../slack/is-permanent-error');
 const cache = require('../cache');
 
 // Temporary "middleware" hack to look up routing before delivering event
@@ -61,13 +62,7 @@ module.exports = function route(callback) {
         try {
           await callback(context, subscription, slack);
         } catch (err) {
-          const PERMANENT_ERRORS = [
-            'no_permission',
-            'account_inactive',
-            'channel_not_found',
-          ];
-
-          if (err.data && PERMANENT_ERRORS.includes(err.data.error)) {
+          if (isPermanentError(err)) {
             await subscription.destroy();
           } else {
             throw err;

--- a/lib/activity/router.js
+++ b/lib/activity/router.js
@@ -58,7 +58,21 @@ module.exports = function route(callback) {
         // Delay GitHub API calls to avoid replication lag
         context.github.hook.before('request', avoidReplicationLag());
 
-        return callback(context, subscription, slack);
+        try {
+          await callback(context, subscription, slack);
+        } catch (err) {
+          const PERMANENT_ERRORS = [
+            'no_permission',
+            'account_inactive',
+            'channel_not_found',
+          ];
+
+          if (err.data && PERMANENT_ERRORS.includes(err.data.error)) {
+            await subscription.destroy();
+          } else {
+            throw err;
+          }
+        }
       }));
     }
   };

--- a/lib/slack/is-permanent-error.js
+++ b/lib/slack/is-permanent-error.js
@@ -1,0 +1,9 @@
+const PERMANENT_ERRORS = [
+  'no_permission',
+  'account_inactive',
+  'channel_not_found',
+  'is_archived',
+  'token_revoked',
+];
+
+module.exports = err => err.data && PERMANENT_ERRORS.includes(err.data.error);

--- a/test/integration/notifications.test.js
+++ b/test/integration/notifications.test.js
@@ -783,5 +783,37 @@ describe('Integration: notifications', () => {
 
       expect(await Subscription.findById(subscription.id)).toBe(null);
     });
+
+    test('other error from slack does not delete subscription', async () => {
+      const subscription = await Subscription.subscribe({
+        githubId: issuePayload.repository.id,
+        channelId: 'C001',
+        slackWorkspaceId: workspace.id,
+        installationId: installation.id,
+        creatorId: slackUser.id,
+      });
+
+      nock('https://api.github.com').get(`/repositories/${issuePayload.repository.id}`).reply(200, {
+        full_name: issuePayload.repository.full_name,
+      });
+      nock('https://api.github.com', {
+        reqHeaders: {
+          Accept: 'application/vnd.github.html+json',
+        },
+      }).get('/repos/github-slack/public-test/issues/1').reply(200, fixtures.issue);
+
+      nock('https://slack.com').post('/api/chat.postMessage')
+        .reply(200, { ok: false, error: 'some_other_error' });
+
+      // Close your eyes, little probot. You do not want to see what is to come
+      probot.logger.level('fatal');
+
+      await expect(probot.receive({
+        event: 'issues',
+        payload: issuePayload,
+      })).rejects.toThrow();
+
+      expect(await subscription.reload()).toEqual(subscription);
+    });
   });
 });

--- a/test/integration/notifications.test.js
+++ b/test/integration/notifications.test.js
@@ -755,7 +755,7 @@ describe('Integration: notifications', () => {
       expect((await Subscription.lookup(repositoryDeleted.repository.id)).length).toBe(0);
     });
 
-    test.only('channel_not_found error from slack deletes subscription', async () => {
+    test('channel_not_found error from slack deletes subscription', async () => {
       const subscription = await Subscription.subscribe({
         githubId: issuePayload.repository.id,
         channelId: 'C001',


### PR DESCRIPTION
Some errors that are currently being raised when delivering notifications are permanent. This rescues them and deletes the subscription so we stop attempting to deliver in the future.

Fixes #197 
Fixes #188 
