### PR TITLE
Update html to mrkdwn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -308,7 +308,8 @@
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
@@ -2603,13 +2604,30 @@
       "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
     },
     "data-urls": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
-      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz",
+      "integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
       "requires": {
-        "abab": "^1.0.4",
-        "whatwg-mimetype": "^2.0.0",
-        "whatwg-url": "^6.4.0"
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "abab": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+          "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
+        },
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "debug": {
@@ -2765,7 +2783,8 @@
     "domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
-      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ=="
+      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ==",
+      "dev": true
     },
     "dont-sniff-mimetype": {
       "version": "1.0.0",
@@ -2962,6 +2981,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
       "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "dev": true,
       "requires": {
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
@@ -2973,7 +2993,8 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
         }
       }
     },
@@ -4752,27 +4773,57 @@
       }
     },
     "html-to-mrkdwn": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-to-mrkdwn/-/html-to-mrkdwn-2.0.1.tgz",
-      "integrity": "sha512-wMGgZ3TZC7xf/oiXEtgT/KPeSv+8UPegJ/xq1hZgFsiQCdEmxP1PVKWWjwOBWpwFFfVRLFsbEqAatnwD7ef01A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-to-mrkdwn/-/html-to-mrkdwn-3.0.0.tgz",
+      "integrity": "sha512-UwbXoiKIb959O01POLuHs8kkv/xXbMKyAvB7+RaxN1bfScB6UkGfEdegb0Dfmbx8valRt2FCjOIbHJH14SOx9w==",
       "requires": {
         "jsdom": "^11.6.2",
         "turndown": "^4.0.0-rc.3",
         "turndown-plugin-gfm": "1.0.1"
       },
       "dependencies": {
+        "abab": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+          "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
+        },
         "acorn": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-          "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
+          "integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw=="
         },
         "cssstyle": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
-          "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
+          "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
           "requires": {
             "cssom": "0.3.x"
           }
+        },
+        "domexception": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+          "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "escodegen": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+          "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+          "requires": {
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
         "html-encoding-sniffer": {
           "version": "1.0.2",
@@ -4782,43 +4833,43 @@
             "whatwg-encoding": "^1.0.1"
           }
         },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-        },
         "jsdom": {
-          "version": "11.11.0",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
-          "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+          "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
           "requires": {
-            "abab": "^1.0.4",
-            "acorn": "^5.3.0",
+            "abab": "^2.0.0",
+            "acorn": "^5.5.3",
             "acorn-globals": "^4.1.0",
             "array-equal": "^1.0.0",
             "cssom": ">= 0.3.2 < 0.4.0",
-            "cssstyle": ">= 0.3.1 < 0.4.0",
+            "cssstyle": "^1.0.0",
             "data-urls": "^1.0.0",
-            "domexception": "^1.0.0",
-            "escodegen": "^1.9.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.9.1",
             "html-encoding-sniffer": "^1.0.2",
-            "left-pad": "^1.2.0",
-            "nwsapi": "^2.0.0",
+            "left-pad": "^1.3.0",
+            "nwsapi": "^2.0.7",
             "parse5": "4.0.0",
             "pn": "^1.1.0",
-            "request": "^2.83.0",
+            "request": "^2.87.0",
             "request-promise-native": "^1.0.5",
             "sax": "^1.2.4",
             "symbol-tree": "^3.2.2",
-            "tough-cookie": "^2.3.3",
+            "tough-cookie": "^2.3.4",
             "w3c-hr-time": "^1.0.1",
             "webidl-conversions": "^4.0.2",
             "whatwg-encoding": "^1.0.3",
             "whatwg-mimetype": "^2.1.0",
             "whatwg-url": "^6.4.1",
-            "ws": "^4.0.0",
+            "ws": "^5.2.0",
             "xml-name-validator": "^3.0.0"
           }
+        },
+        "left-pad": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
         },
         "parse5": {
           "version": "4.0.0",
@@ -4830,21 +4881,18 @@
           "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
           "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
         },
-        "tough-cookie": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.2.tgz",
-          "integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "optional": true
         },
         "whatwg-encoding": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-          "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz",
