### PR TITLE
Test cache access

### DIFF
--- a/test/integration/__snapshots__/actions.test.js.snap
+++ b/test/integration/__snapshots__/actions.test.js.snap
@@ -1,10 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Actions An unknown callback_id returns a 500 1`] = `[MockFunction cache.get]`;
+exports[`Actions An unknown callback_id returns a 500 1`] = `Set {}`;
 
-exports[`Actions An unknown callback_id returns a 500 2`] = `[MockFunction cache.set]`;
-
-exports[`Actions An unknown callback_id returns a 500 3`] = `[MockFunction cache.fetch]`;
+exports[`Actions An unknown callback_id returns a 500 2`] = `Map {}`;
 
 exports[`Actions When an action's name is "cancel", then it is immediately deleted 1`] = `
 Object {
@@ -12,8 +10,6 @@ Object {
 }
 `;
 
-exports[`Actions When an action's name is "cancel", then it is immediately deleted 2`] = `[MockFunction cache.get]`;
+exports[`Actions When an action's name is "cancel", then it is immediately deleted 2`] = `Set {}`;
 
-exports[`Actions When an action's name is "cancel", then it is immediately deleted 3`] = `[MockFunction cache.set]`;
-
-exports[`Actions When an action's name is "cancel", then it is immediately deleted 4`] = `[MockFunction cache.fetch]`;
+exports[`Actions When an action's name is "cancel", then it is immediately deleted 3`] = `Map {}`;

--- a/test/integration/__snapshots__/actions.test.js.snap
+++ b/test/integration/__snapshots__/actions.test.js.snap
@@ -1,7 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Actions An unknown callback_id returns a 500 1`] = `[MockFunction cache.get]`;
+
+exports[`Actions An unknown callback_id returns a 500 2`] = `[MockFunction cache.set]`;
+
+exports[`Actions An unknown callback_id returns a 500 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Actions When an action's name is "cancel", then it is immediately deleted 1`] = `
 Object {
   "delete_original": true,
 }
 `;
+
+exports[`Actions When an action's name is "cancel", then it is immediately deleted 2`] = `[MockFunction cache.get]`;
+
+exports[`Actions When an action's name is "cancel", then it is immediately deleted 3`] = `[MockFunction cache.set]`;
+
+exports[`Actions When an action's name is "cancel", then it is immediately deleted 4`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/api.test.js.snap
+++ b/test/integration/__snapshots__/api.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Integration: api with a valid user token does not post message if user does not have push access 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: api with a valid user token does not post message if user does not have push access 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: api with a valid user token does not post message if user does not have push access 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: api with a valid user token posts message if user has push access 1`] = `
 Object {
   "attachments": "[{\\"text\\":\\"hello world\\"}]",
@@ -7,3 +13,15 @@ Object {
   "token": "xoxp-token",
 }
 `;
+
+exports[`Integration: api with a valid user token posts message if user has push access 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: api with a valid user token posts message if user has push access 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: api with a valid user token posts message if user has push access 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: api without authentication responds with 401 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: api without authentication responds with 401 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: api without authentication responds with 401 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/api.test.js.snap
+++ b/test/integration/__snapshots__/api.test.js.snap
@@ -1,10 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration: api with a valid user token does not post message if user does not have push access 1`] = `[MockFunction cache.get]`;
+exports[`Integration: api with a valid user token does not post message if user does not have push access 1`] = `Set {}`;
 
-exports[`Integration: api with a valid user token does not post message if user does not have push access 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: api with a valid user token does not post message if user does not have push access 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: api with a valid user token does not post message if user does not have push access 2`] = `Map {}`;
 
 exports[`Integration: api with a valid user token posts message if user has push access 1`] = `
 Object {
@@ -14,14 +12,10 @@ Object {
 }
 `;
 
-exports[`Integration: api with a valid user token posts message if user has push access 2`] = `[MockFunction cache.get]`;
+exports[`Integration: api with a valid user token posts message if user has push access 2`] = `Set {}`;
 
-exports[`Integration: api with a valid user token posts message if user has push access 3`] = `[MockFunction cache.set]`;
+exports[`Integration: api with a valid user token posts message if user has push access 3`] = `Map {}`;
 
-exports[`Integration: api with a valid user token posts message if user has push access 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: api without authentication responds with 401 1`] = `Set {}`;
 
-exports[`Integration: api without authentication responds with 401 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: api without authentication responds with 401 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: api without authentication responds with 401 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: api without authentication responds with 401 2`] = `Map {}`;

--- a/test/integration/__snapshots__/create.test.js.snap
+++ b/test/integration/__snapshots__/create.test.js.snap
@@ -7,6 +7,41 @@ Object {
 }
 `;
 
+exports[`Integration: Creating issues from Slack fails when specifying a repository, there are multiple issue templates in it, and no template was specified 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Creating issues from Slack fails when specifying a repository, there are multiple issue templates in it, and no template was specified 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "open kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: Creating issues from Slack fails when specifying a repository, there are multiple issue templates in it, and no template was specified 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: Creating issues from Slack works when specifying a repository 1`] = `
 Object {
   "dialog": "{\\"callback_id\\":\\"create-issue-dialog\\",\\"title\\":\\"Open a new issue\\",\\"submit_label\\":\\"Open\\",\\"elements\\":[{\\"label\\":\\"Repository\\",\\"type\\":\\"select\\",\\"name\\":\\"repository\\",\\"value\\":54321,\\"options\\":[{\\"label\\":\\"kubernetes/kubernetes\\",\\"value\\":54321}]},{\\"type\\":\\"text\\",\\"label\\":\\"Title\\",\\"name\\":\\"title\\"},{\\"type\\":\\"textarea\\",\\"label\\":\\"Body\\",\\"name\\":\\"body\\",\\"placeholder\\":\\"Leave a comment\\",\\"hint\\":\\"GitHub markdown syntax is supported, although you cannot preview it in Slack.\\",\\"value\\":\\"\\"},{\\"label\\":\\"Label\\",\\"type\\":\\"select\\",\\"name\\":\\"label\\",\\"optional\\":true,\\"options\\":[{\\"label\\":\\"test\\",\\"value\\":\\"test\\"}]}]}",
@@ -18,6 +53,41 @@ Object {
 exports[`Integration: Creating issues from Slack works when specifying a repository 2`] = `""`;
 
 exports[`Integration: Creating issues from Slack works when specifying a repository 3`] = `Object {}`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository 4`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository 5`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "open kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository 6`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 1`] = `
 Object {
@@ -31,6 +101,41 @@ exports[`Integration: Creating issues from Slack works when specifying a reposit
 
 exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 3`] = `Object {}`;
 
+exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 4`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 5`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "open kubernetes/kubernetes feature",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 6`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 1`] = `
 Object {
   "dialog": "{\\"callback_id\\":\\"create-issue-dialog\\",\\"title\\":\\"Open a new issue\\",\\"submit_label\\":\\"Open\\",\\"elements\\":[{\\"label\\":\\"Repository\\",\\"type\\":\\"select\\",\\"name\\":\\"repository\\",\\"value\\":54321,\\"options\\":[{\\"label\\":\\"kubernetes/kubernetes\\",\\"value\\":54321}]},{\\"type\\":\\"text\\",\\"label\\":\\"Title\\",\\"name\\":\\"title\\"},{\\"type\\":\\"textarea\\",\\"label\\":\\"Body\\",\\"name\\":\\"body\\",\\"placeholder\\":\\"Leave a comment\\",\\"hint\\":\\"GitHub markdown syntax is supported, although you cannot preview it in Slack.\\",\\"value\\":\\"\\"},{\\"label\\":\\"Label\\",\\"type\\":\\"select\\",\\"name\\":\\"label\\",\\"optional\\":true,\\"options\\":[{\\"label\\":\\"test\\",\\"value\\":\\"test\\"}]}]}",
@@ -42,6 +147,41 @@ Object {
 exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 2`] = `""`;
 
 exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 3`] = `Object {}`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 4`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 5`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "open kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 6`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 1`] = `
 Object {
@@ -55,6 +195,41 @@ exports[`Integration: Creating issues from Slack works when specifying a reposit
 
 exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 3`] = `Object {}`;
 
+exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 4`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 5`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "open kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 6`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 1`] = `
 Object {
   "dialog": "{\\"callback_id\\":\\"create-issue-dialog\\",\\"title\\":\\"Open a new issue\\",\\"submit_label\\":\\"Open\\",\\"elements\\":[{\\"label\\":\\"Repository\\",\\"type\\":\\"select\\",\\"name\\":\\"repository\\",\\"value\\":54321,\\"options\\":[{\\"label\\":\\"kubernetes/kubernetes\\",\\"value\\":54321}]},{\\"type\\":\\"text\\",\\"label\\":\\"Title\\",\\"name\\":\\"title\\"},{\\"type\\":\\"textarea\\",\\"label\\":\\"Body\\",\\"name\\":\\"body\\",\\"placeholder\\":\\"Leave a comment\\",\\"hint\\":\\"GitHub markdown syntax is supported, although you cannot preview it in Slack.\\",\\"value\\":\\"\\"}]}",
@@ -67,6 +242,41 @@ exports[`Integration: Creating issues from Slack works when specifying a reposit
 
 exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 3`] = `Object {}`;
 
+exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 4`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 5`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "open kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 6`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 1`] = `
 Object {
   "dialog": "{\\"callback_id\\":\\"create-issue-dialog\\",\\"title\\":\\"Open a new issue\\",\\"submit_label\\":\\"Open\\",\\"elements\\":[{\\"label\\":\\"Repository\\",\\"type\\":\\"select\\",\\"name\\":\\"repository\\",\\"value\\":54321,\\"options\\":[{\\"label\\":\\"kubernetes/kubernetes\\",\\"value\\":54321}]},{\\"type\\":\\"text\\",\\"label\\":\\"Title\\",\\"name\\":\\"title\\"},{\\"type\\":\\"textarea\\",\\"label\\":\\"Body\\",\\"name\\":\\"body\\",\\"placeholder\\":\\"Leave a comment\\",\\"hint\\":\\"GitHub markdown syntax is supported, although you cannot preview it in Slack.\\",\\"value\\":\\"\\"}]}",
@@ -78,6 +288,41 @@ Object {
 exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 2`] = `""`;
 
 exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 3`] = `Object {}`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 4`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 5`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "open kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 6`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 1`] = `
 Object {
@@ -212,6 +457,12 @@ Object {
 `;
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 5`] = `Object {}`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 6`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 7`] = `[MockFunction cache.set]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 8`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 1`] = `
 Object {
@@ -393,6 +644,12 @@ Object {
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 7`] = `Object {}`;
 
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 8`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 9`] = `[MockFunction cache.set]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 10`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when either URL is missing or no issue was selected 1`] = `
 Object {
   "errors": Array [
@@ -408,6 +665,12 @@ Object {
 }
 `;
 
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when either URL is missing or no issue was selected 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when either URL is missing or no issue was selected 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when either URL is missing or no issue was selected 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting a valid URL but for an issue that doesn't exist 1`] = `
 Object {
   "errors": Array [
@@ -418,6 +681,12 @@ Object {
   ],
 }
 `;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting a valid URL but for an issue that doesn't exist 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting a valid URL but for an issue that doesn't exist 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting a valid URL but for an issue that doesn't exist 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting an invalid URL 1`] = `
 Object {
@@ -430,6 +699,12 @@ Object {
 }
 `;
 
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting an invalid URL 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting an invalid URL 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting an invalid URL 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not exist 1`] = `
 Object {
   "errors": Array [
@@ -441,6 +716,12 @@ Object {
 }
 `;
 
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not exist 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not exist 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not exist 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not have all required permissions 1`] = `
 Object {
   "errors": Array [
@@ -451,3 +732,15 @@ Object {
   ],
 }
 `;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not have all required permissions 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not have all required permissions 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not have all required permissions 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread when a user has not yet connected their GitHub account they are prompted to do so first 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread when a user has not yet connected their GitHub account they are prompted to do so first 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread when a user has not yet connected their GitHub account they are prompted to do so first 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/create.test.js.snap
+++ b/test/integration/__snapshots__/create.test.js.snap
@@ -7,40 +7,31 @@ Object {
 }
 `;
 
-exports[`Integration: Creating issues from Slack fails when specifying a repository, there are multiple issue templates in it, and no template was specified 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: Creating issues from Slack fails when specifying a repository, there are multiple issue templates in it, and no template was specified 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "open kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: Creating issues from Slack fails when specifying a repository, there are multiple issue templates in it, and no template was specified 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: Creating issues from Slack fails when specifying a repository, there are multiple issue templates in it, and no template was specified 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Creating issues from Slack fails when specifying a repository, there are multiple issue templates in it, and no template was specified 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "open kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: Creating issues from Slack works when specifying a repository 1`] = `
 Object {
@@ -54,40 +45,31 @@ exports[`Integration: Creating issues from Slack works when specifying a reposit
 
 exports[`Integration: Creating issues from Slack works when specifying a repository 3`] = `Object {}`;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository 4`] = `[MockFunction cache.get]`;
-
-exports[`Integration: Creating issues from Slack works when specifying a repository 5`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "open kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: Creating issues from Slack works when specifying a repository 4`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository 6`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Creating issues from Slack works when specifying a repository 5`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "open kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 1`] = `
 Object {
@@ -101,40 +83,31 @@ exports[`Integration: Creating issues from Slack works when specifying a reposit
 
 exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 3`] = `Object {}`;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 4`] = `[MockFunction cache.get]`;
-
-exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 5`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "open kubernetes/kubernetes feature",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 4`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 6`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Creating issues from Slack works when specifying a repository and there are multiple issue templates in it 5`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "open kubernetes/kubernetes feature",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 1`] = `
 Object {
@@ -148,40 +121,31 @@ exports[`Integration: Creating issues from Slack works when specifying a reposit
 
 exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 3`] = `Object {}`;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 4`] = `[MockFunction cache.get]`;
-
-exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 5`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "open kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 4`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 6`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Creating issues from Slack works when specifying a repository and there are no issue templates in it 5`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "open kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 1`] = `
 Object {
@@ -195,40 +159,31 @@ exports[`Integration: Creating issues from Slack works when specifying a reposit
 
 exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 3`] = `Object {}`;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 4`] = `[MockFunction cache.get]`;
-
-exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 5`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "open kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 4`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 6`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Creating issues from Slack works when specifying a repository and there is an issue template in it 5`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "open kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 1`] = `
 Object {
@@ -242,40 +197,31 @@ exports[`Integration: Creating issues from Slack works when specifying a reposit
 
 exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 3`] = `Object {}`;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 4`] = `[MockFunction cache.get]`;
-
-exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 5`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "open kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 4`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 6`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Creating issues from Slack works when specifying a repository with a bad labels response 5`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "open kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 1`] = `
 Object {
@@ -289,40 +235,31 @@ exports[`Integration: Creating issues from Slack works when specifying a reposit
 
 exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 3`] = `Object {}`;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 4`] = `[MockFunction cache.get]`;
-
-exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 5`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "open kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 4`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 6`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Creating issues from Slack works when specifying a repository with an empty labels list 5`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "open kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 1`] = `
 Object {
@@ -458,11 +395,9 @@ Object {
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 5`] = `Object {}`;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 6`] = `[MockFunction cache.get]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 6`] = `Set {}`;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 7`] = `[MockFunction cache.set]`;
-
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 8`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can input a URL, comment by submitting the dialog, and view a confirmation message 7`] = `Map {}`;
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 1`] = `
 Object {
@@ -644,11 +579,9 @@ Object {
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 7`] = `Object {}`;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 8`] = `[MockFunction cache.get]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 8`] = `Set {}`;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 9`] = `[MockFunction cache.set]`;
-
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 10`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User can select issue, comment by submitting the dialog, and view a confirmation message 9`] = `Map {}`;
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when either URL is missing or no issue was selected 1`] = `
 Object {
@@ -665,11 +598,9 @@ Object {
 }
 `;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when either URL is missing or no issue was selected 2`] = `[MockFunction cache.get]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when either URL is missing or no issue was selected 2`] = `Set {}`;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when either URL is missing or no issue was selected 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when either URL is missing or no issue was selected 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when either URL is missing or no issue was selected 3`] = `Map {}`;
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting a valid URL but for an issue that doesn't exist 1`] = `
 Object {
@@ -682,11 +613,9 @@ Object {
 }
 `;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting a valid URL but for an issue that doesn't exist 2`] = `[MockFunction cache.get]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting a valid URL but for an issue that doesn't exist 2`] = `Set {}`;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting a valid URL but for an issue that doesn't exist 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting a valid URL but for an issue that doesn't exist 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting a valid URL but for an issue that doesn't exist 3`] = `Map {}`;
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting an invalid URL 1`] = `
 Object {
@@ -699,11 +628,9 @@ Object {
 }
 `;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting an invalid URL 2`] = `[MockFunction cache.get]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting an invalid URL 2`] = `Set {}`;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting an invalid URL 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting an invalid URL 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread User sees error when submitting an invalid URL 3`] = `Map {}`;
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not exist 1`] = `
 Object {
@@ -716,11 +643,9 @@ Object {
 }
 `;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not exist 2`] = `[MockFunction cache.get]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not exist 2`] = `Set {}`;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not exist 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not exist 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not exist 3`] = `Map {}`;
 
 exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not have all required permissions 1`] = `
 Object {
@@ -733,14 +658,10 @@ Object {
 }
 `;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not have all required permissions 2`] = `[MockFunction cache.get]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not have all required permissions 2`] = `Set {}`;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not have all required permissions 3`] = `[MockFunction cache.set]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not have all required permissions 3`] = `Map {}`;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread error is shown in dialog when installation for URL does not have all required permissions 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread when a user has not yet connected their GitHub account they are prompted to do so first 1`] = `Set {}`;
 
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread when a user has not yet connected their GitHub account they are prompted to do so first 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread when a user has not yet connected their GitHub account they are prompted to do so first 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread when a user has not yet connected their GitHub account they are prompted to do so first 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Slack actions Attaching a Slack message to an issue/pr thread when a user has not yet connected their GitHub account they are prompted to do so first 2`] = `Map {}`;

--- a/test/integration/__snapshots__/debug.test.js.snap
+++ b/test/integration/__snapshots__/debug.test.js.snap
@@ -21,37 +21,28 @@ Object {
 }
 `;
 
