### PR TITLE
Manually bootstrap probot so we can load newrelic earlier

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,3 @@
-if (process.env.NEWRELIC_KEY) {
-  require('newrelic'); // eslint-disable-line global-require
-}
-
 const session = require('cookie-session');
 const helmet = require('helmet');
 const sslify = require('express-sslify');

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+require('dotenv').config();
+
+if (process.env.NEWRELIC_KEY) {
+  require('newrelic'); // eslint-disable-line global-require
+}
+
+const { findPrivateKey } = require('probot/lib/private-key');
+const createProbot = require('probot');
+const app = require('.');
+
+const probot = createProbot({
+  id: process.env.APP_ID,
+  secret: process.env.WEBHOOK_SECRET,
+  cert: findPrivateKey(),
+  port: process.env.PORT || 3000,
+  webhookPath: '/github/events',
+  webhookProxy: process.env.WEBHOOK_PROXY_URL,
+});
+
+probot.load(app);
+
+probot.start();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "start": "probot run --webhook-path=/github/events ./lib",
+    "start": "node ./lib/run.js",
     "test": "jest --coverage --runInBand --forceExit",
     "posttest": "npm run lint",
     "lint": "eslint lib test",
@@ -16,6 +16,7 @@
     "body-parser": "^1.18.3",
     "connect-timeout": "^1.9.0",
     "cookie-session": "^2.0.0-beta.3",
+    "dotenv": "^5.0.0",
     "express": "^4.16.2",
     "express-async-errors": "^2.1.1",
     "express-sslify": "^1.2.0",
@@ -36,7 +37,6 @@
     "sequelize-encrypted": "^1.0.0"
   },
   "devDependencies": {
-    "dotenv": "^5.0.0",
     "eslint": "^4.14.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-probot": ">=0.1.0",


### PR DESCRIPTION
This fixes #370 by manually bootstrapping probot, which allows us to require newrelic before anything else loads.