+          "integrity": "sha512-vM9KWN6MP2mIHZ86ytcyIv7e8Cj3KTfO2nd2c8PFDqcI4bxFmQp83ibq4wadq7rL9l9sZV6o9B0LTt8ygGAAXg==",
           "requires": {
-            "iconv-lite": "0.4.19"
+            "iconv-lite": "0.4.23"
           }
         },
         "whatwg-url": {
@@ -4855,6 +4903,14 @@
             "lodash.sortby": "^4.7.0",
             "tr46": "^1.0.1",
             "webidl-conversions": "^4.0.2"
+          }
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
           }
         },
         "xml-name-validator": {
@@ -7290,7 +7346,8 @@
     "left-pad": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
+      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+      "dev": true
     },
     "leven": {
       "version": "2.1.0",
@@ -8039,9 +8096,9 @@
       "dev": true
     },
     "nwsapi": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.3.tgz",
-      "integrity": "sha512-zFJF9lOpg2+uicP0BQKOAfIOqeTp/p8PC669mewxgRkR1hGjne8BMUHk4wpRS9o5Z0icA5Nv04HmGkW31KfMKw=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.8.tgz",
+      "integrity": "sha512-7RZ+qbFGiVc6v14Y8DSZjPN1wZPOaMbiiP4tzf5eNuyOITAeOIA3cMhjuKUypVIqBgCSg1KaSyAv8Ocq/0ZJ1A=="
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -9026,11 +9083,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "psl": {
-      "version": "1.1.28",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
-      "integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw=="
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -11167,18 +11219,48 @@
         "jsdom": "^11.9.0"
       },
       "dependencies": {
+        "abab": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+          "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
+        },
         "acorn": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-          "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
+          "integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw=="
         },
         "cssstyle": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
-          "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
+          "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
           "requires": {
             "cssom": "0.3.x"
           }
+        },
+        "domexception": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+          "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "escodegen": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+          "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+          "requires": {
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
         "html-encoding-sniffer": {
           "version": "1.0.2",
@@ -11188,43 +11270,43 @@
             "whatwg-encoding": "^1.0.1"
           }
         },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-        },
         "jsdom": {
-          "version": "11.11.0",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
-          "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+          "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
           "requires": {
-            "abab": "^1.0.4",
-            "acorn": "^5.3.0",
+            "abab": "^2.0.0",
+            "acorn": "^5.5.3",
             "acorn-globals": "^4.1.0",
             "array-equal": "^1.0.0",
             "cssom": ">= 0.3.2 < 0.4.0",
-            "cssstyle": ">= 0.3.1 < 0.4.0",
+            "cssstyle": "^1.0.0",
             "data-urls": "^1.0.0",
-            "domexception": "^1.0.0",
-            "escodegen": "^1.9.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.9.1",
             "html-encoding-sniffer": "^1.0.2",
-            "left-pad": "^1.2.0",
-            "nwsapi": "^2.0.0",
+            "left-pad": "^1.3.0",
+            "nwsapi": "^2.0.7",
             "parse5": "4.0.0",
             "pn": "^1.1.0",
-            "request": "^2.83.0",
+            "request": "^2.87.0",
             "request-promise-native": "^1.0.5",
             "sax": "^1.2.4",
             "symbol-tree": "^3.2.2",
-            "tough-cookie": "^2.3.3",
+            "tough-cookie": "^2.3.4",
             "w3c-hr-time": "^1.0.1",
             "webidl-conversions": "^4.0.2",
             "whatwg-encoding": "^1.0.3",
             "whatwg-mimetype": "^2.1.0",
             "whatwg-url": "^6.4.1",
-            "ws": "^4.0.0",
+            "ws": "^5.2.0",
             "xml-name-validator": "^3.0.0"
           }
+        },
+        "left-pad": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
         },
         "parse5": {
           "version": "4.0.0",
@@ -11236,21 +11318,18 @@
           "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
           "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
         },
-        "tough-cookie": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.2.tgz",
-          "integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "optional": true
         },
         "whatwg-encoding": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-          "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz",
