### PR TITLE
Add messages for PR reviewer and assignee changes

### DIFF
--- a/lib/activity/index.js
+++ b/lib/activity/index.js
@@ -9,6 +9,7 @@ const {
   pullRequestEvent,
   onStatus,
   storePRMapping,
+  onReviewUpdates,
 } = require('./pull-requests');
 
 const { deploymentStatus } = require('./deployments');
@@ -34,6 +35,8 @@ module.exports = (robot) => {
   ], route(matchMetaDataStatetoIssueMessage));
 
   robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened'], route(pullRequestEvent));
+  robot.on(['pull_request.assigned', 'pull_request.unassigned',
+            'pull_request.review_requested', 'pull_request.review_request_removed'], route(onReviewUpdates));
   robot.on(['pull_request.opened', 'pull_request.synchronize'], storePRMapping);
   robot.on('status', route(onStatus));
   robot.on('deployment_status', route(deploymentStatus));

--- a/lib/activity/index.js
+++ b/lib/activity/index.js
@@ -35,8 +35,12 @@ module.exports = (robot) => {
   ], route(matchMetaDataStatetoIssueMessage));
 
   robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened'], route(pullRequestEvent));
-  robot.on(['pull_request.assigned', 'pull_request.unassigned',
-            'pull_request.review_requested', 'pull_request.review_request_removed'], route(onReviewUpdates));
+  robot.on([
+    'pull_request.assigned',
+    'pull_request.unassigned',
+    'pull_request.review_requested',
+    'pull_request.review_request_removed',
+  ], route(onReviewUpdates));
   robot.on(['pull_request.opened', 'pull_request.synchronize'], storePRMapping);
   robot.on('status', route(onStatus));
   robot.on('deployment_status', route(deploymentStatus));

--- a/lib/activity/pull-requests.js
+++ b/lib/activity/pull-requests.js
@@ -129,5 +129,5 @@ module.exports = {
   pullRequestEvent,
   storePRMapping,
   onStatus,
-  onReviewUpdates
+  onReviewUpdates,
 };

--- a/lib/activity/pull-requests.js
+++ b/lib/activity/pull-requests.js
@@ -1,4 +1,4 @@
-const { PullRequest } = require('../messages/pull-request');
+const { PullRequest, PullRequestReviewUpdate } = require('../messages/pull-request');
 
 const cache = require('../cache');
 
@@ -102,8 +102,32 @@ async function onStatus(context, subscription, slack) {
   context.log(res, 'Updated Slack message');
 }
 
+async function onReviewUpdates(context, subscription, slack) {
+  const pullRequest = {
+    ...context.payload.pull_request,
+  };
+
+  const eventType = `${context.event}.${context.payload.action}`;
+
+  const reviews = await getReviews(context, pullRequest);
+  const prMessage = new PullRequestReviewUpdate({
+    pullRequest,
+    repository: context.payload.repository,
+    eventType,
+    sender: context.payload.sender,
+    reviews,
+  });
+
+  const res = await slack.chat.postMessage({
+    channel: subscription.channelId,
+    ...prMessage.getRenderedMessage(),
+  });
+  context.log(res, 'Posted Slack message');
+}
+
 module.exports = {
   pullRequestEvent,
   storePRMapping,
   onStatus,
+  onReviewUpdates
 };

--- a/lib/messages/pull-request.js
+++ b/lib/messages/pull-request.js
@@ -138,6 +138,48 @@ class PullRequest extends AbstractIssue {
   }
 }
 
+class PullRequestReviewUpdate extends PullRequest {
+  getPreText() {
+    let predicate;
+    let actor;
+    if (this.sender) {
+      actor = this.sender.login;
+    } else {
+      actor = this.abstractIssue.user.login;
+    }
+
+		const predicateRe = /\w+\.(\w+)/g;
+		[, predicate] = predicateRe.exec(this.eventType);
+		if (predicate === 'review_requested') {
+      return `Reviewer added to pull request by ${actor}`;
+		}
+    else if (predicate === 'review_request_removed') {
+      return `Reviewer removed from pull request by ${actor}`;
+    }
+    else if (predicate === 'assigned') {
+      return `Assignee added to pull request by ${actor}`;
+    }
+    else if (predicate === 'unassigned') {
+      return `Assignee removed from pull request by ${actor}`;
+    }
+  }
+
+  getFields() {
+    const fields = [
+      {
+        title: 'Assignees',
+        value: arrayToFormattedString(this.pullRequest.assignees, 'login'),
+      },
+      {
+        title: 'Reviewers',
+        value: arrayToFormattedString(this.pullRequest.requested_reviewers, 'login'),
+      },
+    ];
+    return this.constructor.cleanFields(fields);
+	}
+}
+
 module.exports = {
   PullRequest,
+  PullRequestReviewUpdate
 };

--- a/lib/messages/pull-request.js
+++ b/lib/messages/pull-request.js
@@ -140,7 +140,6 @@ class PullRequest extends AbstractIssue {
 
 class PullRequestReviewUpdate extends PullRequest {
   getPreText() {
-    let predicate;
     let actor;
     if (this.sender) {
       actor = this.sender.login;
@@ -148,18 +147,15 @@ class PullRequestReviewUpdate extends PullRequest {
       actor = this.abstractIssue.user.login;
     }
 
-		const predicateRe = /\w+\.(\w+)/g;
-		[, predicate] = predicateRe.exec(this.eventType);
-		if (predicate === 'review_requested') {
+    const predicateRe = /\w+\.(\w+)/g;
+    const [, predicate] = predicateRe.exec(this.eventType);
+    if (predicate === 'review_requested') {
       return `Reviewer added to pull request by ${actor}`;
-		}
-    else if (predicate === 'review_request_removed') {
+    } else if (predicate === 'review_request_removed') {
       return `Reviewer removed from pull request by ${actor}`;
-    }
-    else if (predicate === 'assigned') {
+    } else if (predicate === 'assigned') {
       return `Assignee added to pull request by ${actor}`;
-    }
-    else if (predicate === 'unassigned') {
+    } else if (predicate === 'unassigned') {
       return `Assignee removed from pull request by ${actor}`;
     }
   }
@@ -176,10 +172,10 @@ class PullRequestReviewUpdate extends PullRequest {
       },
     ];
     return this.constructor.cleanFields(fields);
-	}
+  }
 }
 
 module.exports = {
   PullRequest,
-  PullRequestReviewUpdate
+  PullRequestReviewUpdate,
 };


### PR DESCRIPTION
Receive Slack notifications when assignees and reviewers are edited on a PR. The assignees and reviewers will be listed in the same style as they appear in the unfurled message for a newly opened PR. For example:

<img width="360" alt="screen shot 2018-10-19 at 2 00 06 am" src="https://user-images.githubusercontent.com/2781682/47200175-0120da80-d343-11e8-9c64-cc47e17ecd8e.png">
