### PR TITLE
Update to Terms and Conditions

### DIFF
--- a/docs/terms-and-conditions.md
+++ b/docs/terms-and-conditions.md
@@ -1,47 +1,43 @@
 # GitHub Open Source Applications Terms and Conditions
 
-These GitHub Open Source Applications Terms and Conditions ("Application Terms") are a legal agreement between you (either as an individual or on behalf of an entity) and GitHub, Inc. regarding your use of GitHub's applications, such as GitHub Desktop™ and associated documentation ("Software"). These Application Terms apply to the executable code version of the Software. Source code for the Software is available separately and free of charge under open source software license agreements.
+These GitHub Open Source Applications Terms and Conditions ("Application Terms") are a legal agreement between you (either as an individual or on behalf of an entity) and GitHub, Inc. regarding your use of GitHub's applications, such as the GitHub integration for Slack and associated documentation (the "Application"). These Application Terms apply to the executable code version of the Application. Source code for the Application (the "Software") is available separately and free of charge under open source software license agreements.
 
-If you are agreeing to these Application Terms on behalf of a company, organization, or other legal entity, you represent that you have the authority to bind that entity, its affiliates, and all Users who access the Software on its behalf to these Application Terms. If you do not have authority, you must not accept these Application Terms and you may not use the Software.
+If you are agreeing to these Application Terms on behalf of a company, organization, or other legal entity, you represent that you have the authority to bind that entity, its affiliates, and all Users who access the Application on its behalf to these Application Terms. If you do not have authority, you must not accept these Application Terms and you may not use the Application.
 
-If you do not agree to all of the terms in these Application Terms, do not download, install, use, or copy the Software.
+If you do not agree to all of the terms in these Application Terms, do not download, install, use, or copy the Application.
 
 ### Connecting to GitHub
 
-If you configure the Software to work with one or more accounts on the GitHub.com website or with an instance of GitHub Enterprise, your use of the Software will also be governed your applicable GitHub.com website Terms of Service and/or the license agreement applicable to your instance of GitHub Enterprise ("GitHub Terms").
+If you configure the Application to work with one or more accounts on the GitHub.com website or with an instance of GitHub Enterprise, your use of the Application will also be governed your applicable GitHub.com website Terms of Service and/or the license agreement applicable to your instance of GitHub Enterprise ("GitHub Terms").
 
-You may not use the Software to violate your applicable GitHub Terms. Any use of the Software that violates your applicable GitHub Terms will also be a violation of these Application Terms. The Software may be used for performing automated tasks. In addition, multiple Users may direct the actions of the Software. However, if you set up the Software on your account, or you are an owner of an account that integrates the Software, then you will be responsible for the Software's actions that are performed on or through your account.
+You may not use the Application to violate your applicable GitHub Terms. Any use of the Application that violates your applicable GitHub Terms will also be a violation of these Application Terms. The Application may be used for performing automated tasks. In addition, multiple Users may direct the actions of the Application. However, if you set up the Application on your account, or you are an owner of an account that integrates the Application, then you will be responsible for the Application's actions that are performed on or through your account.
 
 ### GitHub's Logos
 
-The license grant included with the Software is not for GitHub's trademarks, which include the Software logo designs. GitHub reserves all trademark and copyright rights in and to all GitHub trademarks. GitHub's logos include, for instance, the stylized designs that include "logo" in the file title in the "logos" folder.
+The license grant included with the Application and the Software is not for GitHub's trademarks, which include the Application's and the Software's logo designs. GitHub reserves all trademark and copyright rights in and to all GitHub trademarks. GitHub's logos include, for instance, the stylized designs that include "logo" in the file title in the "logos" folder.
 
 The names GitHub, Atom, the Octocat, and related GitHub logos and/or stylized names are trademarks of GitHub. You agree not to display or use these trademarks in any manner without GitHub's prior, written permission, except as allowed by GitHub's Logos and Usage Policy: https://github.com/logos.
 
 ### Privacy
 
-The Software may collect personal information. You may control what information the Software collects in the settings panel. If the Software does collect personal information on GitHub's behalf, GitHub will process that information in accordance with the [GitHub Privacy Statement](/articles/github-privacy-statement/).
+The Application may collect personal information. You may control what information the Application collects in the settings panel. If the Application does collect personal information on GitHub's behalf, GitHub will process that information in accordance with the [GitHub Privacy Statement](/articles/github-privacy-statement/).
 
-### Additional Services
+### Disclaimers and Limitations of Liability
 
-**Disclaimers and Limitations of Liability**
+THE APPLICATION IS PROVIDED ON AN "AS IS" BASIS, AND NO WARRANTY, EITHER EXPRESS OR IMPLIED, IS GIVEN. YOUR USE OF THE APPLICATION IS AT YOUR SOLE RISK. GitHub does not warrant that (i) the Application will meet your specific requirements; (ii) the Application is fully compatible with any particular platform; (iii) your use of the Application will be uninterrupted, timely, secure, or error-free; (iv) the results that may be obtained from the use of the Application will be accurate or reliable; (v) the quality of any products, services, information, or other material purchased or obtained by you through the Application will meet your expectations; or (vi) any errors in the Application will be corrected.
 