+          "integrity": "sha512-vM9KWN6MP2mIHZ86ytcyIv7e8Cj3KTfO2nd2c8PFDqcI4bxFmQp83ibq4wadq7rL9l9sZV6o9B0LTt8ygGAAXg==",
           "requires": {
-            "iconv-lite": "0.4.19"
+            "iconv-lite": "0.4.23"
           }
         },
         "whatwg-url": {
@@ -11261,6 +11340,14 @@
             "lodash.sortby": "^4.7.0",
             "tr46": "^1.0.1",
             "webidl-conversions": "^4.0.2"
+          }
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
           }
         },
         "xml-name-validator": {
@@ -11705,6 +11792,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
       "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express-async-errors": "^2.1.1",
     "express-sslify": "^1.2.0",
     "helmet": "^3.11.0",
-    "html-to-mrkdwn": "^2.0.1",
+    "html-to-mrkdwn": "^3.0.0",
     "jsonwebtoken": "^8.1.0",
     "keyv": "^3.0.0",
     "moment": "^2.21.0",

--- a/test/messages/Issue.test.js
+++ b/test/messages/Issue.test.js
@@ -57,4 +57,16 @@ describe('Issue rendering', () => {
     });
     expect(message.getRenderedMessage()).toMatchSnapshot();
   });
+
+  test('does not render tables', async () => {
+    const message = new Issue({
+      issue: {
+        ...issuesOpened.issue,
+        body_html: '<p>Hi, this is my issue and below this line of text there is a table</p>\n<table>\n<thead>\n<tr>\n<th>test</th>\n<th>hello</th>\n<th>hi</th>\n<th>this is</th>\n<th>a table</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>with</td>\n<td>many</td>\n<td>test</td>\n<td>columns</td>\n<td>and</td>\n</tr>\n<tr>\n<td>rows</td>\n<td>ok</td>\n<td></td>\n<td></td>\n<td></td>\n</tr>\n<tr>\n<td></td>\n<td></td>\n<td></td>\n<td>third</td>\n<td>row!</td>\n</tr></tbody></table>',
+      },
+      repository: issuesOpened.repository,
+      eventType: 'issues.opened',
+    });
+    expect(message.getRenderedMessage()).toMatchSnapshot();
+  });
 });

--- a/test/messages/__snapshots__/Issue.test.js.snap
+++ b/test/messages/__snapshots__/Issue.test.js.snap
@@ -27,35 +27,7 @@ Object {
         "text",
       ],
       "pretext": "Issue opened by wilhelmklopp",
-      "text": "Hi, this is my issue and below this line of text there is a table
-
-test
-
-hello
-
-hi
-
-this is
-
-a table
-
-with
-
-many
-
-test
-
-columns
-
-and
-
-rows
-
-ok
-
-third
-
-row!",
+      "text": "Hi, this is my issue and below this line of text there is a table",
       "title": "#1 Needs content",
       "title_link": "https://github.com/github-slack/public-test/issues/1",
       "ts": 1508171038,

--- a/test/messages/__snapshots__/Issue.test.js.snap
+++ b/test/messages/__snapshots__/Issue.test.js.snap
@@ -1,5 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Issue rendering does not render tables 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "author_icon": "https://avatars1.githubusercontent.com/u/7718702?v=4",
+      "author_link": "https://github.com/wilhelmklopp",
+      "author_name": "wilhelmklopp",
+      "color": "#36a64f",
+      "fallback": "[github-slack/public-test] Issue opened by wilhelmklopp",
+      "fields": Array [
+        Object {
+          "short": true,
+          "title": "Assignees",
+          "value": "wilhelmklopp",
+        },
+        Object {
+          "short": true,
+          "title": "Labels",
+          "value": "enhancement, question, wontfix",
+        },
+      ],
+      "footer": "<https://github.com/github-slack/public-test|github-slack/public-test>",
+      "footer_icon": "https://assets-cdn.github.com/favicon.ico",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "pretext": "Issue opened by wilhelmklopp",
+      "text": "Hi, this is my issue and below this line of text there is a table
+
+test
+
+hello
+
+hi
+
+this is
+
+a table
+
+with
+
+many
+
+test
+
+columns
+
+and
+
+rows
+
+ok
+
+third
+
+row!",
+      "title": "#1 Needs content",
+      "title_link": "https://github.com/github-slack/public-test/issues/1",
+      "ts": 1508171038,
+    },
+  ],
+}
+`;
+
 exports[`Issue rendering extracts image from body_html 1`] = `
 Object {
   "attachments": Array [


### PR DESCRIPTION
Bump html-to-mrkdwn, which means we'll stop showing huuuge tables in Slack.

Before:
![image](https://user-images.githubusercontent.com/7718702/44743189-b41a4800-aaf9-11e8-94a7-eb711bd1c3cf.png)


After:

![image](https://user-images.githubusercontent.com/7718702/44743202-c1373700-aaf9-11e8-91fe-90017f272dc8.png)
