### PR TITLE
Automatically sign out users if they revoke access from their github user settings page

### DIFF
--- a/lib/activity/signout.js
+++ b/lib/activity/signout.js
@@ -1,0 +1,23 @@
+const getRepositories = require('../github/get-repositories');
+const { Subscription } = require('../models');
+const ReEnableMultipleSubscriptions = require('../messages/flow/re-enable-multiple-subscriptions');
+
+module.exports = async (robot, slackUser, slackWorkspace) => {
+  const deletedSubscriptions = await slackUser.signout();
+
+  if (deletedSubscriptions) {
+    const subscriptionsByChannel = Subscription.groupByChannel(deletedSubscriptions);
+
+    await Promise.all(Object.keys(subscriptionsByChannel).map(async (channel) => {
+      const subscriptions = subscriptionsByChannel[channel];
+      const repositories = await getRepositories(subscriptions, robot);
+      if (repositories) {
+        const attachment = new ReEnableMultipleSubscriptions(repositories, slackUser.slackId, 'disconnected their GitHub account').getAttachment();
+        return slackWorkspace.client.chat.postMessage({
+          channel,
+          attachments: [attachment],
+        });
+      }
+    }));
+  }
+};

--- a/lib/commands/signout.js
+++ b/lib/commands/signout.js
@@ -2,9 +2,7 @@ const { SignOut } = require('../messages/flow');
 
 const SignedParams = require('../signed-params');
 const getProtocolAndHost = require('../get-protocol-and-host');
