### PR TITLE
Fixes to subscription settings commands

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -38,5 +38,7 @@ module.exports = (robot) => {
 
   app.post(/.*/, help);
 
+  app.use(middleware.validationError);
+
   robot.log.trace('Loaded commands');
 };

--- a/lib/commands/subscribe.js
+++ b/lib/commands/subscribe.js
@@ -29,7 +29,11 @@ module.exports = async (req, res) => {
   const to = command.channel_id;
 
   let subscription = await Subscription.lookupOne(from.id, to, slackWorkspace.id, installation.id);
-  const settings = command.args.slice(1);
+
+  let settings = command.args.slice(1);
+  if (settings.length > 0) {
+    settings = settings.join(' ').split(/[ ,]+/);
+  }
 
   if (command.subcommand === 'subscribe') {
     if (subscription) {

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -10,6 +10,7 @@ module.exports = {
   pendingCommand: require('./pending-command'),
   urlVerification: require('./url-verification'),
   validate: require('./validate'),
+  validationError: require('./validation-error'),
   parseActionPayload: require('./parse-action-payload'),
   routeAction: require('./route-action'),
 };

--- a/lib/middleware/validation-error.js
+++ b/lib/middleware/validation-error.js
@@ -1,0 +1,20 @@
+const { ValidationError } = require('sequelize');
+
+module.exports = (err, req, res, next) => {
+  if (!(err instanceof ValidationError)) {
+    return next();
+  }
+
+  const { command } = res.locals;
+
+  command.respond({
+    response_type: 'ephemeral',
+    attachments: [
+      {
+        text: err.toString(),
+        color: 'danger',
+        mrkdwn_in: ['text'],
+      },
+    ],
+  });
+};

--- a/lib/middleware/validation-error.js
+++ b/lib/middleware/validation-error.js
@@ -2,7 +2,7 @@ const { ValidationError } = require('sequelize');
 
 module.exports = (err, req, res, next) => {
   if (!(err instanceof ValidationError)) {
-    return next();
+    return next(err);
   }
 
   const { command } = res.locals;

--- a/lib/middleware/validation-error.js
+++ b/lib/middleware/validation-error.js
@@ -7,11 +7,14 @@ module.exports = (err, req, res, next) => {
 
   const { command } = res.locals;
 
+  let text = 'Uh oh! ';
+  text += err.errors.map(e => e.message).join(', ');
+
   command.respond({
     response_type: 'ephemeral',
     attachments: [
       {
-        text: err.toString(),
+        text,
         color: 'danger',
         mrkdwn_in: ['text'],
       },

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -56,12 +56,17 @@ module.exports = (sequelize, DataTypes) => {
 
       validate: {
         hasValidValues(value) {
+          const validValuesMessage = [
+            'Available features are:',
+            Object.keys(DefaultSettings).map(feature => `\`${feature}\``).join(', '),
+          ].join('\n');
+
           Object.keys(value).forEach((setting) => {
             if (DefaultSettings[setting] === undefined) {
-              throw new Error(`"${setting}" is not a setting`);
+              throw new Error(`\`${setting}\` is not a feature. ${validValuesMessage}`);
             }
             if (typeof value[setting] !== 'boolean' && !AllowValues[setting].includes(value[setting])) {
-              throw new Error(`"${setting}:${value[setting]}" is not a setting`);
+              throw new Error(`\`${setting}:${value[setting]}\` is not a feature. ${validValuesMessage}`);
             }
           });
         },

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -94,9 +94,9 @@ module.exports = (sequelize, DataTypes) => {
       return !!settings[key];
     },
 
-    enable(events) {
-      [].concat(events).forEach((event) => {
-        const [name, value] = event.split(':');
+    enable(features) {
+      [].concat(features).forEach((feature) => {
+        const [name, value] = feature.split(':');
         this.settings[name] = value || true;
       });
       this.changed('settings', true);
@@ -114,9 +114,9 @@ module.exports = (sequelize, DataTypes) => {
       }).filter(setting => setting);
     },
 
-    disable(events) {
-      [].concat(events).forEach((event) => {
-        const [name] = event.split(':');
+    disable(features) {
+      [].concat(features).forEach((feature) => {
+        const [name] = feature.split(':');
         this.settings[name] = false;
       });
       this.changed('settings', true);

--- a/test/integration/subscriptions.test.js
+++ b/test/integration/subscriptions.test.js
@@ -282,6 +282,23 @@ describe('Integration: subscriptions', () => {
         expect(subscription.isEnabledForGitHubEvent('issues')).toBe(true);
       });
 
+      test('subscribing to an unknown feature', async () => {
+        nock('https://api.github.com').get('/repos/bkeepers/dotenv/installation').reply(200, {
+          id: installation.githubId,
+          account: fixtures.repo.owner,
+        });
+        nock('https://api.github.com').get('/repos/bkeepers/dotenv').reply(200, fixtures.repo);
+
+        await request.post('/slack/command').use(slackbot)
+          .send(fixtures.slack.command({
+            text: 'subscribe bkeepers/dotenv foobar',
+          }))
+          .expect(200)
+          .expect((res) => {
+            expect(JSON.stringify(res.body)).toMatch(/foobar/i);
+          });
+      });
+
       test('subscribing when already subscribed', async () => {
         nock('https://api.github.com').get('/repos/atom/atom/installation').reply(200, {
           id: installation.githubId,

--- a/test/integration/subscriptions.test.js
+++ b/test/integration/subscriptions.test.js
@@ -270,7 +270,7 @@ describe('Integration: subscriptions', () => {
 
         await request.post('/slack/command').use(slackbot)
           .send(fixtures.slack.command({
-            text: 'subscribe bkeepers/dotenv pulls issues',
+            text: 'subscribe bkeepers/dotenv pulls, issues',
           }))
           .expect(200)
           .expect((res) => {

--- a/test/models/__snapshots__/subscription.test.js.snap
+++ b/test/models/__snapshots__/subscription.test.js.snap
@@ -1,5 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`model: Subscription settings raises an error for unknown setting 1`] = `"Validation error: \\"time-travel\\" is not a setting"`;
-
-exports[`model: Subscription settings raises an error for unknown setting value 1`] = `"Validation error: \\"commits:wat?\\" is not a setting"`;

--- a/test/models/subscription.test.js
+++ b/test/models/subscription.test.js
@@ -171,7 +171,7 @@ describe('model: Subscription', () => {
 
     test('raises an error for unknown setting', async () => {
       subscription.enable('time-travel');
-      await expect(subscription.save()).rejects.toThrowErrorMatchingSnapshot();
+      await expect(subscription.save()).rejects.toThrowError('time-travel');
     });
 
     test('raises an error for unknown setting value', async () => {
@@ -179,7 +179,7 @@ describe('model: Subscription', () => {
       await subscription.save();
 
       subscription.enable('commits:wat?');
-      await expect(subscription.save()).rejects.toThrowErrorMatchingSnapshot();
+      await expect(subscription.save()).rejects.toThrowError('commits:wat?');
     });
   });
 


### PR DESCRIPTION
1. Allow commas to separate multiple subscription features (only spaces were supported previously):  `/github subscribe integrations/slack comments,reviews`
2. Show a friendly error message when using an unknown subscription feature: `/github subscribe integrations/slack foobar`

<img width="679" alt="slack_-_github_slack_dev" src="https://user-images.githubusercontent.com/173/39004441-eccc8594-43c2-11e8-9902-a7314c1e7cee.png">

Fixes #535
cc @izuzak 