### PR TITLE
Fix exception that causes subscription to be removed

### DIFF
--- a/lib/activity/router.js
+++ b/lib/activity/router.js
@@ -63,7 +63,7 @@ module.exports = function route(callback) {
           await callback(context, subscription, slack);
         } catch (err) {
           if (isPermanentError(err)) {
-            context.log.error({ err }, 'Permanent error from Slack. Removing subscription');
+            context.log.info({ err }, 'Permanent error from Slack. Removing subscription');
             await subscription.destroy();
           } else {
             throw err;

--- a/lib/activity/router.js
+++ b/lib/activity/router.js
@@ -63,6 +63,7 @@ module.exports = function route(callback) {
           await callback(context, subscription, slack);
         } catch (err) {
           if (isPermanentError(err)) {
+            context.log.error({ err }, 'Permanent error from Slack. Removing subscription');
             await subscription.destroy();
           } else {
             throw err;

--- a/lib/slack/channel.js
+++ b/lib/slack/channel.js
@@ -34,7 +34,7 @@ module.exports = class Channel {
   async rollup(message, { postNewIf = true, forceNew = false } = {}) {
     const cacheKey = this.cacheKey(message.identifier);
 
-    const ts = await this.cache.get(cacheKey);
+    const { ts } = (await this.cache.get(cacheKey)) || {};
 
     if (!forceNew && ts) {
       this.logger.trace({ channel: this.id, cacheKey, ts }, 'Rolling up changes');
@@ -42,7 +42,7 @@ module.exports = class Channel {
     } else if (postNewIf) {
       this.logger.trace({ channel: this.id, cacheKey }, 'Posting a new message in slack');
       const res = await this.post(message);
-      await this.cache.set(cacheKey, res.ts);
+      await this.cache.set(cacheKey, { ts: res.ts, channel: this.id });
       return res;
     }
   }


### PR DESCRIPTION
#523 added the `Channel` class, which provides an abstractions for rolling up activity in a channel and is used by the new `/github close` and `/github reopen` commands. The problem is, it was extracted from #580, which incidentally changed the formats for cached rollup data (`{ts, channel}`  vs just `ts`).

By itself, this would have just caused a `channel_not_found` exception to occur when an activity message was received in a channel after a slash command was run because the `channel` was missing from the cached data. However, #543 deletes subscriptions when a permanent slack error occurs, and `channel_not_found` is considered a permanent error.

Unfortunately, we weren't logging subscriptions that were deleted due to permanent errors, so we can't tell how many people this has affected.

This PR adds logging for permanent errors, and fixes the format for the new channel rollup class to be consistent with old rollups.