-THE SERVICE IS PROVIDED ON AN "AS IS" BASIS, AND NO WARRANTY, EITHER EXPRESS OR IMPLIED, IS GIVEN. YOUR USE OF THE SERVICE IS AT YOUR SOLE RISK. GitHub does not warrant that (i) the Service will meet your specific requirements; (ii) the Service is fully compatible with any particular platform; (iii) your use of the Service will be uninterrupted, timely, secure, or error-free; (iv) the results that may be obtained from the use of the Service will be accurate or reliable; (v) the quality of any products, services, information, or other material purchased or obtained by you through the Service will meet your expectations; or (vi) any errors in the Service will be corrected.
+YOU EXPRESSLY UNDERSTAND AND AGREE THAT GITHUB SHALL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES, INCLUDING BUT NOT LIMITED TO, DAMAGES FOR LOSS OF PROFITS, GOODWILL, USE, DATA OR OTHER INTANGIBLE LOSSES (EVEN IF GITHUB HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES) RELATED TO THE APPLICATION, including, for example: (i) the use or the inability to use the Application; (ii) the cost of procurement of substitute goods and services resulting from any goods, data, information or services purchased or obtained or messages received or transactions entered into through or from the Application; (iii) unauthorized access to or alteration of your transmissions or data; (iv) statements or conduct of any third-party on the Application; (v) or any other matter relating to the Application.
 
-YOU EXPRESSLY UNDERSTAND AND AGREE THAT GITHUB SHALL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES, INCLUDING BUT NOT LIMITED TO, DAMAGES FOR LOSS OF PROFITS, GOODWILL, USE, DATA OR OTHER INTANGIBLE LOSSES (EVEN IF GITHUB HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES) RELATED TO THE SERVICE, including, for example: (i) the use or the inability to use the Service; (ii) the cost of procurement of substitute goods and services resulting from any goods, data, information or services purchased or obtained or messages received or transactions entered into through or from the Service; (iii) unauthorized access to or alteration of your transmissions or data; (iv) statements or conduct of any third-party on the Service; (v) or any other matter relating to the Service.
+GitHub reserves the right at any time and from time to time to modify or discontinue, temporarily or permanently, the Application (or any part thereof) with or without notice. GitHub shall not be liable to you or to any third-party for any price change, suspension or discontinuance of the Application.
 
-GitHub reserves the right at any time and from time to time to modify or discontinue, temporarily or permanently, the Service (or any part thereof) with or without notice. GitHub shall not be liable to you or to any third-party for any price change, suspension or discontinuance of the Service.
-
-### Miscellanea
+### Miscellaneous
 
 1. No Waiver. The failure of GitHub to exercise or enforce any right or provision of these Application Terms shall not constitute a waiver of such right or provision.
 
-2. Entire Agreement. These Application Terms, together with any applicable Privacy Notices, constitutes the entire agreement between you and GitHub and governs your use of the Software, superseding any prior agreements between you and GitHub (including, but not limited to, any prior versions of the Application Terms).
+2. Governing Law. You agree that these Application Terms and your use of the Application are governed under California law and any dispute related to the Application must be brought in a tribunal of competent jurisdiction located in or near San Francisco, California.
 
-3. Governing Law. You agree that these Application Terms and your use of the Software are governed under California law and any dispute related to the Software must be brought in a tribunal of competent jurisdiction located in or near San Francisco, California.
+3. No Modifications; Complete Agreement. These Application Terms may only be modified by a written amendment signed by an authorized representative of GitHub, or by the posting by GitHub of a revised version. These Application Terms, together with any applicable GitHub Terms and GitHub's Privacy Statement, represent the complete and exclusive statement of the agreement between you and us and governs your use of the Application. These Application Terms supersede any proposal or prior agreement oral or written, and any other communications between you and GitHub relating to the subject matter of these terms (including, but not limited to, any prior versions of the Application Terms).
 
-4. No Modifications; Complete Agreement. These Application Terms may only be modified by a written amendment signed by an authorized representative of GitHub, or by the posting by GitHub of a revised version. These Application Terms, together with any applicable Open Source Licenses and Notices and GitHub's Privacy Statement, represent the complete and exclusive statement of the agreement between you and us. These Application Terms supersede any proposal or prior agreement oral or written, and any other communications between you and GitHub relating to the subject matter of these terms.
+4. License to GitHub Policies. These Application Terms are licensed under this [Creative Commons Zero license](https://creativecommons.org/publicdomain/zero/1.0/). For details, see our [site-policy repository](https://github.com/github/site-policy#license).
 
-5. License to GitHub Policies. These Application Terms are licensed under this [Creative Commons Zero license](https://creativecommons.org/publicdomain/zero/1.0/). For details, see our [site-policy repository](https://github.com/github/site-policy#license).
-
-6. Contact Us. Questions about the Terms of Service? [Contact us](https://github.com/contact).
+5. Contact Us. Questions about the Terms of Service? [Contact us](https://github.com/contact).


### PR DESCRIPTION
These are updates to the Terms and Conditions for the GitHub + Slack integration via @bluemazzoo. 

Changes include: 

- Clarifications to the disclaimer and limitation of liability section
- Removing a redundancy from the Miscellaneous section
- Changes from the "Software" to the "Application", so that "Software" only refers to the downloadable source code version.

