### PR TITLE
Upgrade to @octokit/webhooks 5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,9 +93,9 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-3.1.1.tgz",
-      "integrity": "sha512-VqpGDClqhLw5sKV+or5AnkPmUyur/Oktr9paqiR+yH69Tew9QA/vXHjKP4zctxj5PVAsOdTQFhSzP53qbNLVOg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-5.0.0.tgz",
+      "integrity": "sha512-BQ5b6GeWWSjUXNZIU+4jRoLapeJShxMyCD7hYD86Uy3qpqS6Rf8jyuiutKtlsVNI3a1p4FOzw5J6HsUzrIVvNQ==",
       "requires": {
         "buffer-equal-constant-time": "^1.0.1",
         "debug": "^3.1.0"
@@ -8999,6 +8999,23 @@
         "semver": "^5.5.0"
       },
       "dependencies": {
+        "@octokit/webhooks": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-3.1.1.tgz",
+          "integrity": "sha512-VqpGDClqhLw5sKV+or5AnkPmUyur/Oktr9paqiR+yH69Tew9QA/vXHjKP4zctxj5PVAsOdTQFhSzP53qbNLVOg==",
+          "requires": {
+            "buffer-equal-constant-time": "^1.0.1",
+            "debug": "^3.1.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "raven": {
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@keyv/redis": "github:integrations/keyv-redis#use-keys",
+    "@octokit/webhooks": "^5.0.0",
     "@slack/client": "^4.0.1",
     "axios": "^0.18.0",
     "body-parser": "^1.18.3",


### PR DESCRIPTION
We're investigating some performance issues with #605, and webhook handling seems to be the culprit. Trying to upgrade @octokit/webhooks from 3.1.1 to 5.0.0 to see if we see the same performance issues against Probot 6.

