### PR TITLE
add possibility to subscribe to an entire organization

### DIFF
--- a/lib/activity/router.js
+++ b/lib/activity/router.js
@@ -8,7 +8,17 @@ const cache = require('../cache');
 module.exports = function route(callback) {
   return async (context) => {
     if (context.payload.repository) {
-      const subscriptions = await Subscription.lookup(context.payload.repository.id);
+      let subscriptions = [];
+
+      if (context.payload.sender) {
+        const senderSubscriptions = await Subscription.lookup(context.payload.sender.id);
+        subscriptions = subscriptions.concat(senderSubscriptions);
+      }
+
+      if (context.payload.repository) {
+        const repoSubscriptions = await Subscription.lookup(context.payload.repository.id);
+        subscriptions = subscriptions.concat(repoSubscriptions);
+      }
 
       context.log.debug({ subscriptions }, 'Delivering to subscribed channels');
 
@@ -30,7 +40,7 @@ module.exports = function route(callback) {
 
           const hasRepoAccess = await cache.fetch(
             subscription.cacheKey('creator-access'),
-            () => creator.GitHubUser.hasRepoAccess(subscription.githubId),
+            () => creator.GitHubUser.hasRepoAccess(context.payload.repository.id),
             10 * 60 * 1000,
           );
 

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -29,7 +29,7 @@ module.exports = (robot) => {
   app.post(
     /(?:un)?subscribe/,
     middleware.authenticate,
-    middleware.getResource('repo'),
+    middleware.getResource(['repo', 'account']),
     middleware.getInstallation,
     middleware.pendingCommand.clear,
     subscribe,

--- a/lib/commands/list-subscriptions.js
+++ b/lib/commands/list-subscriptions.js
@@ -21,28 +21,40 @@ module.exports = async (req, res, next) => {
     where: { channelId: command.channel_id },
   });
 
-  let repositories = await Promise.all(subscriptions.map(async (subscription) => {
+  let resources = await Promise.all(subscriptions.map(async (subscription) => {
     const github = await robot.auth(subscription.Installation.githubId);
+    let githubResource;
+
     try {
-      const repository = await github.repos.getById({ id: subscription.githubId });
-      return repository.data;
+      githubResource = await github.repos.getById({ id: subscription.githubId });
+      return githubResource.data;
     } catch (err) {
-      req.log.error({ err, repoId: subscription.githubId }, 'Could not find repository for subscription');
       if (err.code !== 404) {
         throw err;
       }
     }
+
+    try {
+      githubResource = await github.users.getById({ id: subscription.githubId });
+      return githubResource.data;
+    } catch (err) {
+      if (err.code !== 404) {
+        throw err;
+      }
+    }
+
+    req.log.error({ githubId: subscription.githubId }, 'Could not find resource for subscription');
   }));
 
   // remove undefined
-  repositories = repositories.filter(repo => repo);
+  resources = resources.filter(repo => repo);
 
   if (command.text === 'list') {
-    return command.respond(new SubscriptionList(repositories, command.channel_id));
+    return command.respond(new SubscriptionList(resources, command.channel_id));
   }
 
   const response = (new Help(command.command, command.subcommand)).toJSON();
-  const list = new SubscriptionList(repositories, command.channel_id);
+  const list = new SubscriptionList(resources, command.channel_id);
   response.attachments.push(list.toJSON().attachments[0]);
   return command.respond(response);
 };

--- a/lib/commands/subscribe.js
+++ b/lib/commands/subscribe.js
@@ -15,15 +15,23 @@ module.exports = async (req, res) => {
   } = res.locals;
   const { command } = res.locals;
 
-  req.log.debug({ installation, resource }, 'Lookup respository to subscribe');
+  req.log.debug({ installation, resource }, `Lookup ${resource.type} to subscribe`);
 
   // look up the resource
   let from;
   try {
-    from = (await gitHubUser.client.repos.get({ owner: resource.owner, repo: resource.repo })
-    ).data;
+    if (resource.type === 'account') {
+      from = (await gitHubUser.client.users.getForUser({
+        username: resource.owner,
+      })).data;
+    } else {
+      from = (await gitHubUser.client.repos.get({
+        owner: resource.owner,
+        repo: resource.repo,
+      })).data;
+    }
   } catch (err) {
-    req.log.debug({ err }, 'Could not find repository');
+    req.log.debug({ err }, `Could not find ${resource.type}`);
     return command.respond(new NotFound(command.args[0]).toJSON());
   }
   const to = command.channel_id;
@@ -41,7 +49,7 @@ module.exports = async (req, res) => {
         req.log.debug({ settings }, 'Subscription already exists, updating settings');
         subscription.enable(settings);
         await subscription.save();
-        return command.respond(new UpdatedSettings({ subscription, repository: from }).toJSON());
+        return command.respond(new UpdatedSettings({ subscription, resource: from }).toJSON());
       }
       req.log.debug('Subscription already exists');
       return command.respond(new AlreadySubscribed(command.args[0]).toJSON());
@@ -58,19 +66,19 @@ module.exports = async (req, res) => {
 
     await LegacySubscription.migrate(subscription);
 
-    return command.respond(new Subscribed({ channelId: to, fromRepository: from }).toJSON());
+    return command.respond(new Subscribed({ channelId: to, resource: from }).toJSON());
   } else if (command.subcommand === 'unsubscribe') {
     if (subscription) {
       if (settings.length > 0) {
         subscription.disable(settings);
         await subscription.save();
 
-        return command.respond(new UpdatedSettings({ subscription, repository: from }).toJSON());
+        return command.respond(new UpdatedSettings({ subscription, resource: from }).toJSON());
       }
       await Subscription.unsubscribe(from.id, to, slackWorkspace.id);
       return command.respond(new Subscribed({
         channelId: to,
-        fromRepository: from,
+        resource: from,
         unsubscribed: true,
       }).toJSON());
     }

--- a/lib/messages/flow/help.js
+++ b/lib/messages/flow/help.js
@@ -8,7 +8,15 @@ const commands = [
   },
   {
     usage: 'unsubscribe owner/repository',
-    desc: 'Unsubscribe to notifications for a repository',
+    desc: 'Unsubscribe from notifications for a repository',
+  },
+  {
+    usage: 'subscribe owner',
+    desc: 'Subscribe to notifications for an organization',
+  },
+  {
+    usage: 'unsubscribe owner',
+    desc: 'Unsubscribe from notifications for an organization',
   },
   {
     usage: 'subscribe list',

--- a/lib/messages/flow/subscribed.js
+++ b/lib/messages/flow/subscribed.js
@@ -1,11 +1,23 @@
 const { Message, getChannelString } = require('..');
 
 module.exports = class Subscribed extends Message {
-  constructor({ channelId, fromRepository, unsubscribed }) {
+  constructor({ channelId, resource, unsubscribed }) {
     super({});
     this.channelId = channelId;
-    this.fromRepository = fromRepository;
+    this.resource = resource;
     this.unsubscribed = unsubscribed;
+  }
+
+  get channel() {
+    return getChannelString(this.channelId);
+  }
+
+  get resourceName() {
+    return this.resource.full_name || this.resource.login;
+  }
+
+  get resourceLink() {
+    return `<${this.resource.html_url}|${this.resourceName}>`;
   }
 
   toJSON() {
@@ -15,7 +27,7 @@ module.exports = class Subscribed extends Message {
       response_type: 'in_channel',
       attachments: [{
         ...this.getBaseMessage(),
-        text: `${predicate} ${getChannelString(this.channelId)}${preposition} <${this.fromRepository.html_url}|${this.fromRepository.full_name}>`,
+        text: `${predicate} ${this.channel}${preposition} ${this.resourceLink}`,
       }],
     };
   }

--- a/lib/messages/flow/updated-settings.js
+++ b/lib/messages/flow/updated-settings.js
@@ -1,10 +1,10 @@
 const { Message, getChannelString } = require('..');
 
 module.exports = class UpdatedSettings extends Message {
-  constructor({ subscription, repository }) {
+  constructor({ subscription, resource }) {
     super({});
     this.subscription = subscription;
-    this.repository = repository;
+    this.resource = resource;
   }
 
   get channel() {
@@ -15,8 +15,12 @@ module.exports = class UpdatedSettings extends Message {
     return this.subscription.getEnabledSettings().map(setting => `\`${setting}\``).join(', ');
   }
 
-  get repositoryLink() {
-    return `<${this.repository.html_url}|${this.repository.full_name}>`;
+  get resourceName() {
+    return this.resource.full_name || this.resource.login;
+  }
+
+  get resourceLink() {
+    return `<${this.resource.html_url}|${this.resourceName}>`;
   }
 
   toJSON() {
@@ -24,7 +28,7 @@ module.exports = class UpdatedSettings extends Message {
       response_type: 'in_channel',
       attachments: [{
         ...this.getBaseMessage(),
-        text: `${this.channel}will get notifications from ${this.repositoryLink} for: \n` +
+        text: `${this.channel}will get notifications from ${this.resourceLink} for: \n` +
           `${this.enabledSettings}`,
         footer: '<https://github.com/integrations/slack#configuration|Learn More>',
         mrkdwn_in: ['text', 'footer'],

--- a/lib/messages/subscription-list.js
+++ b/lib/messages/subscription-list.js
@@ -1,9 +1,9 @@
 const { getChannelString, Message } = require('.');
 
 module.exports = class SubscriptionList extends Message {
-  constructor(repositories, channelId) {
+  constructor(resources, channelId) {
     super({});
-    this.repositories = repositories;
+    this.resources = resources;
     this.channel = getChannelString(channelId);
   }
 
@@ -17,29 +17,28 @@ module.exports = class SubscriptionList extends Message {
     const output = {
       attachments: [{
         ...this.getBaseMessage(),
-        fallback: `${prefix} ${this.repositories.length} repositor${this.repositories.length === 1 ? 'y' : 'ies'}`,
+        fallback: `${prefix} ${this.resources.length} resource${this.resources.length === 1 ? '' : 's'}`,
       }],
       response_type: 'in_channel',
     };
-    if (this.repositories.length > 0) {
+    if (this.resources.length > 0) {
       output.attachments[0].title = prefix;
-      output.attachments[0].text = this.repositoriesToString().join('\n');
+      output.attachments[0].text = this.resourcesToString().join('\n');
       return output;
     }
     output.attachments[0].text = output.attachments[0].fallback;
     return output;
   }
 
-  repositoriesToString() {
-    return this.repositories
-      .sort((repoA, repoB) => {
-        if (repoA.full_name.toLowerCase() > repoB.full_name.toLowerCase()) {
-          return 1;
-        }
-        return -1;
+  resourcesToString() {
+    return this.resources
+      .sort((resourceA, resourceB) => {
+        const displayA = (resourceA.full_name || resourceA.login).toLowerCase();
+        const displayB = (resourceB.full_name || resourceB.login).toLowerCase();
+        return displayA > displayB ? 1 : -1;
       })
-      .map(repository => (
-        `<${repository.html_url}|${repository.full_name}>`
+      .map(resource => (
+        `<${resource.html_url}|${resource.full_name || resource.login}>`
       ));
   }
 };

--- a/lib/middleware/get-installation.js
+++ b/lib/middleware/get-installation.js
@@ -14,7 +14,11 @@ module.exports = async function getInstallation(req, res, next) {
   req.log.debug({ resource }, 'Looking up installation');
 
   try {
-    const installation = await Installation.sync(await robot.auth(), resource);
+    const installation = await Installation.sync({
+      app: await robot.auth(),
+      user: gitHubUser.client,
+    }, resource);
+
     req.log.debug({ resource, installation }, 'Found installation');
     res.locals.installation = installation;
 

--- a/lib/middleware/get-resource.js
+++ b/lib/middleware/get-resource.js
@@ -5,7 +5,7 @@ const { InvalidUrl } = require('../messages/flow');
 /**
  * Looks up the GitHub resource that is being referenced in a command.
  */
-module.exports = function getResource(type) {
+module.exports = function getResource(types) {
   return (req, res, next) => {
     const { command } = res.locals;
     const url = command.args[0];
@@ -13,7 +13,9 @@ module.exports = function getResource(type) {
     // Turn the argument into a resource
     const resource = githubUrl(url);
 
-    if (resource && (!type || type === resource.type)) {
+    const arrTypes = types && !Array.isArray(types) ? [types] : types;
+
+    if (resource && (!arrTypes || arrTypes.includes(resource.type))) {
       res.locals.resource = resource;
       next();
     } else {

--- a/lib/models/installation.js
+++ b/lib/models/installation.js
@@ -27,18 +27,24 @@ module.exports = (sequelize, DataTypes) => {
     },
 
     async sync(github, { owner, repo }) {
-      const { data } = await github.request({
-        method: 'GET',
-        url: '/repos/:owner/:repo/installation',
-        headers: {
-          accept: 'application/vnd.github.machine-man-preview+json',
-        },
-        owner,
-        repo,
-      });
+      if (repo) {
+        const { data } = await github.app.request({
+          method: 'GET',
+          url: '/repos/:owner/:repo/installation',
+          headers: {
+            accept: 'application/vnd.github.machine-man-preview+json',
+          },
+          owner,
+          repo,
+        });
 
-      // Reuse install, which already does a findOrCreate
-      return Installation.install(data);
+        // Reuse install, which already does a findOrCreate
+        return Installation.install(data);
+      } else if (github.user) {
+        return Installation.getForOwner((await github.user.users.getForUser({
+          username: owner,
+        })).data.id);
+      }
     },
 
     async install(payload) {

--- a/test/integration/__snapshots__/help.test.js.snap
+++ b/test/integration/__snapshots__/help.test.js.snap
@@ -14,8 +14,22 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "Unsubscribe to notifications for a repository:
+      "text": "Unsubscribe from notifications for a repository:
 \`/github unsubscribe owner/repository\`",
+    },
+    Object {
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Subscribe to notifications for an organization:
+\`/github subscribe owner\`",
+    },
+    Object {
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Unsubscribe from notifications for an organization:
+\`/github unsubscribe owner\`",
     },
     Object {
       "mrkdwn_in": Array [
@@ -92,8 +106,22 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "Unsubscribe to notifications for a repository:
+      "text": "Unsubscribe from notifications for a repository:
 \`/github unsubscribe owner/repository\`",
+    },
+    Object {
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Subscribe to notifications for an organization:
+\`/github subscribe owner\`",
+    },
+    Object {
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Unsubscribe from notifications for an organization:
+\`/github unsubscribe owner\`",
     },
     Object {
       "mrkdwn_in": Array [
@@ -170,8 +198,22 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "Unsubscribe to notifications for a repository:
+      "text": "Unsubscribe from notifications for a repository:
 \`/github unsubscribe owner/repository\`",
+    },
+    Object {
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Subscribe to notifications for an organization:
+\`/github subscribe owner\`",
+    },
+    Object {
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Unsubscribe from notifications for an organization:
+\`/github unsubscribe owner\`",
     },
     Object {
       "mrkdwn_in": Array [

--- a/test/integration/__snapshots__/list-subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/list-subscriptions.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "attachments": Array [
     Object {
       "color": "#24292f",
-      "fallback": "<#C2147483705> is subscribed to 1 repository",
+      "fallback": "<#C2147483705> is subscribed to 1 resource",
       "text": "<https://github.com/atom/atom|atom/atom>",
       "title": "<#C2147483705> is subscribed to",
     },
@@ -28,8 +28,22 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "Unsubscribe to notifications for a repository:
+      "text": "Unsubscribe from notifications for a repository:
 \`/github unsubscribe owner/repository\`",
+    },
+    Object {
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Subscribe to notifications for an organization:
+\`/github subscribe owner\`",
+    },
+    Object {
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Unsubscribe from notifications for an organization:
+\`/github unsubscribe owner\`",
     },
     Object {
       "mrkdwn_in": Array [
@@ -46,7 +60,7 @@ Object {
     },
     Object {
       "color": "#24292f",
-      "fallback": "<#C2147483705> is subscribed to 2 repositories",
+      "fallback": "<#C2147483705> is subscribed to 2 resources",
       "text": "<https://github.com/atom/atom|atom/atom>
 <https://github.com/kubernetes/kubernetes|kubernetes/kubernetes>",
       "title": "<#C2147483705> is subscribed to",
@@ -62,7 +76,7 @@ Object {
   "attachments": Array [
     Object {
       "color": "#24292f",
-      "fallback": "<#C2147483705> is subscribed to 2 repositories",
+      "fallback": "<#C2147483705> is subscribed to 2 resources",
       "text": "<https://github.com/atom/atom|atom/atom>
 <https://github.com/kubernetes/kubernetes|kubernetes/kubernetes>",
       "title": "<#C2147483705> is subscribed to",

--- a/test/integration/__snapshots__/subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/subscriptions.test.js.snap
@@ -109,7 +109,7 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "\`wat?\` does not appear to be a GitHub link.",
+      "text": "\`something/not/ok\` does not appear to be a GitHub link.",
     },
   ],
   "response_type": "ephemeral",
@@ -224,7 +224,7 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "\`wat?\` does not appear to be a GitHub link.",
+      "text": "\`something/not/ok\` does not appear to be a GitHub link.",
     },
   ],
   "response_type": "ephemeral",

--- a/test/integration/list-subscriptions.test.js
+++ b/test/integration/list-subscriptions.test.js
@@ -53,7 +53,7 @@ describe('Integration: subscription list', () => {
       });
   });
 
-  test('when a repository has been deleted', async () => {
+  test.only('when a repository has been deleted', async () => {
     probot.logger.level('fatal');
 
     nock('https://api.github.com').get('/repositories/1').reply(200, {
@@ -61,6 +61,7 @@ describe('Integration: subscription list', () => {
       html_url: 'https://github.com/atom/atom',
     });
     nock('https://api.github.com').get('/repositories/2').reply(404, {});
+    nock('https://api.github.com').get('/user/2').reply(404, {});
 
     const command = fixtures.slack.command({
       text: 'subscribe list',

--- a/test/integration/subscriptions.test.js
+++ b/test/integration/subscriptions.test.js
@@ -341,7 +341,7 @@ describe('Integration: subscriptions', () => {
 
       test('subscribing with a bad url', async () => {
         const command = fixtures.slack.command({
-          text: 'subscribe wat?',
+          text: 'subscribe something/not/ok',
         });
 
         const req = request.post('/slack/command').use(slackbot).send(command);
@@ -353,7 +353,7 @@ describe('Integration: subscriptions', () => {
 
       test('unsubscribing with a bad url', async () => {
         const command = fixtures.slack.command({
-          text: 'unsubscribe wat?',
+          text: 'unsubscribe something/not/ok',
         });
 
         const req = request.post('/slack/command').use(slackbot).send(command);

--- a/test/messages/__snapshots__/subscription-list.test.js.snap
+++ b/test/messages/__snapshots__/subscription-list.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "attachments": Array [
     Object {
       "color": "#24292f",
-      "fallback": "<#C01234> is subscribed to 2 repositories",
+      "fallback": "<#C01234> is subscribed to 2 resources",
       "text": "<https://github.com/atom/atom|atom/atom>
 <https://github.com/bkeepers/dotenv|bkeepers/dotenv>",
       "title": "<#C01234> is subscribed to",
@@ -20,8 +20,8 @@ Object {
   "attachments": Array [
     Object {
       "color": "#24292f",
-      "fallback": "<#C01234> is subscribed to 0 repositories",
-      "text": "<#C01234> is subscribed to 0 repositories",
+      "fallback": "<#C01234> is subscribed to 0 resources",
+      "text": "<#C01234> is subscribed to 0 resources",
     },
   ],
   "response_type": "in_channel",
@@ -33,7 +33,7 @@ Object {
   "attachments": Array [
     Object {
       "color": "#24292f",
-      "fallback": "<#C01234> is subscribed to 1 repository",
+      "fallback": "<#C01234> is subscribed to 1 resource",
       "text": "<https://github.com/bkeepers/dotenv|bkeepers/dotenv>",
       "title": "<#C01234> is subscribed to",
     },
@@ -47,7 +47,7 @@ Object {
   "attachments": Array [
     Object {
       "color": "#24292f",
-      "fallback": "Subscribed to 1 repository",
+      "fallback": "Subscribed to 1 resource",
       "text": "<https://github.com/bkeepers/dotenv|bkeepers/dotenv>",
       "title": "Subscribed to",
     },

--- a/test/messages/flow/Subscribed.test.js
+++ b/test/messages/flow/Subscribed.test.js
@@ -5,7 +5,7 @@ describe('Subscribed message rendering', () => {
   test('works for successfully subscribed', async () => {
     const message = new Subscribed({
       channelId: 'C1234',
-      fromRepository: repoFixture,
+      resource: repoFixture,
     });
     expect(message.toJSON()).toMatchSnapshot();
   });
@@ -13,7 +13,7 @@ describe('Subscribed message rendering', () => {
   test('works for successfully unsubscribed', async () => {
     const message = new Subscribed({
       channelId: 'C1234',
-      fromRepository: repoFixture,
+      resource: repoFixture,
       unsubscribed: true,
     });
     expect(message.toJSON()).toMatchSnapshot();
@@ -22,7 +22,7 @@ describe('Subscribed message rendering', () => {
   test('works for direct messages', async () => {
     const message = new Subscribed({
       channelId: 'D1234',
-      fromRepository: repoFixture,
+      resource: repoFixture,
     });
     expect(message.toJSON()).toMatchSnapshot();
   });
@@ -30,7 +30,7 @@ describe('Subscribed message rendering', () => {
   test('works for MPIM messages', async () => {
     const message = new Subscribed({
       channelId: 'G1234',
-      fromRepository: repoFixture,
+      resource: repoFixture,
     });
     expect(message.toJSON()).toMatchSnapshot();
   });

--- a/test/messages/flow/__snapshots__/help.test.js.snap
+++ b/test/messages/flow/__snapshots__/help.test.js.snap
@@ -14,8 +14,22 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "Unsubscribe to notifications for a repository:
+      "text": "Unsubscribe from notifications for a repository:
 \`/github unsubscribe owner/repository\`",
+    },
+    Object {
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Subscribe to notifications for an organization:
+\`/github subscribe owner\`",
+    },
+    Object {
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Unsubscribe from notifications for an organization:
+\`/github unsubscribe owner\`",
     },
     Object {
       "mrkdwn_in": Array [

--- a/test/messages/flow/updated-settings.test.js
+++ b/test/messages/flow/updated-settings.test.js
@@ -8,7 +8,7 @@ describe('UpdatedSettings message', () => {
       channelId: 'C001',
     });
 
-    const message = new UpdatedSettings({ subscription, repository });
+    const message = new UpdatedSettings({ subscription, resource: repository });
     expect(message.toJSON()).toMatchSnapshot();
   });
 
@@ -18,7 +18,7 @@ describe('UpdatedSettings message', () => {
       settings: ['commits:all'],
     });
 
-    const message = new UpdatedSettings({ subscription, repository });
+    const message = new UpdatedSettings({ subscription, resource: repository });
     expect(message.toJSON().attachments[0].text).toMatch(/commits:all/);
     expect(message.toJSON()).toMatchSnapshot();
   });
@@ -29,7 +29,7 @@ describe('UpdatedSettings message', () => {
       settings: { pulls: false },
     });
 
-    const message = new UpdatedSettings({ subscription, repository });
+    const message = new UpdatedSettings({ subscription, resource: repository });
     expect(message.toJSON().attachments[0].text).not.toMatch(/pulls/);
     expect(message.toJSON()).toMatchSnapshot();
   });

--- a/test/messages/subscription-list.test.js
+++ b/test/messages/subscription-list.test.js
@@ -55,7 +55,7 @@ describe('SubscriptionList', () => {
         html_url: 'https://github.com/integrations/slack',
       },
     ];
-    expect(new SubscriptionList(repositories, 'C01234').repositoriesToString()).toEqual([
+    expect(new SubscriptionList(repositories, 'C01234').resourcesToString()).toEqual([
       '<https://github.com/bkeepers/dotenv|bkeepers/dotenv>',
       '<https://github.com/integrations/slack|integrations/slack>',
       '<https://github.com/wilhelmklopp/wilhelmklopp|wilhelmklopp/wilhelmklopp>',
@@ -81,7 +81,7 @@ describe('SubscriptionList', () => {
         html_url: 'https://github.com/JasonEtco/todo',
       },
     ];
-    expect(new SubscriptionList(repositories, 'C01234').repositoriesToString()).toEqual([
+    expect(new SubscriptionList(repositories, 'C01234').resourcesToString()).toEqual([
       '<https://github.com/bkeepers/dotenv|bkeepers/dotenv>',
       '<https://github.com/integrations/slack|integrations/slack>',
       '<https://github.com/JasonEtco/todo|JasonEtco/todo>',

--- a/test/models/installation.test.js
+++ b/test/models/installation.test.js
@@ -50,7 +50,10 @@ describe('models.Installation', () => {
     nock('https://api.github.com').get('/repos/bkeepers/dotenv/installation')
       .reply(200, createdEvent.installation);
 
-    const installation = await Installation.sync(github, { owner: 'bkeepers', repo: 'dotenv' });
+    const installation = await Installation.sync(
+      { app: github },
+      { owner: 'bkeepers', repo: 'dotenv' },
+    );
     await installation.reload();
 
     expect(installation.githubId).toBe('68638');


### PR DESCRIPTION
This is related to multiple issues: https://github.com/integrations/slack/issues/56, https://github.com/integrations/slack/issues/391 and slightly less relevant https://github.com/integrations/slack/issues/557

It proved to be a more challenging issue than I suspected at first, so I went for a basic implementation to get started. I'd be interested to know what you guys think (besides the fact that extra tests should probably be added 🙂.)

__"New" commands:__

- Subscribing `/github subscribe owner`
- Unsubscribing: `/github unsubscribe owner`
- Settings: `/github subscribe owner comments`