### PR TITLE
Document project status

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,9 @@
+# Configuration for new-issue-welcome - https://github.com/behaviorbot/new-issue-welcome
+# Comment to be posted to on first time issues
+newIssueWelcomeComment: >
+  Thanks for opening this issue! The team at GitHub is not actively working on new features for the GitHub + Slack integration. We will still be deploying security/bug fixes and reviewing community contributions. If you would like to help implement an improvement, [read more about contributing](https://github.com/integrations/slack/blob/master/CONTRIBUTING.md#getting-started) and consider submitting a pull request.
+
+# Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
+# Comment to be posted to on PRs from first time contributors
+newPRWelcomeComment: >
+  Thanks for taking time to contribute! The team at GitHub is not actively working on new features for the GitHub + Slack integration, but we will still be reviewing community contributions. We'll check this out soon and let you know if we have any questions or feedback.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,8 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 
 ## Requesting New Features and Reporting Bugs
 
+> **Heads up!** The team at GitHub is not actively working on new features for the GitHub + Slack integration. We will still be deploying security/bug fixes and reviewing community contributions. If you would like to help implement an improvement, [read more about contributing](https://github.com/integrations/slack/blob/master/CONTRIBUTING.md#getting-started) and consider submitting a pull request.
+
 Bugs and feature requests are tracked as issues in this repository.
 
 Before opening a new issue:

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ The integration should also embrace these constraints:
 
 ## Priorities and upcoming themes
 
+> **Heads up!** The team at GitHub is not actively working on new features for the GitHub + Slack integration. We will still be deploying security/bug fixes and reviewing community contributions. If you would like to help implement an improvement, [read more about contributing](https://github.com/integrations/slack/blob/master/CONTRIBUTING.md#getting-started) and consider submitting a pull request.
+
 ### :checkered_flag: Initial Launch
 
 The initial launch of the new Slack integration was focused on preserving functional parity with the [legacy integration](https://github.com/github/ecosystem-integrations/blob/master/docs/slack/legacy-features.md), and offering an easy migration path for existing users. Because of that constraint, it is mostly a one-way stream of activity from GitHub showing up in Slack, with notifications for activity happening on GitHub, and unfurls of GitHub links shared in Slack discussions. 


### PR DESCRIPTION
 The team at GitHub is not actively working on new features for the GitHub + Slack integration for now. We will still be deploying security/bug fixes and reviewing community contributions.

Updates the docs and adds some templates for the [welcome app](http://probot.github.io/apps/welcome) to communicate that to new contributors.