### PR TITLE
Simplify generic error message

### DIFF
--- a/lib/messages/flow/exception.js
+++ b/lib/messages/flow/exception.js
@@ -17,8 +17,8 @@ module.exports = class Exception {
       response_type: 'ephemeral',
       attachments: [
         {
-          text: 'Sorry, we had trouble with your request, but we\'re looking into it! ' +
-            `If this is interfering with your work, please <${this.link}|get in touch>!`,
+          text: 'Sorry, we had trouble with your request! If this is ' +
+            `interfering with your work, please <${this.link}|get in touch>!`,
           color: 'danger',
           mrkdwn_in: ['text'],
         },

--- a/test/messages/flow/__snapshots__/exception.test.js.snap
+++ b/test/messages/flow/__snapshots__/exception.test.js.snap
@@ -8,7 +8,7 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "Sorry, we had trouble with your request, but we're looking into it! If this is interfering with your work, please <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration&form%5Bcomments%5D=Tell%20us%20a%20little%20more%20about%20what%20happened%20and%20include%20the%20error%20code%20and%20metadata%20below.%0A%0AError%20code%3A%20error-code-123%0A%0ASlack%20metadata%3A%0ATeam%3A%20T01234%0AUser%3A%20U01234%0AChannel%3A%20C01234%0ACommand%3A%20%2Fgithub%20subscribe%20integrations%2Ftest%20hihihi|get in touch>!",
+      "text": "Sorry, we had trouble with your request! If this is interfering with your work, please <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration&form%5Bcomments%5D=Tell%20us%20a%20little%20more%20about%20what%20happened%20and%20include%20the%20error%20code%20and%20metadata%20below.%0A%0AError%20code%3A%20error-code-123%0A%0ASlack%20metadata%3A%0ATeam%3A%20T01234%0AUser%3A%20U01234%0AChannel%3A%20C01234%0ACommand%3A%20%2Fgithub%20subscribe%20integrations%2Ftest%20hihihi|get in touch>!",
     },
   ],
   "response_type": "ephemeral",


### PR DESCRIPTION
I started adding a custom error message for issues with the close command in #523 (for example, if I attempt to close an issue that I don't have write access to), but it ended up reading very similar to our default exception message.

This just simplifies the generic error message a bit to make it sound less like it's only for unexpected errors.