-exports[`Integration: debug returns debug information 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: debug returns debug information 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "debug",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: debug returns debug information 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: debug returns debug information 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: debug returns debug information 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "debug",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;

--- a/test/integration/__snapshots__/deployment.test.js.snap
+++ b/test/integration/__snapshots__/deployment.test.js.snap
@@ -63,6 +63,41 @@ Object {
 }
 `;
 
+exports[`Integration: Creating and listing deployments from Slack works when listing deployments 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Creating and listing deployments from Slack works when listing deployments 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "deploy kubernetes/kubernetes list",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: Creating and listing deployments from Slack works when listing deployments 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 1`] = `
 Object {
   "dialog": "{\\"callback_id\\":\\"create-deployment-dialog\\",\\"title\\":\\"Trigger a deployment\\",\\"submit_label\\":\\"Create\\",\\"elements\\":[{\\"label\\":\\"Repository\\",\\"type\\":\\"select\\",\\"name\\":\\"repository\\",\\"value\\":54321,\\"options\\":[{\\"label\\":\\"kubernetes/kubernetes\\",\\"value\\":54321}]},{\\"label\\":\\"Branch or tag to deploy\\",\\"type\\":\\"select\\",\\"name\\":\\"ref\\",\\"option_groups\\":[{\\"label\\":\\"Tags\\",\\"options\\":[{\\"label\\":\\"refs/tags/v1.12.0-rc.2\\",\\"value\\":\\"refs/tags/v1.12.0-rc.2\\"},{\\"label\\":\\"refs/tags/v1.13.0-alpha.0\\",\\"value\\":\\"refs/tags/v1.13.0-alpha.0\\"}]},{\\"label\\":\\"Branches\\",\\"options\\":[{\\"label\\":\\"release-1.7\\",\\"value\\":\\"release-1.7\\"},{\\"label\\":\\"release-1.8\\",\\"value\\":\\"release-1.8\\"}]}]},{\\"type\\":\\"text\\",\\"label\\":\\"Environment\\",\\"name\\":\\"environment\\",\\"optional\\":true,\\"placeholder\\":\\"Default: \`production\`\\"},{\\"type\\":\\"text\\",\\"label\\":\\"Task\\",\\"name\\":\\"task\\",\\"optional\\":true,\\"placeholder\\":\\"Default: \`deploy\`\\"},{\\"type\\":\\"textarea\\",\\"label\\":\\"Payload\\",\\"name\\":\\"payload\\",\\"placeholder\\":\\"{}\\",\\"hint\\":\\"JSON payload with extra information about the deployment\\",\\"optional\\":true}]}",
@@ -74,3 +109,38 @@ Object {
 exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 2`] = `""`;
 
 exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 3`] = `Object {}`;
+
+exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 4`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 5`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "deploy kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 6`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/deployment.test.js.snap
+++ b/test/integration/__snapshots__/deployment.test.js.snap
@@ -63,40 +63,31 @@ Object {
 }
 `;
 
-exports[`Integration: Creating and listing deployments from Slack works when listing deployments 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: Creating and listing deployments from Slack works when listing deployments 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "deploy kubernetes/kubernetes list",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: Creating and listing deployments from Slack works when listing deployments 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: Creating and listing deployments from Slack works when listing deployments 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Creating and listing deployments from Slack works when listing deployments 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "deploy kubernetes/kubernetes list",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 1`] = `
 Object {
@@ -110,37 +101,28 @@ exports[`Integration: Creating and listing deployments from Slack works when spe
 
 exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 3`] = `Object {}`;
 
-exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 4`] = `[MockFunction cache.get]`;
-
-exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 5`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "deploy kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 4`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 6`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Creating and listing deployments from Slack works when specifying a repository 5`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "deploy kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;

--- a/test/integration/__snapshots__/error-handler.test.js.snap
+++ b/test/integration/__snapshots__/error-handler.test.js.snap
@@ -1,29 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration: debug returns debug information 1`] = `
-Object {
-  "attachments": Array [
-    Object {
-      "text": "\`\`\`{
-  \\"team_id\\": \\"T0001\\",
-  \\"team_domain\\": \\"example\\",
-  \\"user_id\\": \\"U2147483697\\",
-  \\"channel_id\\": \\"C2147483705\\",
-  \\"channel_name\\": \\"test\\",
-  \\"text\\": \\"debug\\",
-  \\"enterprise_id\\": \\"E0001\\",
-  \\"enterprise_name\\": \\"Globular%20Construct%20Inc\\"
-}\`\`\`",
-      "title": "Debug information",
-    },
-  ],
-  "response_type": "ephemeral",
-}
-`;
+exports[`Error handling /boom returns 500 1`] = `[MockFunction cache.get]`;
 
-exports[`Integration: debug returns debug information 2`] = `[MockFunction cache.get]`;
+exports[`Error handling /boom returns 500 2`] = `[MockFunction cache.set]`;
 
-exports[`Integration: debug returns debug information 3`] = `
+exports[`Error handling /boom returns 500 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Error handling /boom?async returns 500 1`] = `[MockFunction cache.get]`;
+
+exports[`Error handling /boom?async returns 500 2`] = `[MockFunction cache.set]`;
+
+exports[`Error handling /boom?async returns 500 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Error handling response to failed slack commands 1`] = `[MockFunction cache.get]`;
+
+exports[`Error handling response to failed slack commands 2`] = `
 [MockFunction cache.set] {
   "calls": Array [
     Array [
@@ -37,7 +28,7 @@ exports[`Integration: debug returns debug information 3`] = `
         "response_url": "https://hooks.slack.com/commands/1234/5678",
         "team_domain": "example",
         "team_id": "T0001",
-        "text": "debug",
+        "text": "boom",
         "token": "secret",
         "trigger_id": "13345224609.738474920.8088930838d88f008e0",
         "user_id": "U2147483697",
@@ -54,4 +45,4 @@ exports[`Integration: debug returns debug information 3`] = `
 }
 `;
 
-exports[`Integration: debug returns debug information 4`] = `[MockFunction cache.fetch]`;
+exports[`Error handling response to failed slack commands 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/error-handler.test.js.snap
+++ b/test/integration/__snapshots__/error-handler.test.js.snap
@@ -1,48 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Error handling /boom returns 500 1`] = `[MockFunction cache.get]`;
+exports[`Error handling /boom returns 500 1`] = `Set {}`;
 
-exports[`Error handling /boom returns 500 2`] = `[MockFunction cache.set]`;
+exports[`Error handling /boom returns 500 2`] = `Map {}`;
 
-exports[`Error handling /boom returns 500 3`] = `[MockFunction cache.fetch]`;
+exports[`Error handling /boom?async returns 500 1`] = `Set {}`;
 
-exports[`Error handling /boom?async returns 500 1`] = `[MockFunction cache.get]`;
+exports[`Error handling /boom?async returns 500 2`] = `Map {}`;
 
-exports[`Error handling /boom?async returns 500 2`] = `[MockFunction cache.set]`;
-
-exports[`Error handling /boom?async returns 500 3`] = `[MockFunction cache.fetch]`;
-
-exports[`Error handling response to failed slack commands 1`] = `[MockFunction cache.get]`;
-
-exports[`Error handling response to failed slack commands 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "boom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Error handling response to failed slack commands 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Error handling response to failed slack commands 3`] = `[MockFunction cache.fetch]`;
+exports[`Error handling response to failed slack commands 2`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "boom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;

--- a/test/integration/__snapshots__/frontend.test.js.snap
+++ b/test/integration/__snapshots__/frontend.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration: frontend / 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: frontend / 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: frontend / 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/frontend.test.js.snap
+++ b/test/integration/__snapshots__/frontend.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration: frontend / 1`] = `[MockFunction cache.get]`;
+exports[`Integration: frontend / 1`] = `Set {}`;
 
-exports[`Integration: frontend / 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: frontend / 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: frontend / 2`] = `Map {}`;

--- a/test/integration/__snapshots__/github-app-authorization-revoked.test.js.snap
+++ b/test/integration/__snapshots__/github-app-authorization-revoked.test.js.snap
@@ -16,6 +16,12 @@ Object {
 }
 `;
 
+exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 3`] = `[MockFunction cache.get]`;
+
+exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 4`] = `[MockFunction cache.set]`;
+
+exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 5`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"Subscriptions to 2 repositories have been disabled, because <@U2147483697>, who originally set them up, has disconnected their GitHub account.\\\\nUse the following slash commands to re-enable the subscriptions:\\\\n/github subscribe atom/atom\\\\n/github subscribe kubernetes/kubernetes\\"}]",
@@ -47,3 +53,9 @@ Object {
   "token": "xoxp-token",
 }
 `;
+
+exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 5`] = `[MockFunction cache.get]`;
+
+exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 6`] = `[MockFunction cache.set]`;
+
+exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 7`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/github-app-authorization-revoked.test.js.snap
+++ b/test/integration/__snapshots__/github-app-authorization-revoked.test.js.snap
@@ -16,11 +16,9 @@ Object {
 }
 `;
 
-exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 3`] = `[MockFunction cache.get]`;
+exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 3`] = `Set {}`;
 
-exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 4`] = `[MockFunction cache.set]`;
-
-exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 5`] = `[MockFunction cache.fetch]`;
+exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 4`] = `Map {}`;
 
 exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 1`] = `
 Object {
@@ -54,8 +52,6 @@ Object {
 }
 `;
 
-exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 5`] = `[MockFunction cache.get]`;
+exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 5`] = `Set {}`;
 
-exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 6`] = `[MockFunction cache.set]`;
-
-exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 7`] = `[MockFunction cache.fetch]`;
+exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 6`] = `Map {}`;

--- a/test/integration/__snapshots__/help.test.js.snap
+++ b/test/integration/__snapshots__/help.test.js.snap
@@ -106,40 +106,31 @@ Object {
 }
 `;
 
-exports[`Integration: help returns help with /github help command 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: help returns help with /github help command 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "help",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: help returns help with /github help command 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: help returns help with /github help command 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: help returns help with /github help command 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "help",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: help returns help with no arguments 1`] = `
 Object {
@@ -247,40 +238,31 @@ Object {
 }
 `;
 
-exports[`Integration: help returns help with no arguments 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: help returns help with no arguments 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: help returns help with no arguments 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: help returns help with no arguments 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: help returns help with no arguments 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: help returns help with unknown command 1`] = `
 Object {
@@ -388,37 +370,28 @@ Object {
 }
 `;
 
-exports[`Integration: help returns help with unknown command 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: help returns help with unknown command 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "lolwut?",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: help returns help with unknown command 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: help returns help with unknown command 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: help returns help with unknown command 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "lolwut?",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;

--- a/test/integration/__snapshots__/help.test.js.snap
+++ b/test/integration/__snapshots__/help.test.js.snap
@@ -106,6 +106,41 @@ Object {
 }
 `;
 
+exports[`Integration: help returns help with /github help command 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: help returns help with /github help command 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "help",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: help returns help with /github help command 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: help returns help with no arguments 1`] = `
 Object {
   "attachments": Array [
@@ -212,6 +247,41 @@ Object {
 }
 `;
 
+exports[`Integration: help returns help with no arguments 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: help returns help with no arguments 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: help returns help with no arguments 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: help returns help with unknown command 1`] = `
 Object {
   "attachments": Array [
@@ -317,3 +387,38 @@ Object {
   "text": ":wave: Need some help with \`/github\`?",
 }
 `;
+
+exports[`Integration: help returns help with unknown command 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: help returns help with unknown command 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "lolwut?",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: help returns help with unknown command 4`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/installations.test.js.snap
+++ b/test/integration/__snapshots__/installations.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration: tracking GitHub installations deleting installation cascades to delete all subscriptions related to that installation 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: tracking GitHub installations deleting installation cascades to delete all subscriptions related to that installation 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: tracking GitHub installations deleting installation cascades to delete all subscriptions related to that installation 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: tracking GitHub installations installation created records 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: tracking GitHub installations installation created records 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: tracking GitHub installations installation created records 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/installations.test.js.snap
+++ b/test/integration/__snapshots__/installations.test.js.snap
@@ -1,13 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration: tracking GitHub installations deleting installation cascades to delete all subscriptions related to that installation 1`] = `[MockFunction cache.get]`;
+exports[`Integration: tracking GitHub installations deleting installation cascades to delete all subscriptions related to that installation 1`] = `Set {}`;
 
-exports[`Integration: tracking GitHub installations deleting installation cascades to delete all subscriptions related to that installation 2`] = `[MockFunction cache.set]`;
+exports[`Integration: tracking GitHub installations deleting installation cascades to delete all subscriptions related to that installation 2`] = `Map {}`;
 
-exports[`Integration: tracking GitHub installations deleting installation cascades to delete all subscriptions related to that installation 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: tracking GitHub installations installation created records 1`] = `Set {}`;
 
-exports[`Integration: tracking GitHub installations installation created records 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: tracking GitHub installations installation created records 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: tracking GitHub installations installation created records 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: tracking GitHub installations installation created records 2`] = `Map {}`;

--- a/test/integration/__snapshots__/issue-state.test.js.snap
+++ b/test/integration/__snapshots__/issue-state.test.js.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration: issue state /github close issue 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "channel#C2147483705:issue#undefined",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: issue state /github close issue 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "close https://github.com/owner/repo/issues/123",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+    Array [
+      "channel#C2147483705:issue#undefined",
+      Object {
+        "channel": "C2147483705",
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: issue state /github close issue 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: issue state /github reopen issue 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "channel#C2147483705:issue#undefined",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: issue state /github reopen issue 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "reopen https://github.com/owner/repo/issues/123",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+    Array [
+      "channel#C2147483705:issue#undefined",
+      Object {
+        "channel": "C2147483705",
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: issue state /github reopen issue 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/issue-state.test.js.snap
+++ b/test/integration/__snapshots__/issue-state.test.js.snap
@@ -1,121 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Integration: issue state /github close issue 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "channel#C2147483705:issue#undefined",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+  "channel#C2147483705:issue#undefined",
 }
 `;
 
 exports[`Integration: issue state /github close issue 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "close https://github.com/owner/repo/issues/123",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-    Array [
-      "channel#C2147483705:issue#undefined",
-      Object {
-        "channel": "C2147483705",
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "close https://github.com/owner/repo/issues/123",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+  "channel#C2147483705:issue#undefined" => Object {
+    "channel": "C2147483705",
+    "ts": undefined,
+  },
 }
 `;
 
-exports[`Integration: issue state /github close issue 3`] = `[MockFunction cache.fetch]`;
-
 exports[`Integration: issue state /github reopen issue 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "channel#C2147483705:issue#undefined",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+  "channel#C2147483705:issue#undefined",
 }
 `;
 
 exports[`Integration: issue state /github reopen issue 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "reopen https://github.com/owner/repo/issues/123",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-    Array [
-      "channel#C2147483705:issue#undefined",
-      Object {
-        "channel": "C2147483705",
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "reopen https://github.com/owner/repo/issues/123",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+  "channel#C2147483705:issue#undefined" => Object {
+    "channel": "C2147483705",
+    "ts": undefined,
+  },
 }
 `;
-
-exports[`Integration: issue state /github reopen issue 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/legacy-subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/legacy-subscriptions.test.js.snap
@@ -9,11 +9,9 @@ Object {
 }
 `;
 
-exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack Works for 1 legacy configuration 2`] = `[MockFunction cache.get]`;
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack Works for 1 legacy configuration 2`] = `Set {}`;
 
-exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack Works for 1 legacy configuration 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack Works for 1 legacy configuration 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack Works for 1 legacy configuration 3`] = `Map {}`;
 
 exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack does not duplicate legacy configurations 1`] = `
 Object {
@@ -24,11 +22,9 @@ Object {
 }
 `;
 
-exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack does not duplicate legacy configurations 2`] = `[MockFunction cache.get]`;
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack does not duplicate legacy configurations 2`] = `Set {}`;
 
-exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack does not duplicate legacy configurations 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack does not duplicate legacy configurations 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack does not duplicate legacy configurations 3`] = `Map {}`;
 
 exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack works for 34 legacy configurations 1`] = `
 Object {
@@ -66,8 +62,6 @@ Object {
 }
 `;
 
-exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack works for 34 legacy configurations 5`] = `[MockFunction cache.get]`;
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack works for 34 legacy configurations 5`] = `Set {}`;
 
-exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack works for 34 legacy configurations 6`] = `[MockFunction cache.set]`;
-
-exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack works for 34 legacy configurations 7`] = `[MockFunction cache.fetch]`;
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack works for 34 legacy configurations 6`] = `Map {}`;

--- a/test/integration/__snapshots__/legacy-subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/legacy-subscriptions.test.js.snap
@@ -9,6 +9,12 @@ Object {
 }
 `;
 
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack Works for 1 legacy configuration 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack Works for 1 legacy configuration 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack Works for 1 legacy configuration 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack does not duplicate legacy configurations 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"text\\":\\"Good news: an upgraded GitHub app has been installed in this workspace. Type the following slash command to keep GitHub working in this channel.\\"},{\\"color\\":\\"#24292f\\",\\"fields\\":[{\\"value\\":\\"/github subscribe berttest/testrepo1\\"}],\\"mrkdwn_in\\":[\\"fields\\"],\\"pretext\\":\\"Configuration created by <@U06AXEE2U>:\\"},{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"_Need help? Type \\\\\\"/github help\\\\\\" or <https://get.slack.help/hc/en-us/articles/232289568-GitHub-for-Slack|learn more>._\\"}]",
@@ -17,6 +23,12 @@ Object {
   "token": "xoxa-token",
 }
 `;
+
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack does not duplicate legacy configurations 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack does not duplicate legacy configurations 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack does not duplicate legacy configurations 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack works for 34 legacy configurations 1`] = `
 Object {
@@ -53,3 +65,9 @@ Object {
   "token": "xoxa-token",
 }
 `;
