### PR TITLE
WIP Subscribe to an organization

### DIFF
--- a/lib/activity/router.js
+++ b/lib/activity/router.js
@@ -8,7 +8,15 @@ const cache = require('../cache');
 module.exports = function route(callback) {
   return async (context) => {
     if (context.payload.repository) {
-      const subscriptions = await Subscription.lookup(context.payload.repository.id);
+      const repoSubscriptions = await Subscription.lookup(context.payload.repository.id);
+      const orgSubscriptions = context.payload.organization
+        ? await Subscription.lookup(context.payload.organization.id)
+        : [];
+      const isRepoSubscription = repoSubscriptions.length > 0;
+      const subscriptions = [
+        ...repoSubscriptions,
+        ...orgSubscriptions,
+      ];
 
       context.log.debug({ subscriptions }, 'Delivering to subscribed channels');
 
@@ -28,13 +36,16 @@ module.exports = function route(callback) {
             include: [GitHubUser],
           });
 
-          const hasRepoAccess = await cache.fetch(
+          const hasAccess = await cache.fetch(
             subscription.cacheKey('creator-access'),
-            () => creator.GitHubUser.hasRepoAccess(subscription.githubId),
+            () => (isRepoSubscription
+              ? creator.GitHubUser.hasRepoAccess(subscription.githubId)
+              : creator.GitHubUser.hasOrgAccess(context.payload.organization.id))
+            ,
             10 * 60 * 1000,
           );
 
-          if (!hasRepoAccess) {
+          if (!hasAccess) {
             context.log.debug({
               subscription: {
                 channelId: subscription.channelId,

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -30,7 +30,7 @@ module.exports = (robot) => {
   app.post(
     /(?:un)?subscribe/,
     middleware.authenticate,
-    middleware.getResource('repo'),
+    middleware.getResource(),
     middleware.getInstallation,
     middleware.pendingCommand.clear,
     subscribe,

--- a/lib/commands/list-subscriptions.js
+++ b/lib/commands/list-subscriptions.js
@@ -23,13 +23,16 @@ module.exports = async (req, res, next) => {
   });
 
   const repositories = await getRepositories(subscriptions, robot);
+  // TODO: we have the organization ids, but there's no "getById" method for organizations
+  // So there's no easy way to get the information of the organizations
+  const organizations = [];
 
   if (command.text === 'list') {
-    return command.respond(new SubscriptionList(repositories, command.channel_id));
+    return command.respond(new SubscriptionList(repositories, organizations, command.channel_id));
   }
 
   const response = (new Help(command.command, command.subcommand)).toJSON();
-  const list = new SubscriptionList(repositories, command.channel_id);
+  const list = new SubscriptionList(repositories, organizations, command.channel_id);
   response.attachments.push(list.toJSON().attachments[0]);
   return command.respond(response);
 };

--- a/lib/commands/subscribe.js
+++ b/lib/commands/subscribe.js
@@ -20,8 +20,13 @@ module.exports = async (req, res) => {
   // look up the resource
   let from;
   try {
-    from = (await gitHubUser.client.repos.get({ owner: resource.owner, repo: resource.repo })
-    ).data;
+    if (resource.repo) {
+      from = (await gitHubUser.client.repos.get({ owner: resource.owner, repo: resource.repo })
+      ).data;
+    } else {
+      from = (await gitHubUser.client.orgs.get({ org: resource.owner })
+      ).data;
+    }
   } catch (err) {
     req.log.debug({ err }, 'Could not find repository');
     return command.respond(new NotFound(command.args[0]).toJSON());

--- a/lib/github-url.js
+++ b/lib/github-url.js
@@ -4,7 +4,7 @@
 const { named } = require('named-regexp');
 
 const base = '(?:https:\/\/github.com\/)?';
-const owner = '(:<owner>[^\/]+)';
+const owner = '(:<owner>[a-zA-Z\d-]+)';
 const repo = '(:<repo>[^\/]+)';
 const nwo = `${base}${owner}\/${repo}`;
 const line = 'L(:<line>\\d+)';

--- a/lib/messages/subscription-list.js
+++ b/lib/messages/subscription-list.js
@@ -1,9 +1,10 @@
 const { getChannelString, Message } = require('.');
 
 module.exports = class SubscriptionList extends Message {
-  constructor(repositories, channelId) {
+  constructor(repositories, organizations, channelId) {
     super({});
     this.repositories = repositories;
+    this.organizations = organizations;
     this.channel = getChannelString(channelId);
   }
 
@@ -18,15 +19,24 @@ module.exports = class SubscriptionList extends Message {
       attachments: [{
         ...this.getBaseMessage(),
         fallback: `${prefix} ${this.repositories.length} repositor${this.repositories.length === 1 ? 'y' : 'ies'}`,
+      }, {
+        ...this.getBaseMessage(),
+        fallback: `${prefix} ${this.organizations.length} organization${this.organizations.length === 1 ? '' : 's'}`,
       }],
       response_type: 'in_channel',
     };
     if (this.repositories.length > 0) {
       output.attachments[0].title = prefix;
       output.attachments[0].text = this.repositoriesToString().join('\n');
-      return output;
+    } else {
+      output.attachments[0].text = output.attachments[0].fallback;
     }
-    output.attachments[0].text = output.attachments[0].fallback;
+    if (this.organizations.length > 0) {
+      output.attachments[1].title = prefix;
+      output.attachments[1].text = this.organizationsToString().join('\n');
+    } else {
+      output.attachments[1].text = output.attachments[1].fallback;
+    }
     return output;
   }
 
@@ -40,6 +50,19 @@ module.exports = class SubscriptionList extends Message {
       })
       .map(repository => (
         `<${repository.html_url}|${repository.full_name}>`
+      ));
+  }
+
+  organizationsToString() {
+    return this.organizations
+      .sort((orgA, orgB) => {
+        if (orgA.login.toLowerCase() > orgB.login.toLowerCase()) {
+          return 1;
+        }
+        return -1;
+      })
+      .map(organization => (
+        `<${organization.html_url}|${organization.login}>`
       ));
   }
 };

--- a/lib/models/github-user.js
+++ b/lib/models/github-user.js
@@ -50,6 +50,18 @@ module.exports = (sequelize, DataTypes) => {
         });
     },
 
+    hasOrgAccess(org) {
+      return this.client.orgs.get({ org })
+        .then(() => true)
+        .catch((err) => {
+          if (err.code === 404) {
+            return false;
+          }
+          logger.warn({ err, org, userId: this.id }, 'GitHub returned neither 200 nor 404');
+          return true;
+        });
+    },
+
     toJSON() {
       const { ...values } = this.dataValues;
       delete values.secrets;

--- a/lib/models/installation.js
+++ b/lib/models/installation.js
@@ -27,17 +27,34 @@ module.exports = (sequelize, DataTypes) => {
       return this.findOne({ where: { ownerId } });
     },
 
-    async sync(github, { owner, repo }) {
+    async findInstallation(github, { owner, repo }) {
+      if (repo) {
+        const { data } = await github.request({
+          method: 'GET',
+          url: '/repos/:owner/:repo/installation',
+          headers: {
+            accept: 'application/vnd.github.machine-man-preview+json',
+          },
+          owner,
+          repo,
+        });
+        return data;
+      }
+      // If no repo specified, we assume the owner is an organiztion
+      const org = owner;
       const { data } = await github.request({
         method: 'GET',
-        url: '/repos/:owner/:repo/installation',
+        url: '/orgs/:org/installation',
         headers: {
           accept: 'application/vnd.github.machine-man-preview+json',
         },
-        owner,
-        repo,
+        org,
       });
+      return data;
+    },
 
+    async sync(github, { owner, repo }) {
+      const data = await Installation.findInstallation(github, { owner, repo });
       // Reuse install, which already does a findOrCreate
       return Installation.install(data);
     },

--- a/test/integration/__snapshots__/list-subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/list-subscriptions.test.js.snap
@@ -9,6 +9,11 @@ Object {
       "text": "<https://github.com/atom/atom|atom/atom>",
       "title": "<#C2147483705> is subscribed to",
     },
+    Object {
+      "color": "#24292f",
+      "fallback": "<#C2147483705> is subscribed to 0 organizations",
+      "text": "<#C2147483705> is subscribed to 0 organizations",
+    },
   ],
   "response_type": "in_channel",
 }
@@ -66,6 +71,11 @@ Object {
       "text": "<https://github.com/atom/atom|atom/atom>
 <https://github.com/kubernetes/kubernetes|kubernetes/kubernetes>",
       "title": "<#C2147483705> is subscribed to",
+    },
+    Object {
+      "color": "#24292f",
+      "fallback": "<#C2147483705> is subscribed to 0 organizations",
+      "text": "<#C2147483705> is subscribed to 0 organizations",
     },
   ],
   "response_type": "in_channel",

--- a/test/messages/__snapshots__/subscription-list.test.js.snap
+++ b/test/messages/__snapshots__/subscription-list.test.js.snap
@@ -10,6 +10,11 @@ Object {
 <https://github.com/bkeepers/dotenv|bkeepers/dotenv>",
       "title": "<#C01234> is subscribed to",
     },
+    Object {
+      "color": "#24292f",
+      "fallback": "<#C01234> is subscribed to 0 organizations",
+      "text": "<#C01234> is subscribed to 0 organizations",
+    },
   ],
   "response_type": "in_channel",
 }
@@ -22,6 +27,11 @@ Object {
       "color": "#24292f",
       "fallback": "<#C01234> is subscribed to 0 repositories",
       "text": "<#C01234> is subscribed to 0 repositories",
+    },
+    Object {
+      "color": "#24292f",
+      "fallback": "<#C01234> is subscribed to 0 organizations",
+      "text": "<#C01234> is subscribed to 0 organizations",
     },
   ],
   "response_type": "in_channel",
@@ -37,6 +47,11 @@ Object {
       "text": "<https://github.com/bkeepers/dotenv|bkeepers/dotenv>",
       "title": "<#C01234> is subscribed to",
     },
+    Object {
+      "color": "#24292f",
+      "fallback": "<#C01234> is subscribed to 0 organizations",
+      "text": "<#C01234> is subscribed to 0 organizations",
+    },
   ],
   "response_type": "in_channel",
 }
