### PR TITLE
[WIP] don't show muteUnfurlPromptsUntil setting if timestamp is after now

### DIFF
--- a/lib/messages/user-settings/index.js
+++ b/lib/messages/user-settings/index.js
@@ -36,7 +36,7 @@ class CombinedSettings extends Message {
       });
     }
 
-    if (this.muteUnfurlPromptsUntil || this.muteUnfurlPromptsIndefinitely) {
+    if ((this.muteUnfurlPromptsUntil > moment.unix()) || this.muteUnfurlPromptsIndefinitely) {
       attachments.push({
         ...super.getBaseMessage(),
         title: 'Muted prompts to show rich preview',


### PR DESCRIPTION
## Background

fixes #575 

## Implementation

After getting clarification from @wilhelmklopp here: https://github.com/integrations/slack/issues/575#issuecomment-419195506

The logic to **not** show the setting ended up like so:
```js
if ((this.muteUnfurlPromptsUntil < moment.unix()) && !this.muteUnfurlPromptsIndefinitely) {
  // don't show setting...
}
```
However, it wouldn't have made sense to use an if/else there, so I just did my best to negate that above snippet, and I think the solution should be to just add `moment.unix()` to the conditional:

```js
if ((this.muteUnfurlPromptsUntil > moment.unix()) || this.muteUnfurlPromptsIndefinitely) {
  // push attachment to array...
}
```

Please correct me if there is more to it! 😄 