+
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack works for 34 legacy configurations 5`] = `[MockFunction cache.get]`;
+
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack works for 34 legacy configurations 6`] = `[MockFunction cache.set]`;
+
+exports[`Integration: Slack config_migration event LegacySubscription rows are created in the db and prompt is posted in Slack works for 34 legacy configurations 7`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/list-subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/list-subscriptions.test.js.snap
@@ -14,6 +14,76 @@ Object {
 }
 `;
 
+exports[`Integration: subscription list when a repository and an account has been deleted 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscription list when a repository and an account has been deleted 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe list",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscription list when a repository and an account has been deleted 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: subscription list when some other error occurs 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscription list when some other error occurs 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe list",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscription list when some other error occurs 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscription list works for /github subscribe 1`] = `
 Object {
   "attachments": Array [
@@ -71,6 +141,41 @@ Object {
 }
 `;
 
+exports[`Integration: subscription list works for /github subscribe 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscription list works for /github subscribe 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscription list works for /github subscribe 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscription list works for /github subscribe list 1`] = `
 Object {
   "attachments": Array [
@@ -91,3 +196,38 @@ Object {
   "response_type": "in_channel",
 }
 `;
+
+exports[`Integration: subscription list works for /github subscribe list 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscription list works for /github subscribe list 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe list",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscription list works for /github subscribe list 4`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/list-subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/list-subscriptions.test.js.snap
@@ -14,75 +14,57 @@ Object {
 }
 `;
 
-exports[`Integration: subscription list when a repository and an account has been deleted 2`] = `[MockFunction cache.get]`;
+exports[`Integration: subscription list when a repository and an account has been deleted 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscription list when a repository and an account has been deleted 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe list",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe list",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
 
-exports[`Integration: subscription list when a repository and an account has been deleted 4`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: subscription list when some other error occurs 1`] = `[MockFunction cache.get]`;
+exports[`Integration: subscription list when some other error occurs 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscription list when some other error occurs 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe list",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe list",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: subscription list when some other error occurs 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: subscription list works for /github subscribe 1`] = `
 Object {
@@ -141,40 +123,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscription list works for /github subscribe 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscription list works for /github subscribe 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscription list works for /github subscribe 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscription list works for /github subscribe 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscription list works for /github subscribe 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscription list works for /github subscribe list 1`] = `
 Object {
@@ -197,37 +170,28 @@ Object {
 }
 `;
 
-exports[`Integration: subscription list works for /github subscribe list 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscription list works for /github subscribe list 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe list",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscription list works for /github subscribe list 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscription list works for /github subscribe list 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscription list works for /github subscribe list 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe list",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;

--- a/test/integration/__snapshots__/middleware.test.js.snap
+++ b/test/integration/__snapshots__/middleware.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Middleware Parse action payload returns 400 for invalid format 1`] = `[MockFunction cache.get]`;
+exports[`Middleware Parse action payload returns 400 for invalid format 1`] = `Set {}`;
 
-exports[`Middleware Parse action payload returns 400 for invalid format 2`] = `[MockFunction cache.set]`;
-
-exports[`Middleware Parse action payload returns 400 for invalid format 3`] = `[MockFunction cache.fetch]`;
+exports[`Middleware Parse action payload returns 400 for invalid format 2`] = `Map {}`;

--- a/test/integration/__snapshots__/middleware.test.js.snap
+++ b/test/integration/__snapshots__/middleware.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Middleware Parse action payload returns 400 for invalid format 1`] = `[MockFunction cache.get]`;
+
+exports[`Middleware Parse action payload returns 400 for invalid format 2`] = `[MockFunction cache.set]`;
+
+exports[`Middleware Parse action payload returns 400 for invalid format 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/notifications.test.js.snap
+++ b/test/integration/__snapshots__/notifications.test.js.snap
@@ -1,9 +1,209 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Integration: notifications to a subscribed channel channel_not_found error from slack deletes subscription 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel channel_not_found error from slack deletes subscription 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel channel_not_found error from slack deletes subscription 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel comments are updated when edited 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"footer\\":\\"<https://github.com/github-slack/test|github-slack/test>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"fallback\\":\\"[github-slack/test] Comment on #23\\",\\"title\\":\\"Comment on #23 testing multi-tenet\\",\\"title_link\\":\\"https://github.com/github-slack/test/issues/23#issuecomment-364284529\\",\\"author_name\\":\\"bkeepers\\",\\"author_link\\":\\"https://github.com/bkeepers\\",\\"author_icon\\":\\"https://avatars0.githubusercontent.com/u/173?v=4\\",\\"ts\\":1518132652,\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"edited html\\"}]",
   "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel comments are updated when edited 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100403908",
+    ],
+    Array [
+      "creator-access#1:100403908",
+    ],
+    Array [
+      "channel#C002:issue#283007517",
+    ],
+    Array [
+      "channel#C002:comment#364284529",
+    ],
+    Array [
+      "creator-access#1:100403908",
+    ],
+    Array [
+      "channel#C002:issue#283007517",
+    ],
+    Array [
+      "creator-access#1:100403908",
+    ],
+    Array [
+      "channel#C002:comment#364284529",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel comments are updated when edited 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100403908",
+      true,
+      600000,
+    ],
+    Array [
+      "creator-access#1:100403908",
+      true,
+      600000,
+    ],
+    Array [
+      "channel#C002:comment#364284529",
+      Object {
+        "channel": undefined,
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel comments are updated when edited 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100403908",
+      [Function],
+      600000,
+    ],
+    Array [
+      "creator-access#1:100403908",
+      [Function],
+      600000,
+    ],
+    Array [
+      "creator-access#1:100403908",
+      [Function],
+      600000,
+    ],
+    Array [
+      "creator-access#1:100403908",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
 }
 `;
 
@@ -15,11 +215,133 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel delivers force push with no commits 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel delivers force push with no commits 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel delivers force push with no commits 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"footer\\":\\"<https://github.com/github-slack-test-org/test2|github-slack-test-org/test2>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"fallback\\":\\"[github-slack-test-org/test2] Comment on #1\\",\\"title\\":\\"Comment on #1 Update README.md\\",\\"title_link\\":\\"https://github.com/github-slack-test-org/test2/pull/1#discussion_r171608320\\",\\"author_name\\":\\"wilhelmklopp\\",\\"author_link\\":\\"https://github.com/wilhelmklopp\\",\\"author_icon\\":\\"https://avatars1.githubusercontent.com/u/7718702?v=4\\",\\"ts\\":1519920573,\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"rendered html\\"}]",
   "channel": "C001",
   "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:123302024",
+    ],
+    Array [
+      "channel#C001:comment#171608320",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:123302024",
+      true,
+      600000,
+    ],
+    Array [
+      "channel#C001:comment#171608320",
+      Object {
+        "channel": undefined,
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:123302024",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
 }
 `;
 
@@ -31,11 +353,115 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel delivers pushes on non default branch if enabled 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel delivers pushes on non default branch if enabled 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel delivers pushes on non default branch if enabled 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel delivers release notes by default 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"title\\":\\"Release - vX.Y.Z - Canary Dwarf\\",\\"fallback\\":\\"[github-slack/app] Release - vX.Y.Z - Canary Dwarf\\",\\"title_link\\":\\"https://github.com/github-slack/app/releases/tag/vX.Y.Z\\",\\"author_name\\":\\"wilhelmklopp\\",\\"author_link\\":\\"https://github.com/wilhelmklopp\\",\\"author_icon\\":\\"https://avatars1.githubusercontent.com/u/7718702?v=4\\",\\"ts\\":1523863209,\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"*Features*\\\\n\\\\n• Feature 1  \\\\n    ...\\\\n\\\\n*Fixes*\\\\n\\\\n• Fix 1  \\\\n    ...\\\\n\\\\n*Internals*\\\\n\\\\n• Internal improvement 1  \\\\n    ...\\"}]",
   "channel": "C001",
   "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel delivers release notes by default 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel delivers release notes by default 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel delivers release notes by default 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
 }
 `;
 
@@ -54,11 +480,407 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel deployment_status event 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+    ],
+    Array [
+      "channel#C001:deployment#57919058",
+    ],
+    Array [
+      "creator-access#1:100427737",
+    ],
+    Array [
+      "channel#C001:deployment#57919058",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel deployment_status event 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      true,
+      600000,
+    ],
+    Array [
+      "channel#C001:deployment#57919058",
+      Object {
+        "channel": undefined,
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel deployment_status event 5`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel do not post prompt to re-subscribe after user loses access to repo but the subscription is to an account 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel do not post prompt to re-subscribe after user loses access to repo but the subscription is to an account 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+      142600109,
+    ],
+    Array [
+      "creator-access#1:100427737",
+      false,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel do not post prompt to re-subscribe after user loses access to repo but the subscription is to an account 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 1`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 2`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 3`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver empty reviews which are actually review comments 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver empty reviews which are actually review comments 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver empty reviews which are actually review comments 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 1`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 2`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 3`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 1`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 2`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 3`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver push with no commits 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver push with no commits 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver push with no commits 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver pushes on non-default branch if not explicitly enabled 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver pushes on non-default branch if not explicitly enabled 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver pushes on non-default branch if not explicitly enabled 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 1`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 2`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 3`] = `[MockFunction]`;
+
 exports[`Integration: notifications to a subscribed channel issue opened 1`] = `
 Object {
   "attachments": "[{\\"fields\\":[{\\"title\\":\\"Comments\\",\\"value\\":126,\\"short\\":true}],\\"color\\":\\"#cb2431\\",\\"footer\\":\\"<https://github.com/github-slack/public-test|github-slack/public-test>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1500156238,\\"mrkdwn_in\\":[\\"text\\"],\\"author_name\\":\\"wohali\\",\\"author_link\\":\\"https://github.com/wohali\\",\\"author_icon\\":\\"https://avatars2.githubusercontent.com/u/112292?v=4\\",\\"title\\":\\"#10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\",\\"title_link\\":\\"https://github.com/facebook/react/issues/10191\\",\\"fallback\\":\\"[github-slack/public-test] Issue opened by wilhelmklopp\\",\\"text\\":\\"Hi there,\\\\r\\\\n\\\\r\\\\nThe Apache Software Foundation Legal Affairs Committee [has announced][1] that the so-called 'Facebook BSD+Patents License' is no longer allowed to be used as a direct dependency in Apache projects.\\\\r\\\\n\\\\r\\\\nThis has lead to a lot of upset and frustration in the Apache community, especially from projects requiring similarly-licensed code as direct dependencies - the chief of these being RocksDB.\\\\r\\\\n\\\\r\\\\nHowever, we (the Apache Software Foundation) have just received word that [RocksDB will be re-licensing their code under the dual Apache License v2.0 and GPL 2 licenses][2]. \\\\r\\\\n\\\\r\\\\nAs a user of React.JS in an ASF top-level project (Apache CouchDB), please consider re-licensing React.JS under similar terms. Otherwise, many ASF projects such as our own will have to stop relying on and building with React.\\\\r\\\\n\\\\r\\\\nA previous bug (#9760) suggested I mention @lacker in this issue when asking licensing questions, so I'm doing so.\\\\r\\\\n\\\\r\\\\nThank you kindly for your consideration.\\\\r\\\\n\\\\r\\\\n[1]: https://issues.apache.org/jira/browse/LEGAL-303?focusedCommentId=16088663&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16088663\\\\r\\\\n[2]: https://issues.apache.org/jira/browse/LEGAL-303?focusedCommentId=16088730&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16088730\\",\\"pretext\\":\\"Issue opened by wilhelmklopp\\"}]",
   "channel": "C001",
   "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issue opened 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issue opened 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      true,
+      600000,
+    ],
+    Array [
+      "channel#C001:issue#265831302",
+      Object {
+        "channel": undefined,
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issue opened 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
 }
 `;
 
@@ -70,11 +892,129 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel issues closed does not make an API call to issues endpoint 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+    ],
+    Array [
+      "channel#C001:issue#265831302",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issues closed does not make an API call to issues endpoint 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issues closed does not make an API call to issues endpoint 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel issues reopened does not make an API call to issues endpoint 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#36a64f\\",\\"footer\\":\\"<https://github.com/github-slack/public-test|github-slack/public-test>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1508171038,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#1 Needs content\\",\\"title_link\\":\\"https://github.com/github-slack/public-test/issues/1\\",\\"fallback\\":\\"[github-slack/public-test] Issue reopened by wilhelmklopp\\",\\"pretext\\":\\"Issue reopened by wilhelmklopp\\"}]",
   "channel": "C001",
   "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issues reopened does not make an API call to issues endpoint 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+    ],
+    Array [
+      "channel#C001:issue#265831302",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issues reopened does not make an API call to issues endpoint 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issues reopened does not make an API call to issues endpoint 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
 }
 `;
 
@@ -85,11 +1025,186 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+    ],
+    Array [
+      "creator-access#1:107153132",
+    ],
+    Array [
+      "channel#C001:issue#265831302",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      true,
+      600000,
+    ],
+    Array [
+      "channel#C001:issue#265831302",
+      Object {
+        "channel": undefined,
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 1`] = `
 Object {
   "attachments": "[{\\"fields\\":[{\\"title\\":\\"Comments\\",\\"value\\":3,\\"short\\":true},{\\"title\\":\\"Reviewers\\",\\"value\\":\\"thomasjo, fosslinux\\",\\"short\\":true}],\\"color\\":\\"#6f42c1\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1502411430,\\"mrkdwn_in\\":[\\"text\\"],\\"author_name\\":\\"e-beach\\",\\"author_link\\":\\"https://github.com/e-beach\\",\\"author_icon\\":\\"https://avatars1.githubusercontent.com/u/13651458?v=4\\",\\"title\\":\\"#1535 Make fork command idempotent\\",\\"title_link\\":\\"https://github.com/github/hub/pull/1535\\",\\"fallback\\":\\"[github-slack/app] #1535 Make fork command idempotent\\",\\"text\\":\\"Fixes #1499.\\\\r\\\\n\\\\r\\\\nThis PR makes \`hub fork\` succeed, with no operation, if a remote pointing to the forked repository already exists.\\\\r\\\\n \\",\\"pretext\\":\\"Pull request merged by wilhelmklopp\\"}]",
   "channel": "C001",
   "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 2`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+      142600109,
+    ],
+    Array [
+      "channel#C001:pull#142600109",
+      Object {
+        "channel": undefined,
+        "context": Object {
+          "number": 31,
+          "owner": "github-slack",
+          "repo": "app",
+        },
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 4`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel other error from slack does not delete subscription 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel other error from slack does not delete subscription 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel other error from slack does not delete subscription 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
 }
 `;
 
@@ -102,11 +1217,123 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel post prompt to re-subscribe after user loses access to repo 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel post prompt to re-subscribe after user loses access to repo 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+      142600109,
+    ],
+    Array [
+      "creator-access#1:100427737",
+      false,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel post prompt to re-subscribe after user loses access to repo 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel public event 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"footer\\":\\"<https://github.com/github-slack/private-turned-public|github-slack/private-turned-public>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"author_name\\":\\"wilhelmklopp\\",\\"author_icon\\":\\"https://avatars1.githubusercontent.com/u/7718702?v=4\\",\\"author_link\\":\\"https://github.com/wilhelmklopp\\",\\"text\\":\\"github-slack/private-turned-public is now public!\\",\\"fallback\\":\\"github-slack/private-turned-public is now public!\\",\\"image_url\\":\\"https://octodex.github.com/images/welcometocat.png\\"}]",
   "channel": "C001",
   "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel public event 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:115726862",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel public event 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:115726862",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel public event 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:115726862",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
 }
 `;
 
@@ -118,11 +1345,139 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel pull request closed does not make an API call to issues endpoint 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request closed does not make an API call to issues endpoint 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request closed does not make an API call to issues endpoint 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel pull request opened 1`] = `
 Object {
   "attachments": "[{\\"fields\\":[{\\"title\\":\\"Comments\\",\\"value\\":126,\\"short\\":true},{\\"title\\":\\"Reviewers\\",\\"value\\":\\"thomasjo, fosslinux\\",\\"short\\":true}],\\"color\\":\\"#6f42c1\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1500156238,\\"mrkdwn_in\\":[\\"text\\"],\\"author_name\\":\\"wohali\\",\\"author_link\\":\\"https://github.com/wohali\\",\\"author_icon\\":\\"https://avatars2.githubusercontent.com/u/112292?v=4\\",\\"title\\":\\"#10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\",\\"title_link\\":\\"https://github.com/facebook/react/issues/10191\\",\\"fallback\\":\\"[github-slack/app] #10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\",\\"text\\":\\"Hi there,\\\\r\\\\n\\\\r\\\\nThe Apache Software Foundation Legal Affairs Committee [has announced][1] that the so-called 'Facebook BSD+Patents License' is no longer allowed to be used as a direct dependency in Apache projects.\\\\r\\\\n\\\\r\\\\nThis has lead to a lot of upset and frustration in the Apache community, especially from projects requiring similarly-licensed code as direct dependencies - the chief of these being RocksDB.\\\\r\\\\n\\\\r\\\\nHowever, we (the Apache Software Foundation) have just received word that [RocksDB will be re-licensing their code under the dual Apache License v2.0 and GPL 2 licenses][2]. \\\\r\\\\n\\\\r\\\\nAs a user of React.JS in an ASF top-level project (Apache CouchDB), please consider re-licensing React.JS under similar terms. Otherwise, many ASF projects such as our own will have to stop relying on and building with React.\\\\r\\\\n\\\\r\\\\nA previous bug (#9760) suggested I mention @lacker in this issue when asking licensing questions, so I'm doing so.\\\\r\\\\n\\\\r\\\\nThank you kindly for your consideration.\\\\r\\\\n\\\\r\\\\n[1]: https://issues.apache.org/jira/browse/LEGAL-303?focusedCommentId=16088663&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16088663\\\\r\\\\n[2]: https://issues.apache.org/jira/browse/LEGAL-303?focusedCommentId=16088730&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16088730\\",\\"pretext\\":\\"Pull request merged by wilhelmklopp\\"}]",
   "channel": "C001",
   "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request opened 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request opened 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+      142600109,
+    ],
+    Array [
+      "creator-access#1:100427737",
+      true,
+      600000,
+    ],
+    Array [
+      "channel#C001:pull#142600109",
+      Object {
+        "channel": undefined,
+        "context": Object {
+          "number": 31,
+          "owner": "github-slack",
+          "repo": "app",
+        },
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request opened 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
 }
 `;
 
@@ -141,11 +1496,169 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel pull request opened followed by status 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+    ],
+    Array [
+      "creator-access#1:100427737",
+    ],
+    Array [
+      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+    ],
+    Array [
+      "channel#C001:pull#142600109",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request opened followed by status 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+      142600109,
+    ],
+    Array [
+      "creator-access#1:100427737",
+      true,
+      600000,
+    ],
+    Array [
+      "channel#C001:pull#142600109",
+      Object {
+        "channel": undefined,
+        "context": Object {
+          "number": 31,
+          "owner": "github-slack",
+          "repo": "app",
+        },
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request opened followed by status 5`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#36a64f\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1506092298,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#31 Add badges to readme\\",\\"title_link\\":\\"https://github.com/github-slack/app/pull/31\\",\\"fallback\\":\\"[github-slack/app] #31 Add badges to readme\\",\\"pretext\\":\\"Pull request reopened by wilhelmklopp\\"}]",
   "channel": "C001",
   "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
 }
 `;
 
@@ -157,6 +1670,64 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel ref event 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel ref event 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel ref event 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 1`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 2`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 3`] = `[MockFunction]`;
+
 exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"footer\\":\\"<https://github.com/github-slack-test-org/i-will-be-deleted|github-slack-test-org/i-will-be-deleted>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"fallback\\":\\"[github-slack-test-org/i-will-be-deleted] Repository deleted by wilhelmklopp\\",\\"title\\":\\"github-slack-test-org/i-will-be-deleted\\",\\"fields\\":[{\\"title\\":\\"Last updated\\",\\"value\\":\\"2 months ago\\",\\"short\\":true}],\\"mrkdwn_in\\":[\\"text\\",\\"fields\\"],\\"ts\\":1520343804,\\"pretext\\":\\"Repository deleted by wilhelmklopp\\"}]",
@@ -164,6 +1735,18 @@ Object {
   "token": "test",
 }
 `;
+
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 2`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 3`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 4`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 1`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 2`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 3`] = `[MockFunction]`;
 
 exports[`Integration: notifications to a subscribed channel review event 1`] = `
 Object {
@@ -180,6 +1763,171 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel review event 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+    ],
+    Array [
+      "channel#C001:review#97014958",
+    ],
+    Array [
+      "creator-access#1:107153132",
+    ],
+    Array [
+      "channel#C001:review#97014958",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel review event 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      true,
+      600000,
+    ],
+    Array [
+      "channel#C001:review#97014958",
+      Object {
+        "channel": undefined,
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel review event 5`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+    Array [
+      "creator-access#1:107153132",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 1`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 2`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 3`] = `[MockFunction]`;
+
+exports[`Integration: notifications to a subscribed channel status event with no matching PR does not update a message 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+    ],
+    Array [
+      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+    ],
+    Array [
+      "channel#C001:pull#undefined",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel status event with no matching PR does not update a message 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      true,
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel status event with no matching PR does not update a message 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100427737",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"footer\\":\\"<https://github.com/artnez/environment|artnez/environment>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"fallback\\":\\"[artnez/environment] Comment on commit \\\\\\"update gohere\\\\\\"\\",\\"title\\":\\"Comment on commit \\\\\\"update gohere\\\\\\"\\",\\"title_link\\":\\"https://github.com/artnez/environment/commit/fa3f7c1a10ef7401496040b4508ede9b25b16695#commitcomment-30287269\\",\\"author_name\\":\\"artnez\\",\\"author_link\\":\\"https://github.com/artnez\\",\\"author_icon\\":\\"https://avatars1.githubusercontent.com/u/396654?v=4\\",\\"ts\\":1535170713,\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"Testing.\\"}]",
@@ -188,10 +1936,182 @@ Object {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:16064378",
+    ],
+    Array [
+      "channel#C002:comment#30287269",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:16064378",
+      true,
+      600000,
+    ],
+    Array [
+      "channel#C002:comment#30287269",
+      Object {
+        "channel": undefined,
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:16064378",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"footer\\":\\"<https://github.com/github-slack/test|github-slack/test>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"fallback\\":\\"[github-slack/test] Comment on #23\\",\\"title\\":\\"Comment on #23 testing multi-tenet\\",\\"title_link\\":\\"https://github.com/github-slack/test/issues/23#issuecomment-364284529\\",\\"author_name\\":\\"bkeepers\\",\\"author_link\\":\\"https://github.com/bkeepers\\",\\"author_icon\\":\\"https://avatars0.githubusercontent.com/u/173?v=4\\",\\"ts\\":1518132652,\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"rendered html\\"}]",
   "channel": "C002",
   "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100403908",
+    ],
+    Array [
+      "creator-access#1:100403908",
+    ],
+    Array [
+      "channel#C002:issue#283007517",
+    ],
+    Array [
+      "channel#C002:comment#364284529",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100403908",
+      true,
+      600000,
+    ],
+    Array [
+      "creator-access#1:100403908",
+      true,
+      600000,
+    ],
+    Array [
+      "channel#C002:comment#364284529",
+      Object {
+        "channel": undefined,
+        "ts": undefined,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 4`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "creator-access#1:100403908",
+      [Function],
+      600000,
+    ],
+    Array [
+      "creator-access#1:100403908",
+      [Function],
+      600000,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
 }
 `;

--- a/test/integration/__snapshots__/notifications.test.js.snap
+++ b/test/integration/__snapshots__/notifications.test.js.snap
@@ -1,54 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Integration: notifications to a subscribed channel channel_not_found error from slack deletes subscription 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:107153132",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel channel_not_found error from slack deletes subscription 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel channel_not_found error from slack deletes subscription 3`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:107153132" => true,
 }
 `;
 
@@ -60,150 +20,19 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel comments are updated when edited 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100403908",
-    ],
-    Array [
-      "creator-access#1:100403908",
-    ],
-    Array [
-      "channel#C002:issue#283007517",
-    ],
-    Array [
-      "channel#C002:comment#364284529",
-    ],
-    Array [
-      "creator-access#1:100403908",
-    ],
-    Array [
-      "channel#C002:issue#283007517",
-    ],
-    Array [
-      "creator-access#1:100403908",
-    ],
-    Array [
-      "channel#C002:comment#364284529",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:100403908",
+  "channel#C002:comment#364284529",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel comments are updated when edited 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100403908",
-      true,
-      600000,
-    ],
-    Array [
-      "creator-access#1:100403908",
-      true,
-      600000,
-    ],
-    Array [
-      "channel#C002:comment#364284529",
-      Object {
-        "channel": undefined,
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel comments are updated when edited 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100403908",
-      [Function],
-      600000,
-    ],
-    Array [
-      "creator-access#1:100403908",
-      [Function],
-      600000,
-    ],
-    Array [
-      "creator-access#1:100403908",
-      [Function],
-      600000,
-    ],
-    Array [
-      "creator-access#1:100403908",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:100403908" => true,
+  "channel#C002:comment#364284529" => Object {
+    "channel": undefined,
+    "ts": undefined,
+  },
 }
 `;
 
@@ -216,54 +45,14 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers force push with no commits 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:100427737",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers force push with no commits 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel delivers force push with no commits 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:100427737" => true,
 }
 `;
 
@@ -276,72 +65,19 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:123302024",
-    ],
-    Array [
-      "channel#C001:comment#171608320",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:123302024",
+  "channel#C001:comment#171608320",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:123302024",
-      true,
-      600000,
-    ],
-    Array [
-      "channel#C001:comment#171608320",
-      Object {
-        "channel": undefined,
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:123302024",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:123302024" => true,
+  "channel#C001:comment#171608320" => Object {
+    "channel": undefined,
+    "ts": undefined,
+  },
 }
 `;
 
@@ -354,54 +90,14 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers pushes on non default branch if enabled 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:107153132",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers pushes on non default branch if enabled 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel delivers pushes on non default branch if enabled 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:107153132" => true,
 }
 `;
 
@@ -414,54 +110,14 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers release notes by default 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:100427737",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers release notes by default 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel delivers release notes by default 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:100427737" => true,
 }
 `;
 
@@ -481,337 +137,87 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel deployment_status event 3`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-    ],
-    Array [
-      "channel#C001:deployment#57919058",
-    ],
-    Array [
-      "creator-access#1:100427737",
-    ],
-    Array [
-      "channel#C001:deployment#57919058",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:100427737",
+  "channel#C001:deployment#57919058",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel deployment_status event 4`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      true,
-      600000,
-    ],
-    Array [
-      "channel#C001:deployment#57919058",
-      Object {
-        "channel": undefined,
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel deployment_status event 5`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:100427737" => true,
+  "channel#C001:deployment#57919058" => Object {
+    "channel": undefined,
+    "ts": undefined,
+  },
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel do not post prompt to re-subscribe after user loses access to repo but the subscription is to an account 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+  "creator-access#1:100427737",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel do not post prompt to re-subscribe after user loses access to repo but the subscription is to an account 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
-      142600109,
-    ],
-    Array [
-      "creator-access#1:100427737",
-      false,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc" => 142600109,
+  "creator-access#1:100427737" => false,
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel do not post prompt to re-subscribe after user loses access to repo but the subscription is to an account 3`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 1`] = `Set {}`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 2`] = `Map {}`;
 
 exports[`Integration: notifications to a subscribed channel does not deliver empty reviews which are actually review comments 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:107153132",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel does not deliver empty reviews which are actually review comments 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:107153132" => true,
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel does not deliver empty reviews which are actually review comments 3`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 1`] = `Set {}`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 1`] = `[MockFunction cache.get]`;
+exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 2`] = `Map {}`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 2`] = `[MockFunction cache.set]`;
+exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 1`] = `Set {}`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 3`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 2`] = `Map {}`;
 
 exports[`Integration: notifications to a subscribed channel does not deliver push with no commits 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:100427737",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel does not deliver push with no commits 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel does not deliver push with no commits 3`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:100427737" => true,
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel does not deliver pushes on non-default branch if not explicitly enabled 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:107153132",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel does not deliver pushes on non-default branch if not explicitly enabled 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:107153132" => true,
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel does not deliver pushes on non-default branch if not explicitly enabled 3`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 1`] = `Set {}`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 2`] = `Map {}`;
 
 exports[`Integration: notifications to a subscribed channel issue opened 1`] = `
 Object {
@@ -822,65 +228,19 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel issue opened 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:107153132",
+  "channel#C001:issue#265831302",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel issue opened 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      true,
-      600000,
-    ],
-    Array [
-      "channel#C001:issue#265831302",
-      Object {
-        "channel": undefined,
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel issue opened 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:107153132" => true,
+  "channel#C001:issue#265831302" => Object {
+    "channel": undefined,
+    "ts": undefined,
+  },
 }
 `;
 
@@ -893,61 +253,14 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel issues closed does not make an API call to issues endpoint 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-    ],
-    Array [
-      "channel#C001:issue#265831302",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:107153132",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel issues closed does not make an API call to issues endpoint 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel issues closed does not make an API call to issues endpoint 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:107153132" => true,
 }
 `;
 
@@ -960,61 +273,14 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel issues reopened does not make an API call to issues endpoint 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-    ],
-    Array [
-      "channel#C001:issue#265831302",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:107153132",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel issues reopened does not make an API call to issues endpoint 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel issues reopened does not make an API call to issues endpoint 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:107153132" => true,
 }
 `;
 
@@ -1026,88 +292,19 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-    ],
-    Array [
-      "creator-access#1:107153132",
-    ],
-    Array [
-      "channel#C001:issue#265831302",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:107153132",
+  "channel#C001:issue#265831302",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      true,
-      600000,
-    ],
-    Array [
-      "channel#C001:issue#265831302",
-      Object {
-        "channel": undefined,
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:107153132" => true,
+  "channel#C001:issue#265831302" => Object {
+    "channel": undefined,
+    "ts": undefined,
+  },
 }
 `;
 
@@ -1119,104 +316,45 @@ Object {
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
-      142600109,
-    ],
-    Array [
-      "channel#C001:pull#142600109",
-      Object {
-        "channel": undefined,
-        "context": Object {
-          "number": 31,
-          "owner": "github-slack",
-          "repo": "app",
-        },
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 2`] = `
+Set {
+  "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+  "channel#C001:pull#142600109",
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 3`] = `
+Map {
+  "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc" => 142600109,
+  "channel#C001:pull#142600109" => Object {
+    "channel": undefined,
+    "context": Object {
+      "number": 31,
+      "owner": "github-slack",
+      "repo": "app",
+    },
+    "ts": undefined,
+  },
+}
+`;
 
-exports[`Integration: notifications to a subscribed channel nothing to do if githubId == ownerId but the subscription is for repos 1`] = `[MockFunction cache.get]`;
+exports[`Integration: notifications to a subscribed channel nothing to do if githubId == ownerId but the subscription is for repos 1`] = `Set {}`;
 
-exports[`Integration: notifications to a subscribed channel nothing to do if githubId == ownerId but the subscription is for repos 2`] = `[MockFunction cache.set]`;
+exports[`Integration: notifications to a subscribed channel nothing to do if githubId == ownerId but the subscription is for repos 2`] = `Map {}`;
 
-exports[`Integration: notifications to a subscribed channel nothing to do if githubId == ownerId but the subscription is for repos 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: notifications to a subscribed channel nothing to do if githubId == repoId but the subscription is for accounts 1`] = `Set {}`;
 
-exports[`Integration: notifications to a subscribed channel nothing to do if githubId == repoId but the subscription is for accounts 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: notifications to a subscribed channel nothing to do if githubId == repoId but the subscription is for accounts 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: notifications to a subscribed channel nothing to do if githubId == repoId but the subscription is for accounts 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: notifications to a subscribed channel nothing to do if githubId == repoId but the subscription is for accounts 2`] = `Map {}`;
 
 exports[`Integration: notifications to a subscribed channel other error from slack does not delete subscription 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:107153132",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel other error from slack does not delete subscription 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel other error from slack does not delete subscription 3`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:107153132" => true,
 }
 `;
 
@@ -1230,62 +368,16 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel post prompt to re-subscribe after user loses access to repo 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+  "creator-access#1:100427737",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel post prompt to re-subscribe after user loses access to repo 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
-      142600109,
-    ],
-    Array [
-      "creator-access#1:100427737",
-      false,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel post prompt to re-subscribe after user loses access to repo 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc" => 142600109,
+  "creator-access#1:100427737" => false,
 }
 `;
 
@@ -1298,54 +390,14 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel public event 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:115726862",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:115726862",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel public event 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:115726862",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel public event 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:115726862",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:115726862" => true,
 }
 `;
 
@@ -1358,54 +410,14 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request closed does not make an API call to issues endpoint 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:100427737",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request closed does not make an API call to issues endpoint 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel pull request closed does not make an API call to issues endpoint 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:100427737" => true,
 }
 `;
 
@@ -1418,78 +430,26 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request opened 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+  "creator-access#1:100427737",
+  "channel#C001:pull#142600109",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request opened 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
-      142600109,
-    ],
-    Array [
-      "creator-access#1:100427737",
-      true,
-      600000,
-    ],
-    Array [
-      "channel#C001:pull#142600109",
-      Object {
-        "channel": undefined,
-        "context": Object {
-          "number": 31,
-          "owner": "github-slack",
-          "repo": "app",
-        },
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
+Map {
+  "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc" => 142600109,
+  "creator-access#1:100427737" => true,
+  "channel#C001:pull#142600109" => Object {
+    "channel": undefined,
+    "context": Object {
+      "number": 31,
+      "owner": "github-slack",
+      "repo": "app",
     },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel pull request opened 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+    "ts": undefined,
+  },
 }
 `;
 
@@ -1509,108 +469,26 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request opened followed by status 3`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-    ],
-    Array [
-      "creator-access#1:100427737",
-    ],
-    Array [
-      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
-    ],
-    Array [
-      "channel#C001:pull#142600109",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
+  "creator-access#1:100427737",
+  "channel#C001:pull#142600109",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request opened followed by status 4`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
-      142600109,
-    ],
-    Array [
-      "creator-access#1:100427737",
-      true,
-      600000,
-    ],
-    Array [
-      "channel#C001:pull#142600109",
-      Object {
-        "channel": undefined,
-        "context": Object {
-          "number": 31,
-          "owner": "github-slack",
-          "repo": "app",
-        },
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
+Map {
+  "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc" => 142600109,
+  "creator-access#1:100427737" => true,
+  "channel#C001:pull#142600109" => Object {
+    "channel": undefined,
+    "context": Object {
+      "number": 31,
+      "owner": "github-slack",
+      "repo": "app",
     },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel pull request opened followed by status 5`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+    "ts": undefined,
+  },
 }
 `;
 
@@ -1623,54 +501,14 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:100427737",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:100427737" => true,
 }
 `;
 
@@ -1683,62 +521,20 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel ref event 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:107153132",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel ref event 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:107153132" => true,
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel ref event 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 1`] = `Set {}`;
 
-exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 2`] = `Map {}`;
 
 exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 1`] = `
 Object {
@@ -1748,17 +544,13 @@ Object {
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 2`] = `[MockFunction cache.get]`;
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 2`] = `Set {}`;
 
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 3`] = `[MockFunction cache.set]`;
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 3`] = `Map {}`;
 
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 1`] = `Set {}`;
 
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 2`] = `Map {}`;
 
 exports[`Integration: notifications to a subscribed channel review event 1`] = `
 Object {
@@ -1776,167 +568,35 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel review event 3`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-    ],
-    Array [
-      "channel#C001:review#97014958",
-    ],
-    Array [
-      "creator-access#1:107153132",
-    ],
-    Array [
-      "channel#C001:review#97014958",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:107153132",
+  "channel#C001:review#97014958",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel review event 4`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      true,
-      600000,
-    ],
-    Array [
-      "channel#C001:review#97014958",
-      Object {
-        "channel": undefined,
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:107153132" => true,
+  "channel#C001:review#97014958" => Object {
+    "channel": undefined,
+    "ts": undefined,
+  },
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel review event 5`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-    Array [
-      "creator-access#1:107153132",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 1`] = `Set {}`;
 
-exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 2`] = `Map {}`;
 
 exports[`Integration: notifications to a subscribed channel status event with no matching PR does not update a message 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-    ],
-    Array [
-      "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
-    ],
-    Array [
-      "channel#C001:pull#undefined",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:100427737",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel status event with no matching PR does not update a message 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      true,
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel status event with no matching PR does not update a message 3`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100427737",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:100427737" => true,
 }
 `;
 
@@ -1949,72 +609,19 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:16064378",
-    ],
-    Array [
-      "channel#C002:comment#30287269",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:16064378",
+  "channel#C002:comment#30287269",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:16064378",
-      true,
-      600000,
-    ],
-    Array [
-      "channel#C002:comment#30287269",
-      Object {
-        "channel": undefined,
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:16064378",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:16064378" => true,
+  "channel#C002:comment#30287269" => Object {
+    "channel": undefined,
+    "ts": undefined,
+  },
 }
 `;
 
@@ -2027,103 +634,18 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100403908",
-    ],
-    Array [
-      "creator-access#1:100403908",
-    ],
-    Array [
-      "channel#C002:issue#283007517",
-    ],
-    Array [
-      "channel#C002:comment#364284529",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "creator-access#1:100403908",
+  "channel#C002:comment#364284529",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100403908",
-      true,
-      600000,
-    ],
-    Array [
-      "creator-access#1:100403908",
-      true,
-      600000,
-    ],
-    Array [
-      "channel#C002:comment#364284529",
-      Object {
-        "channel": undefined,
-        "ts": undefined,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 4`] = `
-[MockFunction cache.fetch] {
-  "calls": Array [
-    Array [
-      "creator-access#1:100403908",
-      [Function],
-      600000,
-    ],
-    Array [
-      "creator-access#1:100403908",
-      [Function],
-      600000,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "creator-access#1:100403908" => true,
+  "channel#C002:comment#364284529" => Object {
+    "channel": undefined,
+    "ts": undefined,
+  },
 }
 `;

--- a/test/integration/__snapshots__/notifications.test.js.snap
+++ b/test/integration/__snapshots__/notifications.test.js.snap
@@ -1156,6 +1156,18 @@ exports[`Integration: notifications to a subscribed channel message still gets d
 
 exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 4`] = `[MockFunction cache.fetch]`;
 
+exports[`Integration: notifications to a subscribed channel nothing to do if githubId == ownerId but the subscription is for repos 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: notifications to a subscribed channel nothing to do if githubId == ownerId but the subscription is for repos 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: notifications to a subscribed channel nothing to do if githubId == ownerId but the subscription is for repos 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: notifications to a subscribed channel nothing to do if githubId == repoId but the subscription is for accounts 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: notifications to a subscribed channel nothing to do if githubId == repoId but the subscription is for accounts 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: notifications to a subscribed channel nothing to do if githubId == repoId but the subscription is for accounts 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: notifications to a subscribed channel other error from slack does not delete subscription 1`] = `
 [MockFunction cache.get] {
   "calls": Array [

--- a/test/integration/__snapshots__/notifications.test.js.snap
+++ b/test/integration/__snapshots__/notifications.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Integration: notifications to a subscribed channel channel_not_found error from slack deletes subscription 1`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -17,7 +17,7 @@ exports[`Integration: notifications to a subscribed channel channel_not_found er
 `;
 
 exports[`Integration: notifications to a subscribed channel channel_not_found error from slack deletes subscription 2`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -35,7 +35,7 @@ exports[`Integration: notifications to a subscribed channel channel_not_found er
 `;
 
 exports[`Integration: notifications to a subscribed channel channel_not_found error from slack deletes subscription 3`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -60,7 +60,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel comments are updated when edited 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100403908",
@@ -125,7 +125,7 @@ exports[`Integration: notifications to a subscribed channel comments are updated
 `;
 
 exports[`Integration: notifications to a subscribed channel comments are updated when edited 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:100403908",
@@ -163,7 +163,7 @@ exports[`Integration: notifications to a subscribed channel comments are updated
 `;
 
 exports[`Integration: notifications to a subscribed channel comments are updated when edited 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100403908",
@@ -216,7 +216,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers force push with no commits 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -232,7 +232,7 @@ exports[`Integration: notifications to a subscribed channel delivers force push 
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers force push with no commits 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -250,7 +250,7 @@ exports[`Integration: notifications to a subscribed channel delivers force push 
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers force push with no commits 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -276,7 +276,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:123302024",
@@ -299,7 +299,7 @@ exports[`Integration: notifications to a subscribed channel delivers pull reques
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:123302024",
@@ -328,7 +328,7 @@ exports[`Integration: notifications to a subscribed channel delivers pull reques
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:123302024",
@@ -354,7 +354,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers pushes on non default branch if enabled 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -370,7 +370,7 @@ exports[`Integration: notifications to a subscribed channel delivers pushes on n
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers pushes on non default branch if enabled 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -388,7 +388,7 @@ exports[`Integration: notifications to a subscribed channel delivers pushes on n
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers pushes on non default branch if enabled 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -414,7 +414,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers release notes by default 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -430,7 +430,7 @@ exports[`Integration: notifications to a subscribed channel delivers release not
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers release notes by default 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -448,7 +448,7 @@ exports[`Integration: notifications to a subscribed channel delivers release not
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers release notes by default 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -481,7 +481,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel deployment_status event 3`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -518,7 +518,7 @@ exports[`Integration: notifications to a subscribed channel deployment_status ev
 `;
 
 exports[`Integration: notifications to a subscribed channel deployment_status event 4`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -547,7 +547,7 @@ exports[`Integration: notifications to a subscribed channel deployment_status ev
 `;
 
 exports[`Integration: notifications to a subscribed channel deployment_status event 5`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -574,7 +574,7 @@ exports[`Integration: notifications to a subscribed channel deployment_status ev
 `;
 
 exports[`Integration: notifications to a subscribed channel do not post prompt to re-subscribe after user loses access to repo but the subscription is to an account 1`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -590,7 +590,7 @@ exports[`Integration: notifications to a subscribed channel do not post prompt t
 `;
 
 exports[`Integration: notifications to a subscribed channel do not post prompt to re-subscribe after user loses access to repo but the subscription is to an account 2`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
@@ -616,7 +616,7 @@ exports[`Integration: notifications to a subscribed channel do not post prompt t
 `;
 
 exports[`Integration: notifications to a subscribed channel do not post prompt to re-subscribe after user loses access to repo but the subscription is to an account 3`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -633,14 +633,14 @@ exports[`Integration: notifications to a subscribed channel do not post prompt t
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 1`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 1`] = `[MockFunction cache.get]`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 2`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 2`] = `[MockFunction cache.set]`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 3`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver commit comments if not explicitly enabled 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: notifications to a subscribed channel does not deliver empty reviews which are actually review comments 1`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -656,7 +656,7 @@ exports[`Integration: notifications to a subscribed channel does not deliver emp
 `;
 
 exports[`Integration: notifications to a subscribed channel does not deliver empty reviews which are actually review comments 2`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -674,7 +674,7 @@ exports[`Integration: notifications to a subscribed channel does not deliver emp
 `;
 
 exports[`Integration: notifications to a subscribed channel does not deliver empty reviews which are actually review comments 3`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -691,20 +691,20 @@ exports[`Integration: notifications to a subscribed channel does not deliver emp
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 1`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 1`] = `[MockFunction cache.get]`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 2`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 2`] = `[MockFunction cache.set]`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 3`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver issue comments if not explicitly enabled 3`] = `[MockFunction cache.fetch]`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 1`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 1`] = `[MockFunction cache.get]`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 2`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 2`] = `[MockFunction cache.set]`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 3`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver pull request review comments if not explicitly enabled 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: notifications to a subscribed channel does not deliver push with no commits 1`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -720,7 +720,7 @@ exports[`Integration: notifications to a subscribed channel does not deliver pus
 `;
 
 exports[`Integration: notifications to a subscribed channel does not deliver push with no commits 2`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -738,7 +738,7 @@ exports[`Integration: notifications to a subscribed channel does not deliver pus
 `;
 
 exports[`Integration: notifications to a subscribed channel does not deliver push with no commits 3`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -756,7 +756,7 @@ exports[`Integration: notifications to a subscribed channel does not deliver pus
 `;
 
 exports[`Integration: notifications to a subscribed channel does not deliver pushes on non-default branch if not explicitly enabled 1`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -772,7 +772,7 @@ exports[`Integration: notifications to a subscribed channel does not deliver pus
 `;
 
 exports[`Integration: notifications to a subscribed channel does not deliver pushes on non-default branch if not explicitly enabled 2`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -790,7 +790,7 @@ exports[`Integration: notifications to a subscribed channel does not deliver pus
 `;
 
 exports[`Integration: notifications to a subscribed channel does not deliver pushes on non-default branch if not explicitly enabled 3`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -807,11 +807,11 @@ exports[`Integration: notifications to a subscribed channel does not deliver pus
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 1`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 1`] = `[MockFunction cache.get]`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 2`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 2`] = `[MockFunction cache.set]`;
 
-exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 3`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel does not deliver release notes if explicitely disabled 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: notifications to a subscribed channel issue opened 1`] = `
 Object {
@@ -822,7 +822,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel issue opened 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -838,7 +838,7 @@ exports[`Integration: notifications to a subscribed channel issue opened 2`] = `
 `;
 
 exports[`Integration: notifications to a subscribed channel issue opened 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -867,7 +867,7 @@ exports[`Integration: notifications to a subscribed channel issue opened 3`] = `
 `;
 
 exports[`Integration: notifications to a subscribed channel issue opened 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -893,7 +893,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel issues closed does not make an API call to issues endpoint 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -916,7 +916,7 @@ exports[`Integration: notifications to a subscribed channel issues closed does n
 `;
 
 exports[`Integration: notifications to a subscribed channel issues closed does not make an API call to issues endpoint 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -934,7 +934,7 @@ exports[`Integration: notifications to a subscribed channel issues closed does n
 `;
 
 exports[`Integration: notifications to a subscribed channel issues closed does not make an API call to issues endpoint 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -960,7 +960,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel issues reopened does not make an API call to issues endpoint 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -983,7 +983,7 @@ exports[`Integration: notifications to a subscribed channel issues reopened does
 `;
 
 exports[`Integration: notifications to a subscribed channel issues reopened does not make an API call to issues endpoint 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1001,7 +1001,7 @@ exports[`Integration: notifications to a subscribed channel issues reopened does
 `;
 
 exports[`Integration: notifications to a subscribed channel issues reopened does not make an API call to issues endpoint 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1026,7 +1026,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1056,7 +1056,7 @@ exports[`Integration: notifications to a subscribed channel issues.edited update
 `;
 
 exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1085,7 +1085,7 @@ exports[`Integration: notifications to a subscribed channel issues.edited update
 `;
 
 exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1119,10 +1119,10 @@ Object {
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 2`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 2`] = `[MockFunction cache.get]`;
 
 exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
@@ -1154,10 +1154,10 @@ exports[`Integration: notifications to a subscribed channel message still gets d
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 4`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: notifications to a subscribed channel other error from slack does not delete subscription 1`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1173,7 +1173,7 @@ exports[`Integration: notifications to a subscribed channel other error from sla
 `;
 
 exports[`Integration: notifications to a subscribed channel other error from slack does not delete subscription 2`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1191,7 +1191,7 @@ exports[`Integration: notifications to a subscribed channel other error from sla
 `;
 
 exports[`Integration: notifications to a subscribed channel other error from slack does not delete subscription 3`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1218,7 +1218,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel post prompt to re-subscribe after user loses access to repo 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1234,7 +1234,7 @@ exports[`Integration: notifications to a subscribed channel post prompt to re-su
 `;
 
 exports[`Integration: notifications to a subscribed channel post prompt to re-subscribe after user loses access to repo 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
@@ -1260,7 +1260,7 @@ exports[`Integration: notifications to a subscribed channel post prompt to re-su
 `;
 
 exports[`Integration: notifications to a subscribed channel post prompt to re-subscribe after user loses access to repo 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1286,7 +1286,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel public event 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:115726862",
@@ -1302,7 +1302,7 @@ exports[`Integration: notifications to a subscribed channel public event 2`] = `
 `;
 
 exports[`Integration: notifications to a subscribed channel public event 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:115726862",
@@ -1320,7 +1320,7 @@ exports[`Integration: notifications to a subscribed channel public event 3`] = `
 `;
 
 exports[`Integration: notifications to a subscribed channel public event 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:115726862",
@@ -1346,7 +1346,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request closed does not make an API call to issues endpoint 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1362,7 +1362,7 @@ exports[`Integration: notifications to a subscribed channel pull request closed 
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request closed does not make an API call to issues endpoint 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1380,7 +1380,7 @@ exports[`Integration: notifications to a subscribed channel pull request closed 
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request closed does not make an API call to issues endpoint 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1406,7 +1406,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request opened 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1422,7 +1422,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request opened 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
@@ -1464,7 +1464,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request opened 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1497,7 +1497,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request opened followed by status 3`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1534,7 +1534,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request opened followed by status 4`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
@@ -1576,7 +1576,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request opened followed by status 5`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1611,7 +1611,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1627,7 +1627,7 @@ exports[`Integration: notifications to a subscribed channel pull request reopene
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1645,7 +1645,7 @@ exports[`Integration: notifications to a subscribed channel pull request reopene
 `;
 
 exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1671,7 +1671,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel ref event 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1687,7 +1687,7 @@ exports[`Integration: notifications to a subscribed channel ref event 2`] = `
 `;
 
 exports[`Integration: notifications to a subscribed channel ref event 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1705,7 +1705,7 @@ exports[`Integration: notifications to a subscribed channel ref event 3`] = `
 `;
 
 exports[`Integration: notifications to a subscribed channel ref event 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1722,11 +1722,11 @@ exports[`Integration: notifications to a subscribed channel ref event 4`] = `
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 1`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 1`] = `[MockFunction cache.get]`;
 
-exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 2`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 2`] = `[MockFunction cache.set]`;
 
-exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 3`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel ref event does not get delivered if not explicitly enabled 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 1`] = `
 Object {
@@ -1736,17 +1736,17 @@ Object {
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 2`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 2`] = `[MockFunction cache.get]`;
 
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 3`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 3`] = `[MockFunction cache.set]`;
 
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 4`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and deletes repository subcription 4`] = `[MockFunction cache.fetch]`;
 
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 1`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 1`] = `[MockFunction cache.get]`;
 
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 2`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 2`] = `[MockFunction cache.set]`;
 
-exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 3`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel repository.deleted posts to channel and does not delete account subscription 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: notifications to a subscribed channel review event 1`] = `
 Object {
@@ -1764,7 +1764,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel review event 3`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1801,7 +1801,7 @@ exports[`Integration: notifications to a subscribed channel review event 3`] = `
 `;
 
 exports[`Integration: notifications to a subscribed channel review event 4`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1830,7 +1830,7 @@ exports[`Integration: notifications to a subscribed channel review event 4`] = `
 `;
 
 exports[`Integration: notifications to a subscribed channel review event 5`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:107153132",
@@ -1856,14 +1856,14 @@ exports[`Integration: notifications to a subscribed channel review event 5`] = `
 }
 `;
 
-exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 1`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 1`] = `[MockFunction cache.get]`;
 
-exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 2`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 2`] = `[MockFunction cache.set]`;
 
-exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 3`] = `[MockFunction]`;
+exports[`Integration: notifications to a subscribed channel review event does not get delivered if not explicitly enabled 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: notifications to a subscribed channel status event with no matching PR does not update a message 1`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1893,7 +1893,7 @@ exports[`Integration: notifications to a subscribed channel status event with no
 `;
 
 exports[`Integration: notifications to a subscribed channel status event with no matching PR does not update a message 2`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1911,7 +1911,7 @@ exports[`Integration: notifications to a subscribed channel status event with no
 `;
 
 exports[`Integration: notifications to a subscribed channel status event with no matching PR does not update a message 3`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100427737",
@@ -1937,7 +1937,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:16064378",
@@ -1960,7 +1960,7 @@ exports[`Integration: notifications to a subscribed channel with comments enable
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:16064378",
@@ -1989,7 +1989,7 @@ exports[`Integration: notifications to a subscribed channel with comments enable
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:16064378",
@@ -2015,7 +2015,7 @@ Object {
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 2`] = `
-[MockFunction] {
+[MockFunction cache.get] {
   "calls": Array [
     Array [
       "creator-access#1:100403908",
@@ -2052,7 +2052,7 @@ exports[`Integration: notifications to a subscribed channel with comments enable
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 3`] = `
-[MockFunction] {
+[MockFunction cache.set] {
   "calls": Array [
     Array [
       "creator-access#1:100403908",
@@ -2090,7 +2090,7 @@ exports[`Integration: notifications to a subscribed channel with comments enable
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 4`] = `
-[MockFunction] {
+[MockFunction cache.fetch] {
   "calls": Array [
     Array [
       "creator-access#1:100403908",

--- a/test/integration/__snapshots__/signin.test.js.snap
+++ b/test/integration/__snapshots__/signin.test.js.snap
@@ -15,6 +15,55 @@ Object {
 }
 `;
 
+exports[`Integration: signin unauthenticated user is prompted to authenticate 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "signin",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: signin with a pending subscription redirects to install app and creates subscription 1`] = `
 Object {
   "attachments": Array [
@@ -26,3 +75,110 @@ Object {
   "response_type": "in_channel",
 }
 `;
+
+exports[`Integration: signin with a pending subscription redirects to install app and creates subscription 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin with a pending subscription redirects to install app and creates subscription 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin with a pending subscription redirects to install app and creates subscription 4`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/signin.test.js.snap
+++ b/test/integration/__snapshots__/signin.test.js.snap
@@ -15,6 +15,439 @@ Object {
 }
 `;
 
+exports[`Integration: signin unauthenticated user is prompted to authenticate 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "signin",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "close https://github.com/owner/repo/issues/123" 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "color": "#24292f",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+    },
+  ],
+  "response_type": "ephemeral",
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "close https://github.com/owner/repo/issues/123" 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "close https://github.com/owner/repo/issues/123" 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "close https://github.com/owner/repo/issues/123",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "close https://github.com/owner/repo/issues/123" 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "reopen https://github.com/owner/repo/issues/123" 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "color": "#24292f",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+    },
+  ],
+  "response_type": "ephemeral",
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "reopen https://github.com/owner/repo/issues/123" 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "reopen https://github.com/owner/repo/issues/123" 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "reopen https://github.com/owner/repo/issues/123",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "reopen https://github.com/owner/repo/issues/123" 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes" 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "color": "#24292f",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+    },
+  ],
+  "response_type": "ephemeral",
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes" 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes" 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes" 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes/kubernetes" 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "color": "#24292f",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+    },
+  ],
+  "response_type": "ephemeral",
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes/kubernetes" 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes/kubernetes" 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes/kubernetes" 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes" 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "color": "#24292f",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+    },
+  ],
+  "response_type": "ephemeral",
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes" 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes" 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "unsubscribe kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes" 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes/kubernetes" 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "color": "#24292f",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+    },
+  ],
+  "response_type": "ephemeral",
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes/kubernetes" 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes/kubernetes" 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "unsubscribe kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes/kubernetes" 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: signin with a pending subscription redirects to install app and creates subscription 1`] = `
 Object {
   "attachments": Array [

--- a/test/integration/__snapshots__/signin.test.js.snap
+++ b/test/integration/__snapshots__/signin.test.js.snap
@@ -16,53 +16,30 @@ Object {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "signin",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "signin",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: signin unauthenticated user is prompted to authenticate 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "close https://github.com/owner/repo/issues/123" 1`] = `
 Object {
@@ -80,53 +57,30 @@ Object {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "close https://github.com/owner/repo/issues/123" 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "close https://github.com/owner/repo/issues/123" 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "close https://github.com/owner/repo/issues/123",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "close https://github.com/owner/repo/issues/123",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "close https://github.com/owner/repo/issues/123" 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "reopen https://github.com/owner/repo/issues/123" 1`] = `
 Object {
@@ -144,53 +98,30 @@ Object {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "reopen https://github.com/owner/repo/issues/123" 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "reopen https://github.com/owner/repo/issues/123" 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "reopen https://github.com/owner/repo/issues/123",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "reopen https://github.com/owner/repo/issues/123",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "reopen https://github.com/owner/repo/issues/123" 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes" 1`] = `
 Object {
@@ -208,53 +139,30 @@ Object {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes" 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes" 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes" 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes/kubernetes" 1`] = `
 Object {
@@ -272,53 +180,30 @@ Object {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes/kubernetes" 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes/kubernetes" 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes/kubernetes" 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes" 1`] = `
 Object {
@@ -336,53 +221,30 @@ Object {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes" 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes" 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "unsubscribe kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "unsubscribe kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes" 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes/kubernetes" 1`] = `
 Object {
@@ -400,53 +262,30 @@ Object {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes/kubernetes" 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes/kubernetes" 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "unsubscribe kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "unsubscribe kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes/kubernetes" 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: signin with a pending subscription redirects to install app and creates subscription 1`] = `
 Object {
@@ -461,108 +300,27 @@ Object {
 `;
 
 exports[`Integration: signin with a pending subscription redirects to install app and creates subscription 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-    ],
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-    ],
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
 exports[`Integration: signin with a pending subscription redirects to install app and creates subscription 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: signin with a pending subscription redirects to install app and creates subscription 4`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/signout.test.js.snap
+++ b/test/integration/__snapshots__/signout.test.js.snap
@@ -21,40 +21,31 @@ exports[`Integration: signout a signed in user is successfully signed out and re
 Features like subscriptions and rich link previews will stop working. Use \`/github signin\` to sign back into your GitHub account at any time."
 `;
 
-exports[`Integration: signout a signed in user is successfully signed out and relevant subscriptions are deleted 4`] = `[MockFunction cache.get]`;
-
-exports[`Integration: signout a signed in user is successfully signed out and relevant subscriptions are deleted 5`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "signout",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: signout a signed in user is successfully signed out and relevant subscriptions are deleted 4`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: signout a signed in user is successfully signed out and relevant subscriptions are deleted 6`] = `[MockFunction cache.fetch]`;
+exports[`Integration: signout a signed in user is successfully signed out and relevant subscriptions are deleted 5`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "signout",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: signout a signed out user is prompted to sign in first 1`] = `
 Object {
@@ -72,50 +63,27 @@ Object {
 `;
 
 exports[`Integration: signout a signed out user is prompted to sign in first 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
 exports[`Integration: signout a signed out user is prompted to sign in first 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "signout",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "signout",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: signout a signed out user is prompted to sign in first 4`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/signout.test.js.snap
+++ b/test/integration/__snapshots__/signout.test.js.snap
@@ -21,6 +21,41 @@ exports[`Integration: signout a signed in user is successfully signed out and re
 Features like subscriptions and rich link previews will stop working. Use \`/github signin\` to sign back into your GitHub account at any time."
 `;
 
+exports[`Integration: signout a signed in user is successfully signed out and relevant subscriptions are deleted 4`] = `[MockFunction cache.get]`;
+
+exports[`Integration: signout a signed in user is successfully signed out and relevant subscriptions are deleted 5`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "signout",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signout a signed in user is successfully signed out and relevant subscriptions are deleted 6`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: signout a signed out user is prompted to sign in first 1`] = `
 Object {
   "attachments": Array [
@@ -35,3 +70,52 @@ Object {
   "response_type": "ephemeral",
 }
 `;
+
+exports[`Integration: signout a signed out user is prompted to sign in first 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signout a signed out user is prompted to sign in first 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "signout",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: signout a signed out user is prompted to sign in first 4`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/slack-events.test.js.snap
+++ b/test/integration/__snapshots__/slack-events.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Slack events POST /slack/events.url_verification responds with 400 if token is invalid 1`] = `[MockFunction cache.get]`;
+
+exports[`Slack events POST /slack/events.url_verification responds with 400 if token is invalid 2`] = `[MockFunction cache.set]`;
+
+exports[`Slack events POST /slack/events.url_verification responds with 400 if token is invalid 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Slack events POST /slack/events.url_verification responds with challenge if token matches 1`] = `[MockFunction cache.get]`;
+
+exports[`Slack events POST /slack/events.url_verification responds with challenge if token matches 2`] = `[MockFunction cache.set]`;
+
+exports[`Slack events POST /slack/events.url_verification responds with challenge if token matches 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/slack-events.test.js.snap
+++ b/test/integration/__snapshots__/slack-events.test.js.snap
@@ -1,13 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Slack events POST /slack/events.url_verification responds with 400 if token is invalid 1`] = `[MockFunction cache.get]`;
+exports[`Slack events POST /slack/events.url_verification responds with 400 if token is invalid 1`] = `Set {}`;
 
-exports[`Slack events POST /slack/events.url_verification responds with 400 if token is invalid 2`] = `[MockFunction cache.set]`;
+exports[`Slack events POST /slack/events.url_verification responds with 400 if token is invalid 2`] = `Map {}`;
 
-exports[`Slack events POST /slack/events.url_verification responds with 400 if token is invalid 3`] = `[MockFunction cache.fetch]`;
+exports[`Slack events POST /slack/events.url_verification responds with challenge if token matches 1`] = `Set {}`;
 
-exports[`Slack events POST /slack/events.url_verification responds with challenge if token matches 1`] = `[MockFunction cache.get]`;
-
-exports[`Slack events POST /slack/events.url_verification responds with challenge if token matches 2`] = `[MockFunction cache.set]`;
-
-exports[`Slack events POST /slack/events.url_verification responds with challenge if token matches 3`] = `[MockFunction cache.fetch]`;
+exports[`Slack events POST /slack/events.url_verification responds with challenge if token matches 2`] = `Map {}`;

--- a/test/integration/__snapshots__/slack-oauth.test.js.snap
+++ b/test/integration/__snapshots__/slack-oauth.test.js.snap
@@ -7,11 +7,9 @@ Object {
 }
 `;
 
-exports[`Integration: slack authentication /login 2`] = `[MockFunction cache.get]`;
+exports[`Integration: slack authentication /login 2`] = `Set {}`;
 
-exports[`Integration: slack authentication /login 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: slack authentication /login 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: slack authentication /login 3`] = `Map {}`;
 
 exports[`Integration: slack authentication allows all teams 1`] = `
 Object {
@@ -20,35 +18,25 @@ Object {
 }
 `;
 
-exports[`Integration: slack authentication allows all teams 2`] = `[MockFunction cache.get]`;
+exports[`Integration: slack authentication allows all teams 2`] = `Set {}`;
 
-exports[`Integration: slack authentication allows all teams 3`] = `[MockFunction cache.set]`;
+exports[`Integration: slack authentication allows all teams 3`] = `Map {}`;
 
-exports[`Integration: slack authentication allows all teams 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: slack authentication invalid state redirects to restart OAuth flow 1`] = `Set {}`;
 
-exports[`Integration: slack authentication invalid state redirects to restart OAuth flow 1`] = `[MockFunction cache.get]`;
+exports[`Integration: slack authentication invalid state redirects to restart OAuth flow 2`] = `Map {}`;
 
-exports[`Integration: slack authentication invalid state redirects to restart OAuth flow 2`] = `[MockFunction cache.set]`;
+exports[`Integration: slack authentication no session redirects to restart OAuth flow 1`] = `Set {}`;
 
-exports[`Integration: slack authentication invalid state redirects to restart OAuth flow 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: slack authentication no session redirects to restart OAuth flow 2`] = `Map {}`;
 
-exports[`Integration: slack authentication no session redirects to restart OAuth flow 1`] = `[MockFunction cache.get]`;
+exports[`Integration: slack authentication no state param redirects to restart OAuth flow 1`] = `Set {}`;
 
-exports[`Integration: slack authentication no session redirects to restart OAuth flow 2`] = `[MockFunction cache.set]`;
+exports[`Integration: slack authentication no state param redirects to restart OAuth flow 2`] = `Map {}`;
 
-exports[`Integration: slack authentication no session redirects to restart OAuth flow 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: slack authentication slack non-ok response redirects to restart OAuth flow 1`] = `Set {}`;
 
-exports[`Integration: slack authentication no state param redirects to restart OAuth flow 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: slack authentication no state param redirects to restart OAuth flow 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: slack authentication no state param redirects to restart OAuth flow 3`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: slack authentication slack non-ok response redirects to restart OAuth flow 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: slack authentication slack non-ok response redirects to restart OAuth flow 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: slack authentication slack non-ok response redirects to restart OAuth flow 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: slack authentication slack non-ok response redirects to restart OAuth flow 2`] = `Map {}`;
 
 exports[`Integration: slack authentication updates the access token 1`] = `
 Object {
@@ -57,14 +45,10 @@ Object {
 }
 `;
 
-exports[`Integration: slack authentication updates the access token 2`] = `[MockFunction cache.get]`;
+exports[`Integration: slack authentication updates the access token 2`] = `Set {}`;
 
-exports[`Integration: slack authentication updates the access token 3`] = `[MockFunction cache.set]`;
+exports[`Integration: slack authentication updates the access token 3`] = `Map {}`;
 
-exports[`Integration: slack authentication updates the access token 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: slack authentication user aborting oauth process redirects to restart OAuth flow 1`] = `Set {}`;
 
-exports[`Integration: slack authentication user aborting oauth process redirects to restart OAuth flow 1`] = `[MockFunction cache.get]`;
-
-exports[`Integration: slack authentication user aborting oauth process redirects to restart OAuth flow 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: slack authentication user aborting oauth process redirects to restart OAuth flow 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: slack authentication user aborting oauth process redirects to restart OAuth flow 2`] = `Map {}`;

--- a/test/integration/__snapshots__/slack-oauth.test.js.snap
+++ b/test/integration/__snapshots__/slack-oauth.test.js.snap
@@ -7,6 +7,12 @@ Object {
 }
 `;
 
+exports[`Integration: slack authentication /login 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: slack authentication /login 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: slack authentication /login 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: slack authentication allows all teams 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"text\\":\\"You've successfully installed GitHub on this Slack workspace :tada:\\\\nTo subscribe a channel to a repository use the following slash command:\\\\n/github subscribe owner/repository\\\\n\\",\\"fallback\\":\\"You've successfully installed GitHub on this Slack workspace :tada:\\\\nTo subscribe a channel to a repository use the following slash command:\\\\n/github subscribe owner/repository\\\\n\\"},{\\"color\\":\\"#24292f\\",\\"text\\":\\"Looking for additional help? Try /github help\\",\\"fallback\\":\\"Looking for additional help? Try /github help\\"}]",
@@ -14,9 +20,51 @@ Object {
 }
 `;
 
+exports[`Integration: slack authentication allows all teams 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: slack authentication allows all teams 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: slack authentication allows all teams 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: slack authentication invalid state redirects to restart OAuth flow 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: slack authentication invalid state redirects to restart OAuth flow 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: slack authentication invalid state redirects to restart OAuth flow 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: slack authentication no session redirects to restart OAuth flow 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: slack authentication no session redirects to restart OAuth flow 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: slack authentication no session redirects to restart OAuth flow 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: slack authentication no state param redirects to restart OAuth flow 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: slack authentication no state param redirects to restart OAuth flow 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: slack authentication no state param redirects to restart OAuth flow 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: slack authentication slack non-ok response redirects to restart OAuth flow 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: slack authentication slack non-ok response redirects to restart OAuth flow 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: slack authentication slack non-ok response redirects to restart OAuth flow 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: slack authentication updates the access token 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"text\\":\\"You've successfully installed GitHub on this Slack workspace :tada:\\\\nTo subscribe a channel to a repository use the following slash command:\\\\n/github subscribe owner/repository\\\\n\\",\\"fallback\\":\\"You've successfully installed GitHub on this Slack workspace :tada:\\\\nTo subscribe a channel to a repository use the following slash command:\\\\n/github subscribe owner/repository\\\\n\\"},{\\"color\\":\\"#24292f\\",\\"text\\":\\"Looking for additional help? Try /github help\\",\\"fallback\\":\\"Looking for additional help? Try /github help\\"}]",
   "token": "xoxa-a-b-c-d",
 }
 `;
+
+exports[`Integration: slack authentication updates the access token 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: slack authentication updates the access token 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: slack authentication updates the access token 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: slack authentication user aborting oauth process redirects to restart OAuth flow 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: slack authentication user aborting oauth process redirects to restart OAuth flow 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: slack authentication user aborting oauth process redirects to restart OAuth flow 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/slack-uninstall.test.js.snap
+++ b/test/integration/__snapshots__/slack-uninstall.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Uninstalling the slack app deletes all corresponding subscriptions 1`] = `[MockFunction cache.get]`;
+
+exports[`Uninstalling the slack app deletes all corresponding subscriptions 2`] = `[MockFunction cache.set]`;
+
+exports[`Uninstalling the slack app deletes all corresponding subscriptions 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/slack-uninstall.test.js.snap
+++ b/test/integration/__snapshots__/slack-uninstall.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Uninstalling the slack app deletes all corresponding subscriptions 1`] = `[MockFunction cache.get]`;
+exports[`Uninstalling the slack app deletes all corresponding subscriptions 1`] = `Set {}`;
 
-exports[`Uninstalling the slack app deletes all corresponding subscriptions 2`] = `[MockFunction cache.set]`;
-
-exports[`Uninstalling the slack app deletes all corresponding subscriptions 3`] = `[MockFunction cache.fetch]`;
+exports[`Uninstalling the slack app deletes all corresponding subscriptions 2`] = `Map {}`;

--- a/test/integration/__snapshots__/subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/subscriptions.test.js.snap
@@ -1,5 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C0D70MRAL",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration spread across multiple configurations 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration spread across multiple configurations 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C0D70MRAL",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration spread across multiple configurations 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo that's already reactivated works as normal 1`] = `
 Object {
   "attachments": Array [
@@ -36,6 +106,85 @@ Object {
 }
 `;
 
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo that's already reactivated works as normal 4`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo that's already reactivated works as normal 5`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C0D70MRAL",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C0D70MRAL",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "unsubscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C0D70MRAL",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo that's already reactivated works as normal 6`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo whose legacy configuration is not already reactivated is disabled 1`] = `
 Object {
   "payload": "{\\"action\\":\\"mark_subscribed\\",\\"repo\\":{\\"full_name\\":\\"atom/atom\\",\\"id\\":\\"3228505\\"},\\"service_type\\":\\"github\\"}",
@@ -56,6 +205,41 @@ Object {
 }
 `;
 
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo whose legacy configuration is not already reactivated is disabled 3`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo whose legacy configuration is not already reactivated is disabled 4`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C0D70MRAL",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo whose legacy configuration is not already reactivated is disabled 5`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that does not exist 1`] = `
 Object {
   "attachments": Array [
@@ -70,6 +254,41 @@ Object {
   "response_type": "ephemeral",
 }
 `;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that does not exist 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that does not exist 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that does not exist 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that the user does not have acccess to 1`] = `
 Object {
@@ -86,6 +305,76 @@ Object {
 }
 `;
 
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that the user does not have acccess to 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that the user does not have acccess to 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that the user does not have acccess to 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to an unknown feature 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to an unknown feature 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe bkeepers/dotenv foobar",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to an unknown feature 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing when already subscribed 1`] = `
 Object {
   "attachments": Array [
@@ -101,6 +390,41 @@ Object {
 }
 `;
 
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing when already subscribed 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing when already subscribed 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing when already subscribed 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing with a bad url 1`] = `
 Object {
   "attachments": Array [
@@ -115,6 +439,41 @@ Object {
   "response_type": "ephemeral",
 }
 `;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing with a bad url 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing with a bad url 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe something/not/ok",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing with a bad url 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to a repository 1`] = `
 Object {
@@ -140,6 +499,63 @@ Object {
 }
 `;
 
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to a repository 3`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to a repository 4`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe https://github.com/kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "unsubscribe https://github.com/kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to a repository 5`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to an organization 1`] = `
 Object {
   "attachments": Array [
@@ -164,6 +580,63 @@ Object {
 }
 `;
 
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to an organization 3`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to an organization 4`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe https://github.com/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "unsubscribe https://github.com/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to an organization 5`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with organization shorthand 1`] = `
 Object {
   "attachments": Array [
@@ -176,6 +649,41 @@ Object {
 }
 `;
 
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with organization shorthand 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with organization shorthand 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with organization shorthand 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with repository shorthand 1`] = `
 Object {
   "attachments": Array [
@@ -187,6 +695,41 @@ Object {
   "response_type": "in_channel",
 }
 `;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with repository shorthand 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with repository shorthand 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with repository shorthand 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing from a specific type of notification 1`] = `
 Object {
@@ -236,6 +779,85 @@ Object {
 }
 `;
 
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing from a specific type of notification 4`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing from a specific type of notification 5`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe bkeepers/dotenv",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "unsubscribe bkeepers/dotenv pulls issues",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe bkeepers/dotenv pulls, issues",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing from a specific type of notification 6`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing when not subscribed 1`] = `
 Object {
   "attachments": Array [
@@ -252,6 +874,41 @@ Use \`/github subscribe atom/atom\` to subscribe.",
 }
 `;
 
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing when not subscribed 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing when not subscribed 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "unsubscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing when not subscribed 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing with a bad url 1`] = `
 Object {
   "attachments": Array [
@@ -267,6 +924,41 @@ Object {
 }
 `;
 
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing with a bad url 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing with a bad url 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "unsubscribe something/not/ok",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing with a bad url 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user without the GitHub App installed organization is not found 1`] = `
 Object {
   "attachments": Array [
@@ -281,6 +973,41 @@ Object {
   "response_type": "ephemeral",
 }
 `;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed organization is not found 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed organization is not found 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed organization is not found 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is organization 1`] = `
 Object {
@@ -306,6 +1033,111 @@ _Note: You need to be an organization owner to install the app (or ask one to in
 }
 `;
 
+exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is organization 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is organization 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is organization 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is other user 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is other user 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe wilhelmklopp/wilhelmklopp",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is other user 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed prompts to install app 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed prompts to install app 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe atom/atom",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed prompts to install app 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: subscriptions authenticated user without the GitHub App installed user is repo owner 1`] = `
 Object {
   "attachments": Array [
@@ -328,3 +1160,108 @@ Object {
   "response_type": "ephemeral",
 }
 `;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed user is repo owner 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed user is repo owner 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe bkeepers/dotenv",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions authenticated user without the GitHub App installed user is repo owner 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: subscriptions unauthenticated user is prompted to authenticate before subscribing 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions unauthenticated user is prompted to authenticate before subscribing 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe https://github.com/kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions unauthenticated user is prompted to authenticate before subscribing 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: subscriptions unauthenticated user who exists but hasn	 linked their GitHub account yet is prompted to authenticate before subscribing 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: subscriptions unauthenticated user who exists but hasn	 linked their GitHub account yet is prompted to authenticate before subscribing 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "subscribe https://github.com/kubernetes/kubernetes",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: subscriptions unauthenticated user who exists but hasn	 linked their GitHub account yet is prompted to authenticate before subscribing 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/subscriptions.test.js.snap
@@ -1,74 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration 1`] = `[MockFunction cache.get]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C0D70MRAL",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C0D70MRAL",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe atom/atom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration 3`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration spread across multiple configurations 1`] = `[MockFunction cache.get]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration spread across multiple configurations 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration spread across multiple configurations 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C0D70MRAL",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C0D70MRAL",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: retains old configuration spread across multiple configurations 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo that's already reactivated works as normal 1`] = `
 Object {
@@ -106,84 +88,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo that's already reactivated works as normal 4`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo that's already reactivated works as normal 5`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C0D70MRAL",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C0D70MRAL",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "unsubscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C0D70MRAL",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo that's already reactivated works as normal 4`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo that's already reactivated works as normal 6`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo that's already reactivated works as normal 5`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C0D70MRAL",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe atom/atom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo whose legacy configuration is not already reactivated is disabled 1`] = `
 Object {
@@ -205,40 +134,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo whose legacy configuration is not already reactivated is disabled 3`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo whose legacy configuration is not already reactivated is disabled 4`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C0D70MRAL",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo whose legacy configuration is not already reactivated is disabled 3`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo whose legacy configuration is not already reactivated is disabled 5`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed Legacy subscriptions: subscribing to a repo whose legacy configuration is not already reactivated is disabled 4`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C0D70MRAL",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe atom/atom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that does not exist 1`] = `
 Object {
@@ -255,40 +175,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that does not exist 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that does not exist 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that does not exist 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that does not exist 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that does not exist 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe atom/atom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that the user does not have acccess to 1`] = `
 Object {
@@ -305,75 +216,57 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that the user does not have acccess to 2`] = `[MockFunction cache.get]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that the user does not have acccess to 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that the user does not have acccess to 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe atom/atom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to a repo that the user does not have acccess to 4`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to an unknown feature 1`] = `[MockFunction cache.get]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to an unknown feature 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to an unknown feature 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe bkeepers/dotenv foobar",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe bkeepers/dotenv foobar",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing to an unknown feature 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing when already subscribed 1`] = `
 Object {
@@ -390,40 +283,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing when already subscribed 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing when already subscribed 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing when already subscribed 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing when already subscribed 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing when already subscribed 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe atom/atom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing with a bad url 1`] = `
 Object {
@@ -440,40 +324,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing with a bad url 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing with a bad url 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe something/not/ok",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing with a bad url 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing with a bad url 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed subscribing with a bad url 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe something/not/ok",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to a repository 1`] = `
 Object {
@@ -499,62 +374,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to a repository 3`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to a repository 4`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe https://github.com/kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "unsubscribe https://github.com/kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to a repository 3`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to a repository 5`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to a repository 4`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "unsubscribe https://github.com/kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to an organization 1`] = `
 Object {
@@ -580,62 +424,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to an organization 3`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to an organization 4`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe https://github.com/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "unsubscribe https://github.com/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to an organization 3`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to an organization 5`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing and unsubscribing to an organization 4`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "unsubscribe https://github.com/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with organization shorthand 1`] = `
 Object {
@@ -649,40 +462,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with organization shorthand 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with organization shorthand 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with organization shorthand 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with organization shorthand 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with organization shorthand 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with repository shorthand 1`] = `
 Object {
@@ -696,40 +500,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with repository shorthand 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with repository shorthand 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with repository shorthand 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with repository shorthand 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed successfully subscribing with repository shorthand 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe atom/atom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing from a specific type of notification 1`] = `
 Object {
@@ -779,84 +574,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing from a specific type of notification 4`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing from a specific type of notification 5`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe bkeepers/dotenv",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "unsubscribe bkeepers/dotenv pulls issues",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe bkeepers/dotenv pulls, issues",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing from a specific type of notification 4`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing from a specific type of notification 6`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing from a specific type of notification 5`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe bkeepers/dotenv pulls, issues",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing when not subscribed 1`] = `
 Object {
@@ -874,40 +616,31 @@ Use \`/github subscribe atom/atom\` to subscribe.",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing when not subscribed 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing when not subscribed 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "unsubscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing when not subscribed 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing when not subscribed 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing when not subscribed 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "unsubscribe atom/atom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing with a bad url 1`] = `
 Object {
@@ -924,40 +657,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing with a bad url 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing with a bad url 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "unsubscribe something/not/ok",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing with a bad url 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing with a bad url 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user with GitHub App installed unsubscribing with a bad url 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "unsubscribe something/not/ok",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user without the GitHub App installed organization is not found 1`] = `
 Object {
@@ -974,40 +698,31 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user without the GitHub App installed organization is not found 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: subscriptions authenticated user without the GitHub App installed organization is not found 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: subscriptions authenticated user without the GitHub App installed organization is not found 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: subscriptions authenticated user without the GitHub App installed organization is not found 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: subscriptions authenticated user without the GitHub App installed organization is not found 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe atom/atom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is organization 1`] = `
 Object {
@@ -1033,110 +748,83 @@ _Note: You need to be an organization owner to install the app (or ask one to in
 }
 `;
 
-exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is organization 2`] = `[MockFunction cache.get]`;
+exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is organization 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is organization 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe atom/atom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
 
-exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is organization 4`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is other user 1`] = `[MockFunction cache.get]`;
+exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is other user 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is other user 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe wilhelmklopp/wilhelmklopp",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe wilhelmklopp/wilhelmklopp",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
 
-exports[`Integration: subscriptions authenticated user without the GitHub App installed owner type is other user 3`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: subscriptions authenticated user without the GitHub App installed prompts to install app 1`] = `[MockFunction cache.get]`;
+exports[`Integration: subscriptions authenticated user without the GitHub App installed prompts to install app 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscriptions authenticated user without the GitHub App installed prompts to install app 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe atom/atom",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe atom/atom",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: subscriptions authenticated user without the GitHub App installed prompts to install app 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: subscriptions authenticated user without the GitHub App installed user is repo owner 1`] = `
 Object {
@@ -1161,107 +849,80 @@ Object {
 }
 `;
 
-exports[`Integration: subscriptions authenticated user without the GitHub App installed user is repo owner 2`] = `[MockFunction cache.get]`;
+exports[`Integration: subscriptions authenticated user without the GitHub App installed user is repo owner 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscriptions authenticated user without the GitHub App installed user is repo owner 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe bkeepers/dotenv",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe bkeepers/dotenv",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
 
-exports[`Integration: subscriptions authenticated user without the GitHub App installed user is repo owner 4`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: subscriptions unauthenticated user is prompted to authenticate before subscribing 1`] = `[MockFunction cache.get]`;
+exports[`Integration: subscriptions unauthenticated user is prompted to authenticate before subscribing 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscriptions unauthenticated user is prompted to authenticate before subscribing 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe https://github.com/kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe https://github.com/kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
 
-exports[`Integration: subscriptions unauthenticated user is prompted to authenticate before subscribing 3`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: subscriptions unauthenticated user who exists but hasn	 linked their GitHub account yet is prompted to authenticate before subscribing 1`] = `[MockFunction cache.get]`;
+exports[`Integration: subscriptions unauthenticated user who exists but hasn	 linked their GitHub account yet is prompted to authenticate before subscribing 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: subscriptions unauthenticated user who exists but hasn	 linked their GitHub account yet is prompted to authenticate before subscribing 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "subscribe https://github.com/kubernetes/kubernetes",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe https://github.com/kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: subscriptions unauthenticated user who exists but hasn	 linked their GitHub account yet is prompted to authenticate before subscribing 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/unfurl.test.js.snap
+++ b/test/integration/__snapshots__/unfurl.test.js.snap
@@ -1521,26 +1521,6 @@ exports[`Integration: unfurls public unfurls fails silently when github.com unfu
 
 exports[`Integration: unfurls public unfurls fails silently when github.com unfurls are disabled in the workspace 3`] = `[MockFunction cache.fetch]`;
 
-exports[`Integration: unfurls public unfurls gracefully handles not found link 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: unfurls public unfurls gracefully handles not found link 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls public unfurls gracefully handles not found link 3`] = `[MockFunction cache.fetch]`;
-
 exports[`Integration: unfurls public unfurls gracefully handles not found link or private link without permissions 1`] = `
 [MockFunction cache.get] {
   "calls": Array [

--- a/test/integration/__snapshots__/unfurl.test.js.snap
+++ b/test/integration/__snapshots__/unfurl.test.js.snap
@@ -18,11 +18,101 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls private unfurls a user who does not have their GitHub account connected is gracefully onboarded 3`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls a user who does not have their GitHub account connected is gracefully onboarded 4`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls a user who does not have their GitHub account connected is gracefully onboarded 5`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls automatically unfurls private resources if they are part of subscribed repo 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls automatically unfurls private resources if they are part of subscribed repo 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls automatically unfurls private resources if they are part of subscribed repo 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls private unfurls clicking "Dismiss" deletes the prompt and the unfurl record 1`] = `
 Object {
   "delete_original": true,
 }
 `;
+
+exports[`Integration: unfurls private unfurls clicking "Dismiss" deletes the prompt and the unfurl record 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls clicking "Dismiss" deletes the prompt and the unfurl record 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls clicking "Dismiss" deletes the prompt and the unfurl record 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls clicking "Show rich preview" results in unfurl and deletes prompt 1`] = `
 Object {
@@ -68,6 +158,41 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls private unfurls clicking "Show rich preview" results in unfurl and deletes prompt 3`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls clicking "Show rich preview" results in unfurl and deletes prompt 4`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls clicking "Show rich preview" results in unfurl and deletes prompt 5`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected connecting their account via an Unfurl prompt of an invalid link results in a not found message 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"text\\":\\":white_check_mark: Success! <@U0Other> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>\\",\\"mrkdwn_in\\":[\\"text\\"]}]",
@@ -87,6 +212,141 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected connecting their account via an Unfurl prompt of an invalid link results in a not found message 3`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected connecting their account via an Unfurl prompt of an invalid link results in a not found message 4`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected connecting their account via an Unfurl prompt of an invalid link results in a not found message 5`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected if they also have prompts muted they will not see any prompts when posting links 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected if they also have prompts muted they will not see any prompts when posting links 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected if they also have prompts muted they will not see any prompts when posting links 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected public unfurls work as normal 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T0Other-C0Other-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected public unfurls work as normal 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T0Other-C0Other-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected public unfurls work as normal 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls no prompt is shown for unsupported resources 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv/some/random/thing",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls no prompt is shown for unsupported resources 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls no prompt is shown for unsupported resources 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls no prompt is shown when repo exists but resource does not 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv/issues/4000",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls no prompt is shown when repo exists but resource does not 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls no prompt is shown when repo exists but resource does not 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls no prompt is shown when repo returns 404 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls no prompt is shown when repo returns 404 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls no prompt is shown when repo returns 404 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls private unfurls on a workspace that has github.com unfurls disabled, an error message is shown to a user after graceful onboarding 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"text\\":\\":white_check_mark: Success! <@U0Other> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>\\",\\"mrkdwn_in\\":[\\"text\\"]}]",
@@ -105,6 +365,26 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls private unfurls on a workspace that has github.com unfurls disabled, an error message is shown to a user after graceful onboarding 3`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls on a workspace that has github.com unfurls disabled, an error message is shown to a user after graceful onboarding 4`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls on a workspace that has github.com unfurls disabled, an error message is shown to a user after graceful onboarding 5`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls private unfurls sending prompts works  1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"title\\":\\"Do you want to show a rich preview for https://github.com/bkeepers/dotenv?\\",\\"text\\":\\"The link you shared is from a private repository. Not everyone in this workspace may have access to the associated GitHub content.\\",\\"callback_id\\":\\"unfurl-123\\",\\"actions\\":[{\\"name\\":\\"unfurl\\",\\"text\\":\\"Show rich preview\\",\\"type\\":\\"button\\",\\"style\\":\\"primary\\"},{\\"name\\":\\"unfurl-dismiss\\",\\"text\\":\\"Dismiss\\",\\"type\\":\\"button\\"}]}]",
@@ -114,6 +394,26 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls private unfurls sending prompts works  2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C0Other-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls sending prompts works  3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls sending prompts works  4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls private unfurls sends prompt for private resource that can be unfurled 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"title\\":\\"Do you want to show a rich preview for https://github.com/bkeepers/dotenv?\\",\\"text\\":\\"The link you shared is from a private repository. Not everyone in this workspace may have access to the associated GitHub content.\\",\\"callback_id\\":\\"unfurl-123\\",\\"actions\\":[{\\"name\\":\\"unfurl\\",\\"text\\":\\"Show rich preview\\",\\"type\\":\\"button\\",\\"style\\":\\"primary\\"},{\\"name\\":\\"unfurl-dismiss\\",\\"text\\":\\"Dismiss\\",\\"type\\":\\"button\\"}]}]",
@@ -122,6 +422,147 @@ Object {
   "user": "U88HS",
 }
 `;
+
+exports[`Integration: unfurls private unfurls sends prompt for private resource that can be unfurled 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls sends prompt for private resource that can be unfurled 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls sends prompt for private resource that can be unfurled 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared after 24h does cause a prompt 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared after 24h does cause a prompt 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared after 24h does cause a prompt 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared within 24h does not cause a prompt 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared within 24h does not cause a prompt 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared within 24h does not cause a prompt 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" setting is saved in the database 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" setting is saved in the database 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" setting is saved in the database 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" A shared link does not cause a prompt 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" A shared link does not cause a prompt 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" A shared link does not cause a prompt 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" setting is saved in the database 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" setting is saved in the database 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" setting is saved in the database 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts for 24h", they get a confirmation message 1`] = `
 Object {
@@ -139,6 +580,26 @@ You can adjust this setting by invoking \`/github settings\`",
 }
 `;
 
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts for 24h", they get a confirmation message 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts for 24h", they get a confirmation message 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts for 24h", they get a confirmation message 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts indefinitely", they get a confirmation message 1`] = `
 Object {
   "attachments": Array [
@@ -155,6 +616,111 @@ You can adjust this setting by invoking \`/github settings\`",
 }
 `;
 
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts indefinitely", they get a confirmation message 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts indefinitely", they get a confirmation message 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts indefinitely", they get a confirmation message 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" setting is saved in the database 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" setting is saved in the database 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" setting is saved in the database 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link (to the same repo) shared in a different channel is automatically unfurled 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C0Other-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link (to the same repo) shared in a different channel is automatically unfurled 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+    Array [
+      "T000A-C0Other-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link (to the same repo) shared in a different channel is automatically unfurled 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link shared to a different repo results in a new prompt 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"title\\":\\"Do you want to show a rich preview for https://github.com/integrations/test?\\",\\"text\\":\\"The link you shared is from a private repository. Not everyone in this workspace may have access to the associated GitHub content.\\",\\"callback_id\\":\\"unfurl-123\\",\\"actions\\":[{\\"name\\":\\"unfurl\\",\\"text\\":\\"Show rich preview\\",\\"type\\":\\"button\\",\\"style\\":\\"primary\\"},{\\"name\\":\\"unfurl-dismiss\\",\\"text\\":\\"Dismiss\\",\\"type\\":\\"button\\"}]}]",
@@ -163,6 +729,168 @@ Object {
   "user": "U88HS",
 }
 `;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link shared to a different repo results in a new prompt 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/integrations/test",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link shared to a different repo results in a new prompt 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link shared to a different repo results in a new prompt 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" User can enable auto unfurls for the same repo in a different channel 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" User can enable auto unfurls for the same repo in a different channel 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" User can enable auto unfurls for the same repo in a different channel 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" setting is saved in the database 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" setting is saved in the database 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" setting is saved in the database 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link (to the same repo) shared in the same channel is automatically unfurled 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv/issues/1",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link (to the same repo) shared in the same channel is automatically unfurled 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv/issues/1",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link (to the same repo) shared in the same channel is automatically unfurled 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in a different channel results in a new prompt 1`] = `
 Object {
@@ -173,6 +901,48 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in a different channel results in a new prompt 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C0Other-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in a different channel results in a new prompt 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in a different channel results in a new prompt 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in the same channel to a different repo results in a new prompt 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#24292f\\",\\"title\\":\\"Do you want to show a rich preview for https://github.com/integrations/test?\\",\\"text\\":\\"The link you shared is from a private repository. Not everyone in this workspace may have access to the associated GitHub content.\\",\\"callback_id\\":\\"unfurl-123\\",\\"actions\\":[{\\"name\\":\\"unfurl\\",\\"text\\":\\"Show rich preview\\",\\"type\\":\\"button\\",\\"style\\":\\"primary\\"},{\\"name\\":\\"unfurl-dismiss\\",\\"text\\":\\"Dismiss\\",\\"type\\":\\"button\\"}]}]",
@@ -181,6 +951,48 @@ Object {
   "user": "U88HS",
 }
 `;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in the same channel to a different repo results in a new prompt 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/integrations/test",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in the same channel to a different repo results in a new prompt 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in the same channel to a different repo results in a new prompt 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for all channels", they get a confirmation message 1`] = `
 Object {
@@ -197,6 +1009,41 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for all channels", they get a confirmation message 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for all channels", they get a confirmation message 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for all channels", they get a confirmation message 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for this channel", they get a confirmation message 1`] = `
 Object {
   "attachments": Array [
@@ -211,6 +1058,41 @@ Object {
   "replace_original": true,
 }
 `;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for this channel", they get a confirmation message 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for this channel", they get a confirmation message 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for this channel", they get a confirmation message 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls settings when user clicks "dismiss" 5 times, the MutePromptsPrompt is shown 1`] = `
 Object {
@@ -266,11 +1148,106 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls private unfurls settings when user clicks "dismiss" 5 times, the MutePromptsPrompt is shown 6`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings when user clicks "dismiss" 5 times, the MutePromptsPrompt is shown 7`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls settings when user clicks "dismiss" 5 times, the MutePromptsPrompt is shown 8`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls private unfurls settings when user clicks "dismiss", no follow up prompt is immediately shown 1`] = `
 Object {
   "delete_original": true,
 }
 `;
+
+exports[`Integration: unfurls private unfurls settings when user clicks "dismiss", no follow up prompt is immediately shown 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls settings when user clicks "dismiss", no follow up prompt is immediately shown 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls settings when user clicks "dismiss", no follow up prompt is immediately shown 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls private unfurls throws error when user is not linked 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls throws error when user is not linked 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls throws error when user is not linked 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls unfurls resources that cannot be private (such as organisations) without looking up repo privacy 1`] = `
 Object {
@@ -280,6 +1257,41 @@ Object {
   "unfurls": "{\\"https://github.com/kubernetes\\":{\\"color\\":\\"#24292f\\",\\"footer\\":\\"<https://github.com/kubernetes|@kubernetes>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"fallback\\":\\"Kubernetes\\",\\"title\\":\\"Kubernetes\\",\\"text\\":\\"Kubernetes\\",\\"thumb_url\\":\\"https://avatars2.githubusercontent.com/u/13629408?v=4\\",\\"fields\\":[{\\"title\\":\\"URL\\",\\"value\\":\\"http://kubernetes.io\\",\\"short\\":true},{\\"title\\":\\"Repositories\\",\\"value\\":51,\\"short\\":true}],\\"ts\\":1438624543}}",
 }
 `;
+
+exports[`Integration: unfurls private unfurls unfurls resources that cannot be private (such as organisations) without looking up repo privacy 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/kubernetes",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls unfurls resources that cannot be private (such as organisations) without looking up repo privacy 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/kubernetes",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls unfurls resources that cannot be private (such as organisations) without looking up repo privacy 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls user sees error message when github.com unfurls are disabled in the workspace 1`] = `
 Object {
@@ -296,6 +1308,26 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls private unfurls user sees error message when github.com unfurls are disabled in the workspace 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls user sees error message when github.com unfurls are disabled in the workspace 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls private unfurls user sees error message when github.com unfurls are disabled in the workspace 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls private unfurls uses user access token for public resources 1`] = `
 Object {
   "channel": "C74M",
@@ -304,6 +1336,96 @@ Object {
   "unfurls": "{\\"https://github.com/bkeepers/dotenv\\":{\\"color\\":\\"#24292f\\",\\"footer\\":\\"<https://github.com/bkeepers/dotenv|bkeepers/dotenv>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"fallback\\":\\"bkeepers/dotenv\\",\\"title\\":\\"bkeepers/dotenv\\",\\"text\\":\\"A Ruby gem to load environment variables from \`.env\`. \\",\\"fields\\":[{\\"title\\":\\"Stars\\",\\"value\\":4230,\\"short\\":true},{\\"title\\":\\"Language\\",\\"value\\":\\"Ruby\\",\\"short\\":true}],\\"mrkdwn_in\\":[\\"text\\",\\"fields\\"],\\"ts\\":1343101131}}",
 }
 `;
+
+exports[`Integration: unfurls private unfurls uses user access token for public resources 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls uses user access token for public resources 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls private unfurls uses user access token for public resources 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls public unfurls Successful unfurl gets stored in db 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls Successful unfurl gets stored in db 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls Successful unfurl gets stored in db 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls public unfurls Unsuccessful unfurl does not get stored in db 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls Unsuccessful unfurl does not get stored in db 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls public unfurls Unsuccessful unfurl does not get stored in db 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 1`] = `
 Object {
@@ -323,6 +1445,122 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 3`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/facebook/react/issues/10191",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/atom/atom/issues/16292",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 4`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/atom/atom/issues/16292",
+      true,
+    ],
+    Array [
+      "T000A-C74M-https://github.com/facebook/react/issues/10191",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 5`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls public unfurls does not unfurl if more than 2 links 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: unfurls public unfurls does not unfurl if more than 2 links 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls public unfurls does not unfurl if more than 2 links 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls public unfurls fails silently when github.com unfurls are disabled in the workspace 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls fails silently when github.com unfurls are disabled in the workspace 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls public unfurls fails silently when github.com unfurls are disabled in the workspace 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls public unfurls gracefully handles not found link 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls gracefully handles not found link 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls public unfurls gracefully handles not found link 3`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls public unfurls gracefully handles unknown resources 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/probot/probot/issues",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls gracefully handles unknown resources 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls public unfurls gracefully handles unknown resources 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls public unfurls issue 1`] = `
 Object {
   "channel": "C74M",
@@ -332,6 +1570,41 @@ Object {
 }
 `;
 
+exports[`Integration: unfurls public unfurls issue 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls issue 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls issue 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls public unfurls only unfurls link first time a link is shared 1`] = `
 Object {
   "channel": "C74M",
@@ -340,3 +1613,65 @@ Object {
   "unfurls": "{\\"https://github.com/bkeepers/dotenv\\":{\\"color\\":\\"#24292f\\",\\"footer\\":\\"<https://github.com/bkeepers/dotenv|bkeepers/dotenv>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"fallback\\":\\"bkeepers/dotenv\\",\\"title\\":\\"bkeepers/dotenv\\",\\"text\\":\\"A Ruby gem to load environment variables from \`.env\`. \\",\\"fields\\":[{\\"title\\":\\"Stars\\",\\"value\\":4230,\\"short\\":true},{\\"title\\":\\"Language\\",\\"value\\":\\"Ruby\\",\\"short\\":true}],\\"mrkdwn_in\\":[\\"text\\",\\"fields\\"],\\"ts\\":1343101131}}",
 }
 `;
+
+exports[`Integration: unfurls public unfurls only unfurls link first time a link is shared 2`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls only unfurls link first time a link is shared 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+      true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls only unfurls link first time a link is shared 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: unfurls public unfurls renders 500 when other error happens 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls renders 500 when other error happens 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls public unfurls renders 500 when other error happens 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/unfurl.test.js.snap
+++ b/test/integration/__snapshots__/unfurl.test.js.snap
@@ -19,74 +19,28 @@ Object {
 `;
 
 exports[`Integration: unfurls private unfurls a user who does not have their GitHub account connected is gracefully onboarded 3`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls a user who does not have their GitHub account connected is gracefully onboarded 4`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
 
-exports[`Integration: unfurls private unfurls a user who does not have their GitHub account connected is gracefully onboarded 5`] = `[MockFunction cache.fetch]`;
-
 exports[`Integration: unfurls private unfurls automatically unfurls private resources if they are part of subscribed repo 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls automatically unfurls private resources if they are part of subscribed repo 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
-
-exports[`Integration: unfurls private unfurls automatically unfurls private resources if they are part of subscribed repo 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls clicking "Dismiss" deletes the prompt and the unfurl record 1`] = `
 Object {
@@ -94,25 +48,9 @@ Object {
 }
 `;
 
-exports[`Integration: unfurls private unfurls clicking "Dismiss" deletes the prompt and the unfurl record 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls clicking "Dismiss" deletes the prompt and the unfurl record 2`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls clicking "Dismiss" deletes the prompt and the unfurl record 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls clicking "Dismiss" deletes the prompt and the unfurl record 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls clicking "Dismiss" deletes the prompt and the unfurl record 3`] = `Map {}`;
 
 exports[`Integration: unfurls private unfurls clicking "Show rich preview" results in unfurl and deletes prompt 1`] = `
 Object {
@@ -159,39 +97,16 @@ Object {
 `;
 
 exports[`Integration: unfurls private unfurls clicking "Show rich preview" results in unfurl and deletes prompt 3`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls clicking "Show rich preview" results in unfurl and deletes prompt 4`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
-
-exports[`Integration: unfurls private unfurls clicking "Show rich preview" results in unfurl and deletes prompt 5`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected connecting their account via an Unfurl prompt of an invalid link results in a not found message 1`] = `
 Object {
@@ -212,140 +127,37 @@ Object {
 }
 `;
 
-exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected connecting their account via an Unfurl prompt of an invalid link results in a not found message 3`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected connecting their account via an Unfurl prompt of an invalid link results in a not found message 3`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected connecting their account via an Unfurl prompt of an invalid link results in a not found message 4`] = `[MockFunction cache.set]`;
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected connecting their account via an Unfurl prompt of an invalid link results in a not found message 4`] = `Map {}`;
 
-exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected connecting their account via an Unfurl prompt of an invalid link results in a not found message 5`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected if they also have prompts muted they will not see any prompts when posting links 1`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected if they also have prompts muted they will not see any prompts when posting links 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected if they also have prompts muted they will not see any prompts when posting links 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected if they also have prompts muted they will not see any prompts when posting links 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected if they also have prompts muted they will not see any prompts when posting links 2`] = `Map {}`;
 
 exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected public unfurls work as normal 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T0Other-C0Other-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T0Other-C0Other-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected public unfurls work as normal 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T0Other-C0Other-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T0Other-C0Other-https://github.com/bkeepers/dotenv" => true,
 }
 `;
 
-exports[`Integration: unfurls private unfurls for users who do not yet have their GitHub account connected public unfurls work as normal 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls no prompt is shown for unsupported resources 1`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls no prompt is shown for unsupported resources 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv/some/random/thing",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls no prompt is shown for unsupported resources 2`] = `Map {}`;
 
-exports[`Integration: unfurls private unfurls no prompt is shown for unsupported resources 2`] = `[MockFunction cache.set]`;
+exports[`Integration: unfurls private unfurls no prompt is shown when repo exists but resource does not 1`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls no prompt is shown for unsupported resources 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls no prompt is shown when repo exists but resource does not 2`] = `Map {}`;
 
-exports[`Integration: unfurls private unfurls no prompt is shown when repo exists but resource does not 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv/issues/4000",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls no prompt is shown when repo returns 404 1`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls no prompt is shown when repo exists but resource does not 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls no prompt is shown when repo exists but resource does not 3`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: unfurls private unfurls no prompt is shown when repo returns 404 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: unfurls private unfurls no prompt is shown when repo returns 404 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls no prompt is shown when repo returns 404 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls no prompt is shown when repo returns 404 2`] = `Map {}`;
 
 exports[`Integration: unfurls private unfurls on a workspace that has github.com unfurls disabled, an error message is shown to a user after graceful onboarding 1`] = `
 Object {
@@ -365,25 +177,9 @@ Object {
 }
 `;
 
-exports[`Integration: unfurls private unfurls on a workspace that has github.com unfurls disabled, an error message is shown to a user after graceful onboarding 3`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls on a workspace that has github.com unfurls disabled, an error message is shown to a user after graceful onboarding 3`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls on a workspace that has github.com unfurls disabled, an error message is shown to a user after graceful onboarding 4`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls on a workspace that has github.com unfurls disabled, an error message is shown to a user after graceful onboarding 5`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls on a workspace that has github.com unfurls disabled, an error message is shown to a user after graceful onboarding 4`] = `Map {}`;
 
 exports[`Integration: unfurls private unfurls sending prompts works  1`] = `
 Object {
@@ -394,25 +190,9 @@ Object {
 }
 `;
 
-exports[`Integration: unfurls private unfurls sending prompts works  2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C0Other-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls sending prompts works  2`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls sending prompts works  3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls sending prompts works  4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls sending prompts works  3`] = `Map {}`;
 
 exports[`Integration: unfurls private unfurls sends prompt for private resource that can be unfurled 1`] = `
 Object {
@@ -423,146 +203,29 @@ Object {
 }
 `;
 
-exports[`Integration: unfurls private unfurls sends prompt for private resource that can be unfurled 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls sends prompt for private resource that can be unfurled 2`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls sends prompt for private resource that can be unfurled 3`] = `[MockFunction cache.set]`;
+exports[`Integration: unfurls private unfurls sends prompt for private resource that can be unfurled 3`] = `Map {}`;
 
-exports[`Integration: unfurls private unfurls sends prompt for private resource that can be unfurled 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared after 24h does cause a prompt 1`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared after 24h does cause a prompt 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared after 24h does cause a prompt 2`] = `Map {}`;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared after 24h does cause a prompt 2`] = `[MockFunction cache.set]`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared within 24h does not cause a prompt 1`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared after 24h does cause a prompt 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared within 24h does not cause a prompt 2`] = `Map {}`;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared within 24h does not cause a prompt 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" setting is saved in the database 1`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared within 24h does not cause a prompt 2`] = `[MockFunction cache.set]`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" setting is saved in the database 2`] = `Map {}`;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" A link shared within 24h does not cause a prompt 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" A shared link does not cause a prompt 1`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" setting is saved in the database 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" A shared link does not cause a prompt 2`] = `Map {}`;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" setting is saved in the database 2`] = `[MockFunction cache.set]`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" setting is saved in the database 1`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts for 24h" setting is saved in the database 3`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" A shared link does not cause a prompt 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" A shared link does not cause a prompt 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" A shared link does not cause a prompt 3`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" setting is saved in the database 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" setting is saved in the database 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" setting is saved in the database 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt User clicks "Mute prompts indefinitely" setting is saved in the database 2`] = `Map {}`;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts for 24h", they get a confirmation message 1`] = `
 Object {
@@ -580,25 +243,9 @@ You can adjust this setting by invoking \`/github settings\`",
 }
 `;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts for 24h", they get a confirmation message 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts for 24h", they get a confirmation message 2`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts for 24h", they get a confirmation message 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts for 24h", they get a confirmation message 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts for 24h", they get a confirmation message 3`] = `Map {}`;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts indefinitely", they get a confirmation message 1`] = `
 Object {
@@ -616,110 +263,35 @@ You can adjust this setting by invoking \`/github settings\`",
 }
 `;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts indefinitely", they get a confirmation message 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts indefinitely", they get a confirmation message 2`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts indefinitely", they get a confirmation message 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts indefinitely", they get a confirmation message 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls settings User clicks "Dismiss" and gets MutePromptsPrompt When user clicks "Mute prompts indefinitely", they get a confirmation message 3`] = `Map {}`;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" setting is saved in the database 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" setting is saved in the database 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" setting is saved in the database 3`] = `[MockFunction cache.fetch]`;
-
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link (to the same repo) shared in a different channel is automatically unfurled 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C0Other-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
+  "T000A-C0Other-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link (to the same repo) shared in a different channel is automatically unfurled 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-    Array [
-      "T000A-C0Other-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
+  "T000A-C0Other-https://github.com/bkeepers/dotenv" => true,
 }
 `;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link (to the same repo) shared in a different channel is automatically unfurled 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link shared to a different repo results in a new prompt 1`] = `
 Object {
@@ -731,166 +303,54 @@ Object {
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link shared to a different repo results in a new prompt 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/integrations/test",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link shared to a different repo results in a new prompt 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for all channels" subsequent link shared to a different repo results in a new prompt 4`] = `[MockFunction cache.fetch]`;
-
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" User can enable auto unfurls for the same repo in a different channel 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" User can enable auto unfurls for the same repo in a different channel 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" User can enable auto unfurls for the same repo in a different channel 3`] = `[MockFunction cache.fetch]`;
-
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" setting is saved in the database 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" setting is saved in the database 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
 
-exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" setting is saved in the database 3`] = `[MockFunction cache.fetch]`;
-
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link (to the same repo) shared in the same channel is automatically unfurled 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv/issues/1",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
+  "T000A-C74M-https://github.com/bkeepers/dotenv/issues/1",
 }
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link (to the same repo) shared in the same channel is automatically unfurled 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv/issues/1",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
+  "T000A-C74M-https://github.com/bkeepers/dotenv/issues/1" => true,
 }
 `;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link (to the same repo) shared in the same channel is automatically unfurled 3`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in a different channel results in a new prompt 1`] = `
 Object {
@@ -902,46 +362,16 @@ Object {
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in a different channel results in a new prompt 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C0Other-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in a different channel results in a new prompt 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in a different channel results in a new prompt 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in the same channel to a different repo results in a new prompt 1`] = `
 Object {
@@ -953,46 +383,16 @@ Object {
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in the same channel to a different repo results in a new prompt 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/integrations/test",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in the same channel to a different repo results in a new prompt 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt User clicks "Enable for this channel" subsequent link shared in the same channel to a different repo results in a new prompt 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for all channels", they get a confirmation message 1`] = `
 Object {
@@ -1010,39 +410,16 @@ Object {
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for all channels", they get a confirmation message 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for all channels", they get a confirmation message 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for all channels", they get a confirmation message 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for this channel", they get a confirmation message 1`] = `
 Object {
@@ -1060,39 +437,16 @@ Object {
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for this channel", they get a confirmation message 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for this channel", they get a confirmation message 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
-
-exports[`Integration: unfurls private unfurls settings User clicks "Show rich preview" and gets AutoUnfurlPrompt when user clicks "Enable for this channel", they get a confirmation message 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls settings when user clicks "dismiss" 5 times, the MutePromptsPrompt is shown 1`] = `
 Object {
@@ -1148,60 +502,9 @@ Object {
 }
 `;
 
-exports[`Integration: unfurls private unfurls settings when user clicks "dismiss" 5 times, the MutePromptsPrompt is shown 6`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls settings when user clicks "dismiss" 5 times, the MutePromptsPrompt is shown 6`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls settings when user clicks "dismiss" 5 times, the MutePromptsPrompt is shown 7`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls settings when user clicks "dismiss" 5 times, the MutePromptsPrompt is shown 8`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls settings when user clicks "dismiss" 5 times, the MutePromptsPrompt is shown 7`] = `Map {}`;
 
 exports[`Integration: unfurls private unfurls settings when user clicks "dismiss", no follow up prompt is immediately shown 1`] = `
 Object {
@@ -1209,45 +512,13 @@ Object {
 }
 `;
 
-exports[`Integration: unfurls private unfurls settings when user clicks "dismiss", no follow up prompt is immediately shown 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls settings when user clicks "dismiss", no follow up prompt is immediately shown 2`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls settings when user clicks "dismiss", no follow up prompt is immediately shown 3`] = `[MockFunction cache.set]`;
+exports[`Integration: unfurls private unfurls settings when user clicks "dismiss", no follow up prompt is immediately shown 3`] = `Map {}`;
 
-exports[`Integration: unfurls private unfurls settings when user clicks "dismiss", no follow up prompt is immediately shown 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls throws error when user is not linked 1`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls throws error when user is not linked 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: unfurls private unfurls throws error when user is not linked 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls throws error when user is not linked 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls throws error when user is not linked 2`] = `Map {}`;
 
 exports[`Integration: unfurls private unfurls unfurls resources that cannot be private (such as organisations) without looking up repo privacy 1`] = `
 Object {
@@ -1259,39 +530,16 @@ Object {
 `;
 
 exports[`Integration: unfurls private unfurls unfurls resources that cannot be private (such as organisations) without looking up repo privacy 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/kubernetes",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/kubernetes",
 }
 `;
 
 exports[`Integration: unfurls private unfurls unfurls resources that cannot be private (such as organisations) without looking up repo privacy 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/kubernetes",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/kubernetes" => true,
 }
 `;
-
-exports[`Integration: unfurls private unfurls unfurls resources that cannot be private (such as organisations) without looking up repo privacy 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls private unfurls user sees error message when github.com unfurls are disabled in the workspace 1`] = `
 Object {
@@ -1308,25 +556,9 @@ Object {
 }
 `;
 
-exports[`Integration: unfurls private unfurls user sees error message when github.com unfurls are disabled in the workspace 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls private unfurls user sees error message when github.com unfurls are disabled in the workspace 2`] = `Set {}`;
 
-exports[`Integration: unfurls private unfurls user sees error message when github.com unfurls are disabled in the workspace 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls private unfurls user sees error message when github.com unfurls are disabled in the workspace 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls private unfurls user sees error message when github.com unfurls are disabled in the workspace 3`] = `Map {}`;
 
 exports[`Integration: unfurls private unfurls uses user access token for public resources 1`] = `
 Object {
@@ -1338,94 +570,32 @@ Object {
 `;
 
 exports[`Integration: unfurls private unfurls uses user access token for public resources 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls private unfurls uses user access token for public resources 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
 
-exports[`Integration: unfurls private unfurls uses user access token for public resources 4`] = `[MockFunction cache.fetch]`;
-
 exports[`Integration: unfurls public unfurls Successful unfurl gets stored in db 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls public unfurls Successful unfurl gets stored in db 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
 
-exports[`Integration: unfurls public unfurls Successful unfurl gets stored in db 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls public unfurls Unsuccessful unfurl does not get stored in db 1`] = `Set {}`;
 
-exports[`Integration: unfurls public unfurls Unsuccessful unfurl does not get stored in db 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: unfurls public unfurls Unsuccessful unfurl does not get stored in db 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls public unfurls Unsuccessful unfurl does not get stored in db 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls public unfurls Unsuccessful unfurl does not get stored in db 2`] = `Map {}`;
 
 exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 1`] = `
 Object {
@@ -1446,120 +616,34 @@ Object {
 `;
 
 exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 3`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/facebook/react/issues/10191",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/atom/atom/issues/16292",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/facebook/react/issues/10191",
+  "T000A-C74M-https://github.com/atom/atom/issues/16292",
 }
 `;
 
 exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 4`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/facebook/react/issues/10191",
-      true,
-    ],
-    Array [
-      "T000A-C74M-https://github.com/atom/atom/issues/16292",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/facebook/react/issues/10191" => true,
+  "T000A-C74M-https://github.com/atom/atom/issues/16292" => true,
 }
 `;
 
-exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 5`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls public unfurls does not unfurl if more than 2 links 1`] = `Set {}`;
 
-exports[`Integration: unfurls public unfurls does not unfurl if more than 2 links 1`] = `[MockFunction cache.get]`;
+exports[`Integration: unfurls public unfurls does not unfurl if more than 2 links 2`] = `Map {}`;
 
-exports[`Integration: unfurls public unfurls does not unfurl if more than 2 links 2`] = `[MockFunction cache.set]`;
+exports[`Integration: unfurls public unfurls fails silently when github.com unfurls are disabled in the workspace 1`] = `Set {}`;
 
-exports[`Integration: unfurls public unfurls does not unfurl if more than 2 links 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls public unfurls fails silently when github.com unfurls are disabled in the workspace 2`] = `Map {}`;
 
-exports[`Integration: unfurls public unfurls fails silently when github.com unfurls are disabled in the workspace 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
+exports[`Integration: unfurls public unfurls gracefully handles not found link or private link without permissions 1`] = `Set {}`;
 
-exports[`Integration: unfurls public unfurls fails silently when github.com unfurls are disabled in the workspace 2`] = `[MockFunction cache.set]`;
+exports[`Integration: unfurls public unfurls gracefully handles not found link or private link without permissions 2`] = `Map {}`;
 
-exports[`Integration: unfurls public unfurls fails silently when github.com unfurls are disabled in the workspace 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls public unfurls gracefully handles unknown resources 1`] = `Set {}`;
 
-exports[`Integration: unfurls public unfurls gracefully handles not found link or private link without permissions 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: unfurls public unfurls gracefully handles not found link or private link without permissions 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls public unfurls gracefully handles not found link or private link without permissions 3`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: unfurls public unfurls gracefully handles unknown resources 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/probot/probot/issues",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: unfurls public unfurls gracefully handles unknown resources 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls public unfurls gracefully handles unknown resources 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls public unfurls gracefully handles unknown resources 2`] = `Map {}`;
 
 exports[`Integration: unfurls public unfurls issue 1`] = `
 Object {
@@ -1571,39 +655,16 @@ Object {
 `;
 
 exports[`Integration: unfurls public unfurls issue 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls public unfurls issue 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
-
-exports[`Integration: unfurls public unfurls issue 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: unfurls public unfurls only unfurls link first time a link is shared 1`] = `
 Object {
@@ -1615,63 +676,17 @@ Object {
 `;
 
 exports[`Integration: unfurls public unfurls only unfurls link first time a link is shared 2`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Set {
+  "T000A-C74M-https://github.com/bkeepers/dotenv",
 }
 `;
 
 exports[`Integration: unfurls public unfurls only unfurls link first time a link is shared 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-      true,
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "T000A-C74M-https://github.com/bkeepers/dotenv" => true,
 }
 `;
 
-exports[`Integration: unfurls public unfurls only unfurls link first time a link is shared 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls public unfurls renders 500 when other error happens 1`] = `Set {}`;
 
-exports[`Integration: unfurls public unfurls renders 500 when other error happens 1`] = `
-[MockFunction cache.get] {
-  "calls": Array [
-    Array [
-      "T000A-C74M-https://github.com/bkeepers/dotenv",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`Integration: unfurls public unfurls renders 500 when other error happens 2`] = `[MockFunction cache.set]`;
-
-exports[`Integration: unfurls public unfurls renders 500 when other error happens 3`] = `[MockFunction cache.fetch]`;
+exports[`Integration: unfurls public unfurls renders 500 when other error happens 2`] = `Map {}`;

--- a/test/integration/__snapshots__/unfurl.test.js.snap
+++ b/test/integration/__snapshots__/unfurl.test.js.snap
@@ -1541,6 +1541,26 @@ exports[`Integration: unfurls public unfurls gracefully handles not found link 2
 
 exports[`Integration: unfurls public unfurls gracefully handles not found link 3`] = `[MockFunction cache.fetch]`;
 
+exports[`Integration: unfurls public unfurls gracefully handles not found link or private link without permissions 1`] = `
+[MockFunction cache.get] {
+  "calls": Array [
+    Array [
+      "T000A-C74M-https://github.com/bkeepers/dotenv",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: unfurls public unfurls gracefully handles not found link or private link without permissions 2`] = `[MockFunction cache.set]`;
+
+exports[`Integration: unfurls public unfurls gracefully handles not found link or private link without permissions 3`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: unfurls public unfurls gracefully handles unknown resources 1`] = `
 [MockFunction cache.get] {
   "calls": Array [

--- a/test/integration/__snapshots__/unfurl.test.js.snap
+++ b/test/integration/__snapshots__/unfurl.test.js.snap
@@ -1472,11 +1472,11 @@ exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are sh
 [MockFunction cache.set] {
   "calls": Array [
     Array [
-      "T000A-C74M-https://github.com/atom/atom/issues/16292",
+      "T000A-C74M-https://github.com/facebook/react/issues/10191",
       true,
     ],
     Array [
-      "T000A-C74M-https://github.com/facebook/react/issues/10191",
+      "T000A-C74M-https://github.com/atom/atom/issues/16292",
       true,
     ],
   ],

--- a/test/integration/__snapshots__/user-settings.test.js.snap
+++ b/test/integration/__snapshots__/user-settings.test.js.snap
@@ -43,6 +43,41 @@ Object {
 }
 `;
 
+exports[`Integration: User settings authenticated user with both automatic unfurls configured and prompts muted sees both settings 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: User settings authenticated user with both automatic unfurls configured and prompts muted sees both settings 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "settings",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: User settings authenticated user with both automatic unfurls configured and prompts muted sees both settings 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: User settings authenticated user with both settings configured clicks unmute button and sees confirmation message 1`] = `
 Object {
   "attachments": Array [
@@ -53,6 +88,12 @@ Object {
   ],
 }
 `;
+
+exports[`Integration: User settings authenticated user with both settings configured clicks unmute button and sees confirmation message 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: User settings authenticated user with both settings configured clicks unmute button and sees confirmation message 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: User settings authenticated user with both settings configured clicks unmute button and sees confirmation message 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: User settings authenticated user with both settings configured confirms removal of autounfurl removes repo from settings and posts confirmation message to user 1`] = `
 Object {
@@ -67,6 +108,12 @@ Object {
   ],
 }
 `;
+
+exports[`Integration: User settings authenticated user with both settings configured confirms removal of autounfurl removes repo from settings and posts confirmation message to user 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: User settings authenticated user with both settings configured confirms removal of autounfurl removes repo from settings and posts confirmation message to user 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: User settings authenticated user with both settings configured confirms removal of autounfurl removes repo from settings and posts confirmation message to user 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: User settings authenticated user with both settings configured selects repo for which to stop autounfurls and is presented with a follow up message 1`] = `
 Object {
@@ -100,6 +147,12 @@ Object {
 }
 `;
 
+exports[`Integration: User settings authenticated user with both settings configured selects repo for which to stop autounfurls and is presented with a follow up message 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: User settings authenticated user with both settings configured selects repo for which to stop autounfurls and is presented with a follow up message 3`] = `[MockFunction cache.set]`;
+
+exports[`Integration: User settings authenticated user with both settings configured selects repo for which to stop autounfurls and is presented with a follow up message 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: User settings authenticated user with just auto unfurls configured sees just that setting 1`] = `
 Object {
   "attachments": Array [
@@ -130,6 +183,41 @@ Object {
 }
 `;
 
+exports[`Integration: User settings authenticated user with just auto unfurls configured sees just that setting 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: User settings authenticated user with just auto unfurls configured sees just that setting 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "settings",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: User settings authenticated user with just auto unfurls configured sees just that setting 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: User settings authenticated user with just prompts muted sees just that setting 1`] = `
 Object {
   "attachments": Array [
@@ -150,6 +238,41 @@ Object {
 }
 `;
 
+exports[`Integration: User settings authenticated user with just prompts muted sees just that setting 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: User settings authenticated user with just prompts muted sees just that setting 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "settings",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: User settings authenticated user with just prompts muted sees just that setting 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: User settings authenticated user with no settings configured gets message stating that 1`] = `
 Object {
   "attachments": Array [
@@ -161,6 +284,41 @@ Object {
 }
 `;
 
+exports[`Integration: User settings authenticated user with no settings configured gets message stating that 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: User settings authenticated user with no settings configured gets message stating that 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "settings",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: User settings authenticated user with no settings configured gets message stating that 4`] = `[MockFunction cache.fetch]`;
+
 exports[`Integration: User settings authenticated user with prompts muted temporarily doesn't see setting showing time remaining 1`] = `
 Object {
   "attachments": Array [
@@ -171,6 +329,41 @@ Object {
   ],
 }
 `;
+
+exports[`Integration: User settings authenticated user with prompts muted temporarily doesn't see setting showing time remaining 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: User settings authenticated user with prompts muted temporarily doesn't see setting showing time remaining 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "settings",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: User settings authenticated user with prompts muted temporarily doesn't see setting showing time remaining 4`] = `[MockFunction cache.fetch]`;
 
 exports[`Integration: User settings authenticated user with prompts muted temporarily sees setting showing time remaining 1`] = `
 Object {
@@ -191,3 +384,73 @@ Object {
   ],
 }
 `;
+
+exports[`Integration: User settings authenticated user with prompts muted temporarily sees setting showing time remaining 2`] = `[MockFunction cache.get]`;
+
+exports[`Integration: User settings authenticated user with prompts muted temporarily sees setting showing time remaining 3`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "settings",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: User settings authenticated user with prompts muted temporarily sees setting showing time remaining 4`] = `[MockFunction cache.fetch]`;
+
+exports[`Integration: User settings unauthenticated user is prompted to authenticate first 1`] = `[MockFunction cache.get]`;
+
+exports[`Integration: User settings unauthenticated user is prompted to authenticate first 2`] = `
+[MockFunction cache.set] {
+  "calls": Array [
+    Array [
+      "pending-command#13345224609.738474920.8088930838d88f008e0",
+      Object {
+        "channel_id": "C2147483705",
+        "channel_name": "test",
+        "command": "/github",
+        "enterprise_id": "E0001",
+        "enterprise_name": "Globular%20Construct%20Inc",
+        "response_url": "https://hooks.slack.com/commands/1234/5678",
+        "team_domain": "example",
+        "team_id": "T0001",
+        "text": "settings",
+        "token": "secret",
+        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+        "user_id": "U2147483697",
+        "user_name": "Steve",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Integration: User settings unauthenticated user is prompted to authenticate first 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/__snapshots__/user-settings.test.js.snap
+++ b/test/integration/__snapshots__/user-settings.test.js.snap
@@ -43,40 +43,31 @@ Object {
 }
 `;
 
-exports[`Integration: User settings authenticated user with both automatic unfurls configured and prompts muted sees both settings 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: User settings authenticated user with both automatic unfurls configured and prompts muted sees both settings 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "settings",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: User settings authenticated user with both automatic unfurls configured and prompts muted sees both settings 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: User settings authenticated user with both automatic unfurls configured and prompts muted sees both settings 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: User settings authenticated user with both automatic unfurls configured and prompts muted sees both settings 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "settings",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: User settings authenticated user with both settings configured clicks unmute button and sees confirmation message 1`] = `
 Object {
@@ -89,11 +80,9 @@ Object {
 }
 `;
 
-exports[`Integration: User settings authenticated user with both settings configured clicks unmute button and sees confirmation message 2`] = `[MockFunction cache.get]`;
+exports[`Integration: User settings authenticated user with both settings configured clicks unmute button and sees confirmation message 2`] = `Set {}`;
 
-exports[`Integration: User settings authenticated user with both settings configured clicks unmute button and sees confirmation message 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: User settings authenticated user with both settings configured clicks unmute button and sees confirmation message 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: User settings authenticated user with both settings configured clicks unmute button and sees confirmation message 3`] = `Map {}`;
 
 exports[`Integration: User settings authenticated user with both settings configured confirms removal of autounfurl removes repo from settings and posts confirmation message to user 1`] = `
 Object {
@@ -109,11 +98,9 @@ Object {
 }
 `;
 
-exports[`Integration: User settings authenticated user with both settings configured confirms removal of autounfurl removes repo from settings and posts confirmation message to user 2`] = `[MockFunction cache.get]`;
+exports[`Integration: User settings authenticated user with both settings configured confirms removal of autounfurl removes repo from settings and posts confirmation message to user 2`] = `Set {}`;
 
-exports[`Integration: User settings authenticated user with both settings configured confirms removal of autounfurl removes repo from settings and posts confirmation message to user 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: User settings authenticated user with both settings configured confirms removal of autounfurl removes repo from settings and posts confirmation message to user 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: User settings authenticated user with both settings configured confirms removal of autounfurl removes repo from settings and posts confirmation message to user 3`] = `Map {}`;
 
 exports[`Integration: User settings authenticated user with both settings configured selects repo for which to stop autounfurls and is presented with a follow up message 1`] = `
 Object {
@@ -147,11 +134,9 @@ Object {
 }
 `;
 
-exports[`Integration: User settings authenticated user with both settings configured selects repo for which to stop autounfurls and is presented with a follow up message 2`] = `[MockFunction cache.get]`;
+exports[`Integration: User settings authenticated user with both settings configured selects repo for which to stop autounfurls and is presented with a follow up message 2`] = `Set {}`;
 
-exports[`Integration: User settings authenticated user with both settings configured selects repo for which to stop autounfurls and is presented with a follow up message 3`] = `[MockFunction cache.set]`;
-
-exports[`Integration: User settings authenticated user with both settings configured selects repo for which to stop autounfurls and is presented with a follow up message 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: User settings authenticated user with both settings configured selects repo for which to stop autounfurls and is presented with a follow up message 3`] = `Map {}`;
 
 exports[`Integration: User settings authenticated user with just auto unfurls configured sees just that setting 1`] = `
 Object {
@@ -183,40 +168,31 @@ Object {
 }
 `;
 
-exports[`Integration: User settings authenticated user with just auto unfurls configured sees just that setting 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: User settings authenticated user with just auto unfurls configured sees just that setting 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "settings",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: User settings authenticated user with just auto unfurls configured sees just that setting 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: User settings authenticated user with just auto unfurls configured sees just that setting 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: User settings authenticated user with just auto unfurls configured sees just that setting 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "settings",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: User settings authenticated user with just prompts muted sees just that setting 1`] = `
 Object {
@@ -238,40 +214,31 @@ Object {
 }
 `;
 
-exports[`Integration: User settings authenticated user with just prompts muted sees just that setting 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: User settings authenticated user with just prompts muted sees just that setting 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "settings",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: User settings authenticated user with just prompts muted sees just that setting 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: User settings authenticated user with just prompts muted sees just that setting 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: User settings authenticated user with just prompts muted sees just that setting 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "settings",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: User settings authenticated user with no settings configured gets message stating that 1`] = `
 Object {
@@ -284,40 +251,31 @@ Object {
 }
 `;
 
-exports[`Integration: User settings authenticated user with no settings configured gets message stating that 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: User settings authenticated user with no settings configured gets message stating that 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "settings",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: User settings authenticated user with no settings configured gets message stating that 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: User settings authenticated user with no settings configured gets message stating that 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: User settings authenticated user with no settings configured gets message stating that 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "settings",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: User settings authenticated user with prompts muted temporarily doesn't see setting showing time remaining 1`] = `
 Object {
@@ -330,40 +288,31 @@ Object {
 }
 `;
 
-exports[`Integration: User settings authenticated user with prompts muted temporarily doesn't see setting showing time remaining 2`] = `[MockFunction cache.get]`;
-
-exports[`Integration: User settings authenticated user with prompts muted temporarily doesn't see setting showing time remaining 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "settings",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+exports[`Integration: User settings authenticated user with prompts muted temporarily doesn't see setting showing time remaining 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
 }
 `;
 
-exports[`Integration: User settings authenticated user with prompts muted temporarily doesn't see setting showing time remaining 4`] = `[MockFunction cache.fetch]`;
+exports[`Integration: User settings authenticated user with prompts muted temporarily doesn't see setting showing time remaining 3`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "settings",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
 
 exports[`Integration: User settings authenticated user with prompts muted temporarily sees setting showing time remaining 1`] = `
 Object {
@@ -385,72 +334,54 @@ Object {
 }
 `;
 
-exports[`Integration: User settings authenticated user with prompts muted temporarily sees setting showing time remaining 2`] = `[MockFunction cache.get]`;
+exports[`Integration: User settings authenticated user with prompts muted temporarily sees setting showing time remaining 2`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: User settings authenticated user with prompts muted temporarily sees setting showing time remaining 3`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "settings",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "settings",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
 
-exports[`Integration: User settings authenticated user with prompts muted temporarily sees setting showing time remaining 4`] = `[MockFunction cache.fetch]`;
-
-exports[`Integration: User settings unauthenticated user is prompted to authenticate first 1`] = `[MockFunction cache.get]`;
+exports[`Integration: User settings unauthenticated user is prompted to authenticate first 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
 
 exports[`Integration: User settings unauthenticated user is prompted to authenticate first 2`] = `
-[MockFunction cache.set] {
-  "calls": Array [
-    Array [
-      "pending-command#13345224609.738474920.8088930838d88f008e0",
-      Object {
-        "channel_id": "C2147483705",
-        "channel_name": "test",
-        "command": "/github",
-        "enterprise_id": "E0001",
-        "enterprise_name": "Globular%20Construct%20Inc",
-        "response_url": "https://hooks.slack.com/commands/1234/5678",
-        "team_domain": "example",
-        "team_id": "T0001",
-        "text": "settings",
-        "token": "secret",
-        "trigger_id": "13345224609.738474920.8088930838d88f008e0",
-        "user_id": "U2147483697",
-        "user_name": "Steve",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "isThrow": false,
-      "value": Promise {},
-    },
-  ],
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "settings",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
 }
 `;
-
-exports[`Integration: User settings unauthenticated user is prompted to authenticate first 3`] = `[MockFunction cache.fetch]`;

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -24,7 +24,14 @@ beforeAll(async () => models.sequelize.authenticate());
 // Close connection when tests are done
 afterAll(async () => models.sequelize.close());
 
+let setSpy;
+let getSpy;
+let fetchSpy;
 beforeEach(() => {
+  getSpy = jest.spyOn(cache, 'get');
+  setSpy = jest.spyOn(cache, 'set');
+  fetchSpy = jest.spyOn(cache, 'fetch');
+
   // Restore log level after each test
   probot.logger.level(process.env.LOG_LEVEL);
 
@@ -36,6 +43,16 @@ beforeEach(() => {
     models.sequelize.truncate({ cascade: true }),
     cache.clear(),
   ]);
+});
+
+afterEach(() => {
+  expect(getSpy).toMatchSnapshot();
+  expect(setSpy).toMatchSnapshot();
+  expect(fetchSpy).toMatchSnapshot();
+
+  getSpy.mockRestore();
+  setSpy.mockRestore();
+  fetchSpy.mockRestore();
 });
 
 module.exports = {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -26,15 +26,9 @@ afterAll(async () => models.sequelize.close());
 
 let setSpy;
 let getSpy;
-let fetchSpy;
 beforeEach(() => {
   getSpy = jest.spyOn(cache, 'get');
   setSpy = jest.spyOn(cache, 'set');
-  fetchSpy = jest.spyOn(cache, 'fetch');
-
-  getSpy.mockName('cache.get');
-  setSpy.mockName('cache.set');
-  fetchSpy.mockName('cache.fetch');
 
   // Restore log level after each test
   probot.logger.level(process.env.LOG_LEVEL);
@@ -50,13 +44,21 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  expect(getSpy).toMatchSnapshot();
-  expect(setSpy).toMatchSnapshot();
-  expect(fetchSpy).toMatchSnapshot();
+  const getKeys = setSpy.mock.calls.reduce((keys, args) => {
+    keys.add(args[0]);
+    return keys;
+  }, new Set());
+
+  const cacheStatus = setSpy.mock.calls.reduce((status, args) => {
+    status.set(args[0], args[1]);
+    return status;
+  }, new Map());
+
+  expect(getKeys).toMatchSnapshot();
+  expect(cacheStatus).toMatchSnapshot();
 
   getSpy.mockRestore();
   setSpy.mockRestore();
-  fetchSpy.mockRestore();
 });
 
 module.exports = {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -32,6 +32,10 @@ beforeEach(() => {
   setSpy = jest.spyOn(cache, 'set');
   fetchSpy = jest.spyOn(cache, 'fetch');
 
+  getSpy.mockName('cache.get');
+  setSpy.mockName('cache.set');
+  fetchSpy.mockName('cache.fetch');
+
   // Restore log level after each test
   probot.logger.level(process.env.LOG_LEVEL);
 

--- a/test/integration/notifications.test.js
+++ b/test/integration/notifications.test.js
@@ -19,8 +19,6 @@ const reviewCommentCreated = require('../fixtures/webhooks/pull_request_review/p
 const repositoryDeleted = require('../fixtures/webhooks/repository.deleted.json');
 const releasePublishedPayload = require('../fixtures/webhooks/release.published.json');
 
-const cache = require('../../lib/cache');
-
 const {
   Subscription,
   SlackWorkspace,

--- a/test/integration/notifications.test.js
+++ b/test/integration/notifications.test.js
@@ -19,6 +19,8 @@ const reviewCommentCreated = require('../fixtures/webhooks/pull_request_review/p
 const repositoryDeleted = require('../fixtures/webhooks/repository.deleted.json');
 const releasePublishedPayload = require('../fixtures/webhooks/release.published.json');
 
+const cache = require('../../lib/cache');
+
 const {
   Subscription,
   SlackWorkspace,


### PR DESCRIPTION
Closes https://github.com/github/ecosystem-primitives/issues/106

In order to test what we put inside Redis and whether or not we are accesing it, I've added spies to the `cache` module. Similar to what we do with `nock`. I'm testing which values are accessed (`get`) and which ones are `set`. I could not test all the calls with `expect(spy).toMatchSnapshot()` because execution order is not guaranteed when we are using `async` functions.

For example both, the `matchMetaDataStatetoIssueMessage` function and the `comments` function in `lib/activity.js` are called for the `issue_comment.created` and `issue_comment.edited` events. But the execution order of those functions changes, even when running multiple times the same test. In the future it would be great to be able to just test one of those functions directly, but right now there's no easy way to do that, unless we do an important refactoring.

I found also that since two functions are being executed for the same event type, we are effectively executing the `route()` function twice. It would be a lot better to be able to specify like a middleware to probot since we are using the `route()` function for all types of events.