@@ -50,6 +65,11 @@ Object {
       "fallback": "Subscribed to 1 repository",
       "text": "<https://github.com/bkeepers/dotenv|bkeepers/dotenv>",
       "title": "Subscribed to",
+    },
+    Object {
+      "color": "#24292f",
+      "fallback": "Subscribed to 0 organizations",
+      "text": "Subscribed to 0 organizations",
     },
   ],
   "response_type": "in_channel",

--- a/test/messages/subscription-list.test.js
+++ b/test/messages/subscription-list.test.js
@@ -12,7 +12,7 @@ describe('SubscriptionList', () => {
         html_url: 'https://github.com/atom/atom',
       },
     ];
-    expect(new SubscriptionList(repositories, 'C01234').toJSON()).toMatchSnapshot();
+    expect(new SubscriptionList(repositories, [], 'C01234').toJSON()).toMatchSnapshot();
   });
 
   test('works for one subscription active in a channel', async () => {
@@ -22,12 +22,12 @@ describe('SubscriptionList', () => {
         html_url: 'https://github.com/bkeepers/dotenv',
       },
     ];
-    expect(new SubscriptionList(repositories, 'C01234').toJSON()).toMatchSnapshot();
+    expect(new SubscriptionList(repositories, [], 'C01234').toJSON()).toMatchSnapshot();
   });
 
   test('works for no subscriptions active in a channel', async () => {
     const repositories = [];
-    expect(new SubscriptionList(repositories, 'C01234').toJSON()).toMatchSnapshot();
+    expect(new SubscriptionList(repositories, [], 'C01234').toJSON()).toMatchSnapshot();
   });
 
   test('works for one subscription active in a direct message', async () => {
@@ -37,7 +37,7 @@ describe('SubscriptionList', () => {
         html_url: 'https://github.com/bkeepers/dotenv',
       },
     ];
-    expect(new SubscriptionList(repositories, 'D01234').toJSON()).toMatchSnapshot();
+    expect(new SubscriptionList(repositories, [], 'D01234').toJSON()).toMatchSnapshot();
   });
 
   test('sorts repositories alphabetically', async () => {
@@ -55,7 +55,7 @@ describe('SubscriptionList', () => {
         html_url: 'https://github.com/integrations/slack',
       },
     ];
-    expect(new SubscriptionList(repositories, 'C01234').repositoriesToString()).toEqual([
+    expect(new SubscriptionList(repositories, [], 'C01234').repositoriesToString()).toEqual([
       '<https://github.com/bkeepers/dotenv|bkeepers/dotenv>',
       '<https://github.com/integrations/slack|integrations/slack>',
       '<https://github.com/wilhelmklopp/wilhelmklopp|wilhelmklopp/wilhelmklopp>',
@@ -81,7 +81,7 @@ describe('SubscriptionList', () => {
         html_url: 'https://github.com/JasonEtco/todo',
       },
     ];
-    expect(new SubscriptionList(repositories, 'C01234').repositoriesToString()).toEqual([
+    expect(new SubscriptionList(repositories, [], 'C01234').repositoriesToString()).toEqual([
       '<https://github.com/bkeepers/dotenv|bkeepers/dotenv>',
       '<https://github.com/integrations/slack|integrations/slack>',
       '<https://github.com/JasonEtco/todo|JasonEtco/todo>',


### PR DESCRIPTION
This is basically working, although it needs some additional tests. The problem is that some things are not elegant enough basically because a db/api limitation. The db is designed to store the id of the repo for a subscription. I'm now storing the id of the organization if you subscribe to one. One problem is that there's no way to GET an organization by its id. This is needed when listing the subscriptions. Maybe we can just get all the organizations and filter by id.

Also, it would be helpful to know if a subscription is for a repo or an organization without having to do API requests, just having that information in the subscriptions table. It would make a few things more elegant, readable and robust. So I suggest adding a `type` column that can be either `repo` or `org`. When migrating the db all existing subscriptions will be set to `type=repo`.

If you are ok with these ideas I'll implement them and I'll add tests.

Closes https://github.com/integrations/slack/issues/391