### PR TITLE
Only mark issues as stale after a year of no activity

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
+daysUntilStale: 365
 
 # Number of days of inactivity before a stale Issue or Pull Request is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.


### PR DESCRIPTION
In maintenance, I believe our requirement for `stale` has changed in that we won't get to open issues as quickly as we used to, so updating the settings for `stale` accordingly.