### PR TITLE
Only attach command metadata if exception happened as result of command

### DIFF
--- a/lib/messages/flow/exception.js
+++ b/lib/messages/flow/exception.js
@@ -2,13 +2,16 @@ const supportLink = require('../../support-link');
 
 module.exports = class Exception {
   constructor(errorCode, command) {
-    this.link = supportLink({
-      comments: `Tell us a little more about what happened and include the error code and metadata below.\n\nError code: ${errorCode}\n\n` +
-        'Slack metadata:\n' +
+    let comments = `Tell us a little more about what happened and include the error code and metadata below.\n\nError code: ${errorCode}\n\n`;
+    if (command) {
+      comments += 'Slack metadata:\n' +
         `Team: ${command.team_id}\n` +
         `User: ${command.user_id}\n` +
         `Channel: ${command.channel_id}\n` +
-        `Command: ${command.command} ${command.subcommand} ${command.text}`,
+        `Command: ${command.command} ${command.subcommand} ${command.text}`;
+    }
+    this.link = supportLink({
+      comments,
     });
   }
 


### PR DESCRIPTION
The improvements to the exception support link introduced a bug where we swallow some error messages by causing a new error (`Cannot read property 'team_id' of undefined`) if the exception didn't happen as a direct result of a slash command invocation 😨 

This PR adds logic to ensure that we only attach command-specific metadata if the command is actually defined