-const getRepositories = require('../github/get-repositories');
-const { Subscription } = require('../models');
-const ReEnableMultipleSubscriptions = require('../messages/flow/re-enable-multiple-subscriptions');
+const signout = require('../activity/signout');
 
 module.exports = async (req, res) => {
   const {
@@ -14,23 +12,7 @@ module.exports = async (req, res) => {
     robot,
   } = res.locals;
 
-  const deletedSubscriptions = await slackUser.signout();
-
-  if (deletedSubscriptions) {
-    const subscriptionsByChannel = Subscription.groupByChannel(deletedSubscriptions);
-
-    await Promise.all(Object.keys(subscriptionsByChannel).map(async (channel) => {
-      const subscriptions = subscriptionsByChannel[channel];
-      const repositories = await getRepositories(subscriptions, robot);
-      if (repositories) {
-        const attachment = new ReEnableMultipleSubscriptions(repositories, slackUser.slackId, 'disconnected their GitHub account').getAttachment();
-        return slackWorkspace.client.chat.postMessage({
-          channel,
-          attachments: [attachment],
-        });
-      }
-    }));
-  }
+  await signout(robot, slackUser, slackWorkspace);
 
   const state = new SignedParams({
     trigger_id: command.trigger_id,

--- a/lib/github/oauth.js
+++ b/lib/github/oauth.js
@@ -130,6 +130,7 @@ module.exports = (robot) => {
       where: { githubId: context.payload.sender.id },
       include: [SlackWorkspace],
     });
+    robot.log.debug({ gitHubUser: context.payload.sender, slackUsers }, 'User revoked GitHub App authorization');
 
     await Promise.all(slackUsers.map(slackUser => signout(
       robot,

--- a/lib/github/oauth.js
+++ b/lib/github/oauth.js
@@ -5,6 +5,7 @@ const GitHubApi = require('probot/lib/github');
 const SignedParams = require('../signed-params');
 const SignInConfirm = require('../messages/flow/sign-in-confirm');
 const { deliverAfterSignIn } = require('../unfurls');
+const signout = require('../activity/signout');
 
 const {
   SlackWorkspace, SlackUser, GitHubUser, PendingCommand,
@@ -122,5 +123,18 @@ module.exports = (robot) => {
       await deliverAfterSignIn(state.slackAction.callback_id.replace('unfurl-', ''));
     }
     return res.redirect(redirectUrl);
+  });
+
+  robot.on('github_app_authorization.revoked', async (context) => {
+    const slackUsers = await SlackUser.findAll({
+      where: { githubId: context.payload.sender.id },
+      include: [SlackWorkspace],
+    });
+
+    await Promise.all(slackUsers.map(slackUser => signout(
+      robot,
+      slackUser,
+      slackUser.SlackWorkspace,
+    )));
   });
 };

--- a/test/fixtures/webhooks/github_app_authorization.revoked.json
+++ b/test/fixtures/webhooks/github_app_authorization.revoked.json
@@ -1,0 +1,23 @@
+{
+  "action": "revoked",
+  "sender": {
+    "login": "wilhelmklopp",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/1?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/wilhelmklopp",
+    "html_url": "https://github.com/wilhelmklopp",
+    "followers_url": "https://api.github.com/users/wilhelmklopp/followers",
+    "following_url": "https://api.github.com/users/wilhelmklopp/following{/other_user}",
+    "gists_url": "https://api.github.com/users/wilhelmklopp/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/wilhelmklopp/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/wilhelmklopp/subscriptions",
+    "organizations_url": "https://api.github.com/users/wilhelmklopp/orgs",
+    "repos_url": "https://api.github.com/users/wilhelmklopp/repos",
+    "events_url": "https://api.github.com/users/wilhelmklopp/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/wilhelmklopp/received_events",
+    "type": "User",
+    "site_admin": true
+  }
+}

--- a/test/integration/__snapshots__/github-app-authorization-revoked.test.js.snap
+++ b/test/integration/__snapshots__/github-app-authorization-revoked.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 1`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"Subscriptions to 2 repositories have been disabled, because <@U2147483697>, who originally set them up, has disconnected their GitHub account.\\\\nUse the following slash commands to re-enable the subscriptions:\\\\n/github subscribe atom/atom\\\\n/github subscribe kubernetes/kubernetes\\"}]",
+  "channel": "C2147483705",
+  "token": "xoxp-token",
+}
+`;
+
+exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 2`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled, because <@U2147483697>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe integrations/slack\\"}]",
+  "channel": "C12345",
+  "token": "xoxp-token",
+}
+`;
+
+exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 1`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"Subscriptions to 2 repositories have been disabled, because <@U2147483697>, who originally set them up, has disconnected their GitHub account.\\\\nUse the following slash commands to re-enable the subscriptions:\\\\n/github subscribe atom/atom\\\\n/github subscribe kubernetes/kubernetes\\"}]",
+  "channel": "C2147483705",
+  "token": "xoxp-token",
+}
+`;
+
+exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 2`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled, because <@U2147483697>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe integrations/slack\\"}]",
+  "channel": "C12345",
+  "token": "xoxp-token",
+}
+`;
+
+exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 3`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled, because <@U123456>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe integrations/slack\\"}]",
+  "channel": "C12121212",
+  "token": "xoxp-token",
+}
+`;
+
+exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 4`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled, because <@U123456>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe kubernetes/kubernetes\\"}]",
+  "channel": "C9999999",
+  "token": "xoxp-token",
+}
+`;

--- a/test/integration/github-app-authorization-revoked.test.js
+++ b/test/integration/github-app-authorization-revoked.test.js
@@ -1,13 +1,3 @@
-/*
-Test cases:
-- GitHubUser with one Slack user and multiple subscriptions
-- GitHubUser with multiple Slack users and multiple subscriptions
-
-expect that:
-- all subscriptions by github user are deleted across multiple workspaces
-- expect githubId field to be null for all SlackUsers attached to githubUser
-- expect that a slack message is posted in each channel
-*/
 const nock = require('nock');
 const Sequelize = require('sequelize');
 

--- a/test/integration/github-app-authorization-revoked.test.js
+++ b/test/integration/github-app-authorization-revoked.test.js
@@ -1,0 +1,170 @@
+/*
+Test cases:
+- GitHubUser with one Slack user and multiple subscriptions
+- GitHubUser with multiple Slack users and multiple subscriptions
+
+expect that:
+- all subscriptions by github user are deleted across multiple workspaces
+- expect githubId field to be null for all SlackUsers attached to githubUser
+- expect that a slack message is posted in each channel
+*/
+const nock = require('nock');
+const Sequelize = require('sequelize');
+
+
+const { probot, models } = require('.');
+const githubAppAuthorizationRevoked = require('../fixtures/webhooks/github_app_authorization.revoked.json');
+
+const { Op } = Sequelize;
+const {
+  SlackWorkspace,
+  GitHubUser,
+  SlackUser,
+  Installation,
+  Subscription,
+} = models;
+
+describe('Integration: github_app_authorization.revoked', async () => {
+  let workspace;
+  let githubUser;
+  let slackUser;
+  let installation1;
+  let installation2;
+  beforeEach(async () => {
+    // create workspace
+    workspace = await SlackWorkspace.create({
+      slackId: 'T0001',
+      accessToken: 'xoxp-token',
+    });
+
+    githubUser = await GitHubUser.create({
+      id: 1,
+      accessToken: 'secret',
+    });
+
+    slackUser = await SlackUser.create({
+      slackId: 'U2147483697',
+      slackWorkspaceId: workspace.id,
+      githubId: githubUser.id,
+    });
+
+    installation1 = await Installation.create({
+      githubId: 1,
+      ownerId: 1,
+    });
+
+    installation2 = await Installation.create({
+      githubId: 2,
+      ownerId: 2,
+    });
+
+    await Subscription.subscribe({
+      channelId: 'C2147483705',
+      githubId: 1,
+      installationId: installation1.id,
+      slackWorkspaceId: workspace.id,
+      creatorId: slackUser.id,
+    });
+
+    await Subscription.subscribe({
+      channelId: 'C2147483705',
+      githubId: 2,
+      installationId: installation2.id,
+      slackWorkspaceId: workspace.id,
+      creatorId: slackUser.id,
+    });
+
+    await Subscription.subscribe({
+      channelId: 'C12345',
+      githubId: 3,
+      installationId: installation2.id,
+      slackWorkspaceId: workspace.id,
+      creatorId: slackUser.id,
+    });
+  });
+
+  test('works for a user  who has connected their GitHub account to one Slack workspace', async () => {
+    nock('https://api.github.com').get('/repositories/1').reply(200, {
+      full_name: 'atom/atom',
+    });
+
+    nock('https://api.github.com').get('/repositories/2').reply(200, {
+      full_name: 'kubernetes/kubernetes',
+    });
+
+    nock('https://api.github.com').get('/repositories/3').reply(200, {
+      full_name: 'integrations/slack',
+    });
+
+    nock('https://slack.com').post('/api/chat.postMessage', (body) => {
+      expect(body).toMatchSnapshot();
+      return true;
+    }).times(2).reply(200, { ok: true });
+
+    await probot.receive({
+      event: 'github_app_authorization',
+      payload: githubAppAuthorizationRevoked,
+    });
+
+    expect((await slackUser.reload()).githubId).toBe(null);
+    expect((await Subscription.findAll({ where: { creatorId: slackUser.id } })).length).toBe(0);
+  });
+  test('works for a user who has connected their GitHub account to multiple Slack workspaces', async () => {
+    const workspace2 = await SlackWorkspace.create({
+      slackId: 'T0002',
+      accessToken: 'xoxp-token2',
+    });
+    const slackUser2 = await SlackUser.create({
+      slackId: 'U123456',
+      slackWorkspaceId: workspace.id,
+      githubId: githubUser.id,
+    });
+    await Subscription.subscribe({
+      channelId: 'C12121212',
+      githubId: 3,
+      installationId: installation2.id,
+      slackWorkspaceId: workspace2.id,
+      creatorId: slackUser2.id,
+    });
+
+    await Subscription.subscribe({
+      channelId: 'C9999999',
+      githubId: 2,
+      installationId: installation2.id,
+      slackWorkspaceId: workspace2.id,
+      creatorId: slackUser2.id,
+    });
+
+    nock('https://api.github.com').get('/repositories/1').reply(200, {
+      full_name: 'atom/atom',
+    });
+
+    nock('https://api.github.com').get('/repositories/2').times(2).reply(200, {
+      full_name: 'kubernetes/kubernetes',
+    });
+
+    nock('https://api.github.com').get('/repositories/3').times(2).reply(200, {
+      full_name: 'integrations/slack',
+    });
+
+    nock('https://slack.com').post('/api/chat.postMessage', (body) => {
+      expect(body).toMatchSnapshot();
+      return true;
+    }).times(4).reply(200, { ok: true });
+
+    await probot.receive({
+      event: 'github_app_authorization',
+      payload: githubAppAuthorizationRevoked,
+    });
+
+    expect((await slackUser.reload()).githubId).toBe(null);
+    expect((await slackUser2.reload()).githubId).toBe(null);
+    expect((await Subscription.findAll({
+      where: {
+        creatorId: {
+          [Op.or]: [slackUser.id, slackUser2.id],
+        },
+      },
+    })).length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR introduces logic that automatically signs out users if they revoke the GitHub App authorization from their individual user settings page. Currently revoking this access causes a bunch of features to break for those users that have revoked access. As part of the sign out, subscriptions are automatically deleted and each channel receives a message with a prompt to re-enable them.


Follow up to #545
Closes https://github.com/integrations/slack/issues/446