### PR TITLE
fail on missing STORAGE_SECRET

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,8 @@ Follow the [Probot docs for configuring up a GitHub App](https://probot.github.i
 - **Setup URL**: `https://DOMAIN/github/setup`
 - **Webhook URL**: `https://DOMAIN/github/events`
 
+Add in a `STORAGE_SECRET` to your `.env` file, running `openssl rand -hex 32` should provide a suitable secret.
+
 #### Configuring a Slack App
 
 1. [Create a new Slack app](https://api.slack.com/apps?new_app_token=1). Note that this app uses the new [workspace token-based Slack app](https://api.slack.com/slack-apps-preview).
@@ -122,7 +124,7 @@ Follow the [Probot docs for configuring up a GitHub App](https://probot.github.i
 
   Means you aren't running postgres and redis when your tests are running.
 
-* Requests to `https://DOMAIN/github/events` from your GitHub app fail with: 
+* Requests to `https://DOMAIN/github/events` from your GitHub app fail with:
 
   ```
   ERROR http: No X-Hub-Signature found on request
@@ -134,10 +136,10 @@ Follow the [Probot docs for configuring up a GitHub App](https://probot.github.i
 
   ```
   $ script/server
-  
+
   > @ start /integrations/slack
   > probot run --webhook-path=/github/events ./lib
-  
+
   13:23:04.150Z  INFO probot: Forwarding https://DOMAIN to http://localhost:3000/github/events
   13:23:04.154Z  INFO probot: Listening on http://localhost:3000
   13:23:04.364Z  INFO http: GET / 200 - 55.34 ms (id=df405c97-d0e2-4379-a50c-3beb54135ed6)
@@ -151,7 +153,7 @@ Follow the [Probot docs for configuring up a GitHub App](https://probot.github.i
   13:23:04.705Z ERROR probot:  (type=error)
   ... repeated until process killed ....
   ```
-  
+
   Means you have `WEBHOOK_PROXY_URL` set in your `.env` file. Remove it and try again.
 
 ## Submitting a pull request

--- a/lib/models/github-user.js
+++ b/lib/models/github-user.js
@@ -5,7 +5,7 @@ const Sequelize = require('sequelize');
 const EncryptedField = require('sequelize-encrypted');
 
 if (!process.env.STORAGE_SECRET) {
-  throw 'STORAGE_SECRET is not defined.'
+  throw new Error('STORAGE_SECRET is not defined.');
 }
 
 const encrypted = EncryptedField(Sequelize, process.env.STORAGE_SECRET);

--- a/lib/models/github-user.js
+++ b/lib/models/github-user.js
@@ -4,6 +4,10 @@ const logger = require('../logger');
 const Sequelize = require('sequelize');
 const EncryptedField = require('sequelize-encrypted');
 
+if (!process.env.STORAGE_SECRET) {
+  throw 'STORAGE_SECRET is not defined.'
+}
+
 const encrypted = EncryptedField(Sequelize, process.env.STORAGE_SECRET);
 
 module.exports = (sequelize, DataTypes) => {

--- a/lib/models/slack-workspace.js
+++ b/lib/models/slack-workspace.js
@@ -3,6 +3,10 @@ const EncryptedField = require('sequelize-encrypted');
 
 const slack = require('../slack/client');
 
+if (!process.env.STORAGE_SECRET) {
+  throw 'STORAGE_SECRET is not defined.'
+}
+
 const encrypted = EncryptedField(Sequelize, process.env.STORAGE_SECRET);
 
 module.exports = (sequelize, DataTypes) => {

--- a/lib/models/slack-workspace.js
+++ b/lib/models/slack-workspace.js
@@ -4,7 +4,7 @@ const EncryptedField = require('sequelize-encrypted');
 const slack = require('../slack/client');
 
 if (!process.env.STORAGE_SECRET) {
-  throw 'STORAGE_SECRET is not defined.'
+  throw new Error('STORAGE_SECRET is not defined.');
 }
 
 const encrypted = EncryptedField(Sequelize, process.env.STORAGE_SECRET);


### PR DESCRIPTION
Add in notes to the docs about the storage secret. Also ensure that if its not specified instead of getting the error below, we get a quick fail:

```
7:18:00.182Z ERROR http: Invalid key length (id=4bc6e05b-f6cf-4453-b513-f8f6dc270ade)
  Error: Invalid key length
      at new Cipheriv (crypto.js:219:16)
```