### PR TITLE
Add github copyright notice to footer

### DIFF
--- a/lib/frontend.js
+++ b/lib/frontend.js
@@ -9,7 +9,7 @@ app.set('views', path.join(__dirname, '..', 'views'));
 app.use('/static', express.static(path.join(__dirname, '..', 'static')));
 
 app.get('/', (req, res) => {
-  res.render('index.hbs');
+  res.render('index.hbs', { year: new Date().getFullYear() });
 });
 
 module.exports = app;

--- a/test/integration/frontend.test.js
+++ b/test/integration/frontend.test.js
@@ -4,8 +4,8 @@ const { probot } = require('.');
 describe('Integration: frontend', () => {
   test('/', async () => {
     const res = await request(probot.server).get('/');
-
     expect(res.status).toBe(200);
     expect(res.text).toMatch(/Add to Slack/);
+    expect(res.text).toMatch(`&copy;${new Date().getFullYear()}`);
   });
 });

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -327,8 +327,8 @@
         </div>
         <nav class="container-xl mx-auto clearfix f5 gutter-spacious">
           <div class="col-12">
-            <div class="d-md-flex flex-justify-start pb-3">
-              <p class="text-gray500 mb-1 mr-md-3 f6">GitHub Inc. &copy;{{year}}</p>
+            <div class="flex-justify-start pb-3">
+              <p class="f6 text-gray500 mb-1">GitHub Inc. &copy;{{year}}</p>
               <p class="f6 text-gray500" style="vertical-align: text-bottom;">
                 <a class="text-gray500" href="https://help.github.com/articles/github-terms-of-service/">Terms</a> / <a class="text-gray500" href="https://help.github.com/articles/github-privacy-statement/">Privacy</a>
               </p>

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -325,6 +325,16 @@
           <a href="/slack/oauth/login" class="btn btn-large btn-primary f4">Add to Slack</a>
           <a href="https://github.com/integrations/slack" class="mt-4 d-block">Learn more about the GitHub and Slack integration</a>
         </div>
+        <nav class="container-xl mx-auto clearfix f5 gutter-spacious">
+          <div class="col-12">
+            <div class="d-md-flex flex-justify-start pb-3">
+              <p class="text-gray500 mb-1 mr-md-3 f6">GitHub Inc. &copy;{{year}}</p>
+              <p class="f6 text-gray500" style="vertical-align: text-bottom;">
+                <a class="text-gray500" href="https://help.github.com/articles/github-terms-of-service/">Terms</a> / <a class="text-gray500" href="https://help.github.com/articles/github-privacy-statement/">Privacy</a>
+              </p>
+            </div>
+          </div>
+        </nav>
       </div>
     </div>
 


### PR DESCRIPTION
Adds a responsive footer to the bottom of frontend view with GitHub copyright and links to ToS and Privacy Statement.

**Renders:**
&gt;800px:
![image](https://user-images.githubusercontent.com/13207348/43910545-1dd5d5ea-9bcb-11e8-9cb7-236ed5955d0b.png)

<800px:
![image](https://user-images.githubusercontent.com/13207348/43910584-34b91b50-9bcb-11e8-9d3a-300b4a850bf0.png)
