### PR TITLE
Only listen to comment created and edited, not deleted

### DIFF
--- a/lib/activity/index.js
+++ b/lib/activity/index.js
@@ -38,7 +38,12 @@ module.exports = (robot) => {
   robot.on('push', route(push));
   robot.on('public', route(publicEvent));
 
-  robot.on(['issue_comment', 'pull_request_review_comment'], route(comments));
+  robot.on([
+    'issue_comment.created',
+    'issue_comment.edited',
+    'pull_request_review_comment.created',
+    'pull_request_review_comment.edited',
+  ], route(comments));
 
   robot.on(['create', 'delete'], route(ref));
   robot.on(['pull_request_review.submitted', 'pull_request_review.edited'], route(review));


### PR DESCRIPTION
Currently we're getting errors whenever an issue comment or a pull request review comment is deleted, because we try to fetch it and get a `404`. With this PR, we'll only respond to when either comment is created or edited.