### PR TITLE
update regex to exclude apps and topics

### DIFF
--- a/lib/github-url.js
+++ b/lib/github-url.js
@@ -4,7 +4,7 @@
 const { named } = require('named-regexp');
 
 const base = '(?:https:\/\/github.com\/)?';
-const owner = '(:<owner>[^\/]+)';
+const owner = '(?!apps|topics)(:<owner>[^\/]+)';
 const repo = '(:<repo>[^\/]+)';
 const nwo = `${base}${owner}\/${repo}`;
 const line = 'L(:<line>\\d+)';


### PR DESCRIPTION
Solves the private unfurl issue mentioned in https://github.com/integrations/slack/issues/507#issuecomment-395648098. This adds a negative lookahead to the regex to exclude apps and topics (definitely a regex noob here). Not sure how this will affect bigger picture stuff either if excluding them will break the links somewhere in the logic?

cc/ @wilhelmklopp 