### PR TITLE
Scope queries and cache keys by workspace id

### DIFF
--- a/lib/commands/list-subscriptions.js
+++ b/lib/commands/list-subscriptions.js
@@ -1,4 +1,4 @@
-const { Subscription, Installation } = require('../models');
+const { Subscription, Installation, SlackWorkspace } = require('../models');
 const SubscriptionList = require('../messages/subscription-list');
 const { Help } = require('../messages/flow');
 const getRepositories = require('../github/get-repositories');
@@ -19,8 +19,8 @@ module.exports = async (req, res, next) => {
   }
 
   const subscriptions = await Subscription.findAll({
-    include: [Installation],
-    where: { channelId: command.channel_id },
+    include: [Installation, SlackWorkspace],
+    where: { channelId: command.channel_id, '$SlackWorkspace.slackId$': command.team_id },
   });
 
   const repositories = await getRepositories(subscriptions.filter(s => s.type === 'repo'), robot);

--- a/lib/models/slack-workspace.js
+++ b/lib/models/slack-workspace.js
@@ -12,7 +12,7 @@ const encrypted = EncryptedField(Sequelize, process.env.STORAGE_SECRET);
 module.exports = (sequelize, DataTypes) => {
   const SlackWorkspace = sequelize.define('SlackWorkspace', {
     slackId: {
-      type: DataTypes.BIGINT,
+      type: DataTypes.STRING,
       allowNull: false,
     },
 

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -96,7 +96,7 @@ module.exports = (sequelize, DataTypes) => {
 
   Object.assign(Subscription.prototype, {
     cacheKey(...parts) {
-      return [`channel#${this.channelId}`].concat(parts).join(':');
+      return [`channel#${this.slackWorkspaceId}#${this.channelId}`].concat(parts).join(':');
     },
 
     isEnabledForGitHubEvent(event) {

--- a/test/integration/__snapshots__/notifications.test.js.snap
+++ b/test/integration/__snapshots__/notifications.test.js.snap
@@ -22,14 +22,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel comments are updated when edited 2`] = `
 Set {
   "creator-access#1:100403908",
-  "channel#C002:comment#364284529",
+  "channel#9517#C002:comment#364284529",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel comments are updated when edited 3`] = `
 Map {
   "creator-access#1:100403908" => true,
-  "channel#C002:comment#364284529" => Object {
+  "channel#9517#C002:comment#364284529" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -67,14 +67,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 2`] = `
 Set {
   "creator-access#1:123302024",
-  "channel#C001:comment#171608320",
+  "channel#9523#C001:comment#171608320",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel delivers pull request review commments if comments are enabled 3`] = `
 Map {
   "creator-access#1:123302024" => true,
-  "channel#C001:comment#171608320" => Object {
+  "channel#9523#C001:comment#171608320" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -139,14 +139,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel deployment_status event 3`] = `
 Set {
   "creator-access#1:100427737",
-  "channel#C001:deployment#57919058",
+  "channel#9509#C001:deployment#57919058",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel deployment_status event 4`] = `
 Map {
   "creator-access#1:100427737" => true,
-  "channel#C001:deployment#57919058" => Object {
+  "channel#9509#C001:deployment#57919058" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -230,14 +230,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel issue opened 2`] = `
 Set {
   "creator-access#1:107153132",
-  "channel#C001:issue#265831302",
+  "channel#9495#C001:issue#265831302",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel issue opened 3`] = `
 Map {
   "creator-access#1:107153132" => true,
-  "channel#C001:issue#265831302" => Object {
+  "channel#9495#C001:issue#265831302" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -294,14 +294,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 2`] = `
 Set {
   "creator-access#1:107153132",
-  "channel#C001:issue#265831302",
+  "channel#9496#C001:issue#265831302",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 3`] = `
 Map {
   "creator-access#1:107153132" => true,
-  "channel#C001:issue#265831302" => Object {
+  "channel#9496#C001:issue#265831302" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -319,14 +319,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 2`] = `
 Set {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
-  "channel#C001:pull#142600109",
+  "channel#9512#C001:pull#142600109",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 3`] = `
 Map {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc" => 142600109,
-  "channel#C001:pull#142600109" => Object {
+  "channel#9512#C001:pull#142600109" => Object {
     "channel": undefined,
     "context": Object {
       "number": 31,
@@ -433,7 +433,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 Set {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
   "creator-access#1:100427737",
-  "channel#C001:pull#142600109",
+  "channel#9499#C001:pull#142600109",
 }
 `;
 
@@ -441,7 +441,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 Map {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc" => 142600109,
   "creator-access#1:100427737" => true,
-  "channel#C001:pull#142600109" => Object {
+  "channel#9499#C001:pull#142600109" => Object {
     "channel": undefined,
     "context": Object {
       "number": 31,
@@ -472,7 +472,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 Set {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
   "creator-access#1:100427737",
-  "channel#C001:pull#142600109",
+  "channel#9502#C001:pull#142600109",
 }
 `;
 
@@ -480,7 +480,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 Map {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc" => 142600109,
   "creator-access#1:100427737" => true,
-  "channel#C001:pull#142600109" => Object {
+  "channel#9502#C001:pull#142600109" => Object {
     "channel": undefined,
     "context": Object {
       "number": 31,
@@ -570,14 +570,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel review event 3`] = `
 Set {
   "creator-access#1:107153132",
-  "channel#C001:review#97014958",
+  "channel#9507#C001:review#97014958",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel review event 4`] = `
 Map {
   "creator-access#1:107153132" => true,
-  "channel#C001:review#97014958" => Object {
+  "channel#9507#C001:review#97014958" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -611,14 +611,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 2`] = `
 Set {
   "creator-access#1:16064378",
-  "channel#C002:comment#30287269",
+  "channel#9516#C002:comment#30287269",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 3`] = `
 Map {
   "creator-access#1:16064378" => true,
-  "channel#C002:comment#30287269" => Object {
+  "channel#9516#C002:comment#30287269" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -636,14 +636,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 2`] = `
 Set {
   "creator-access#1:100403908",
-  "channel#C002:comment#364284529",
+  "channel#9515#C002:comment#364284529",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 3`] = `
 Map {
   "creator-access#1:100403908" => true,
-  "channel#C002:comment#364284529" => Object {
+  "channel#9515#C002:comment#364284529" => Object {
     "channel": undefined,
     "ts": undefined,
   },

--- a/test/integration/__snapshots__/notifications.test.js.snap
+++ b/test/integration/__snapshots__/notifications.test.js.snap
@@ -22,14 +22,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel comments are updated when edited 2`] = `
 Set {
   "creator-access#1:100403908",
-  "channel#9517#C002:comment#364284529",
+  "channel#9523#C002:comment#364284529",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel comments are updated when edited 3`] = `
 Map {
   "creator-access#1:100403908" => true,
-  "channel#9517#C002:comment#364284529" => Object {
+  "channel#9523#C002:comment#364284529" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -139,14 +139,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel deployment_status event 3`] = `
 Set {
   "creator-access#1:100427737",
-  "channel#9509#C001:deployment#57919058",
+  "channel#9523#C001:deployment#57919058",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel deployment_status event 4`] = `
 Map {
   "creator-access#1:100427737" => true,
-  "channel#9509#C001:deployment#57919058" => Object {
+  "channel#9523#C001:deployment#57919058" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -230,14 +230,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel issue opened 2`] = `
 Set {
   "creator-access#1:107153132",
-  "channel#9495#C001:issue#265831302",
+  "channel#9523#C001:issue#265831302",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel issue opened 3`] = `
 Map {
   "creator-access#1:107153132" => true,
-  "channel#9495#C001:issue#265831302" => Object {
+  "channel#9523#C001:issue#265831302" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -294,14 +294,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 2`] = `
 Set {
   "creator-access#1:107153132",
-  "channel#9496#C001:issue#265831302",
+  "channel#9523#C001:issue#265831302",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel issues.edited updates issue message 3`] = `
 Map {
   "creator-access#1:107153132" => true,
-  "channel#9496#C001:issue#265831302" => Object {
+  "channel#9523#C001:issue#265831302" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -319,14 +319,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 2`] = `
 Set {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
-  "channel#9512#C001:pull#142600109",
+  "channel#9523#C001:pull#142600109",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 3`] = `
 Map {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc" => 142600109,
-  "channel#9512#C001:pull#142600109" => Object {
+  "channel#9523#C001:pull#142600109" => Object {
     "channel": undefined,
     "context": Object {
       "number": 31,
@@ -433,7 +433,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 Set {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
   "creator-access#1:100427737",
-  "channel#9499#C001:pull#142600109",
+  "channel#9523#C001:pull#142600109",
 }
 `;
 
@@ -441,7 +441,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 Map {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc" => 142600109,
   "creator-access#1:100427737" => true,
-  "channel#9499#C001:pull#142600109" => Object {
+  "channel#9523#C001:pull#142600109" => Object {
     "channel": undefined,
     "context": Object {
       "number": 31,
@@ -472,7 +472,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 Set {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc",
   "creator-access#1:100427737",
-  "channel#9502#C001:pull#142600109",
+  "channel#9523#C001:pull#142600109",
 }
 `;
 
@@ -480,7 +480,7 @@ exports[`Integration: notifications to a subscribed channel pull request opened 
 Map {
   "status-cb67adc76ba600bfb6dccd50c5c837f29d3912dc" => 142600109,
   "creator-access#1:100427737" => true,
-  "channel#9502#C001:pull#142600109" => Object {
+  "channel#9523#C001:pull#142600109" => Object {
     "channel": undefined,
     "context": Object {
       "number": 31,
@@ -570,14 +570,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel review event 3`] = `
 Set {
   "creator-access#1:107153132",
-  "channel#9507#C001:review#97014958",
+  "channel#9523#C001:review#97014958",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel review event 4`] = `
 Map {
   "creator-access#1:107153132" => true,
-  "channel#9507#C001:review#97014958" => Object {
+  "channel#9523#C001:review#97014958" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -611,14 +611,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 2`] = `
 Set {
   "creator-access#1:16064378",
-  "channel#9516#C002:comment#30287269",
+  "channel#9523#C002:comment#30287269",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (commit) 3`] = `
 Map {
   "creator-access#1:16064378" => true,
-  "channel#9516#C002:comment#30287269" => Object {
+  "channel#9523#C002:comment#30287269" => Object {
     "channel": undefined,
     "ts": undefined,
   },
@@ -636,14 +636,14 @@ Object {
 exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 2`] = `
 Set {
   "creator-access#1:100403908",
-  "channel#9515#C002:comment#364284529",
+  "channel#9523#C002:comment#364284529",
 }
 `;
 
 exports[`Integration: notifications to a subscribed channel with comments enabled (issue) 3`] = `
 Map {
   "creator-access#1:100403908" => true,
-  "channel#9515#C002:comment#364284529" => Object {
+  "channel#9523#C002:comment#364284529" => Object {
     "channel": undefined,
     "ts": undefined,
   },

--- a/test/integration/list-subscriptions.test.js
+++ b/test/integration/list-subscriptions.test.js
@@ -10,7 +10,7 @@ describe('Integration: subscription list', () => {
   beforeEach(async () => {
     const workspace = await SlackWorkspace.create({
       accessToken: 'secret',
-      slackId: 1,
+      slackId: 'T0001',
     });
 
     const installation = await Installation.create({

--- a/test/integration/notifications.test.js
+++ b/test/integration/notifications.test.js
@@ -36,6 +36,7 @@ describe('Integration: notifications', () => {
 
     beforeEach(async () => {
       workspace = await SlackWorkspace.create({
+        id: 9523, // same id always for jest snapshots
         slackId: 'T001',
         accessToken: 'test',
       });

--- a/test/models/subscription.test.js
+++ b/test/models/subscription.test.js
@@ -33,9 +33,9 @@ describe('model: Subscription', () => {
       type: 'repo',
     });
 
-    expect(subscription.cacheKey()).toEqual('channel#1');
-    expect(subscription.cacheKey('foo#1')).toEqual('channel#1:foo#1');
-    expect(subscription.cacheKey('foo#1', 'bar#2')).toEqual('channel#1:foo#1:bar#2');
+    expect(subscription.cacheKey()).toEqual(`channel#${workspace.id}#1`);
+    expect(subscription.cacheKey('foo#1')).toEqual(`channel#${workspace.id}#1:foo#1`);
+    expect(subscription.cacheKey('foo#1', 'bar#2')).toEqual(`channel#${workspace.id}#1:foo#1:bar#2`);
   });
 
   describe('subscribe', () => {


### PR DESCRIPTION
Closes https://github.com/github/ecosystem-primitives/issues/98

Channel id uniqueness is not guaranteed, even though in practice they are unique. This PR enforces always scoping queries and cache keys by workspace id.