### PR TITLE
Add GitHub marketplace link

### DIFF
--- a/lib/messages/flow/help.js
+++ b/lib/messages/flow/help.js
@@ -60,6 +60,11 @@ if (process.env.DEPLOY_COMMAND_ENABLED) {
   });
 }
 
+const marketplace = {
+  header: 'Find more apps for Slack in GitHub Marketplace:',
+  link: '<https://github.com/marketplace/category/chat|Browse GitHub Marketplace →>',
+};
+
 const { Message } = require('../../messages');
 
 module.exports = class Help extends Message {
@@ -88,6 +93,10 @@ module.exports = class Help extends Message {
         text: `${command.desc}:\n\`${this.command} ${command.usage}\``,
         mrkdwn_in: ['text'],
       }));
+
+    attachments.push({
+      text: `${marketplace.header}\n${marketplace.link}`,
+    });
 
     attachments.push({
       ...this.getBaseMessage(),

--- a/lib/messages/flow/help.js
+++ b/lib/messages/flow/help.js
@@ -68,7 +68,7 @@ module.exports = class Help extends Message {
       footer: [
         '<https://github.com/integrations/slack#readme|Learn More>',
         `<${supportLink()}|Contact Support>`,
-      ].join(' — '),
+      ].join(' · '),
     });
     this.command = command;
     this.subcommand = subcommand;

--- a/test/integration/__snapshots__/help.test.js.snap
+++ b/test/integration/__snapshots__/help.test.js.snap
@@ -95,6 +95,10 @@ Object {
 \`/github deploy owner/repository list\`",
     },
     Object {
+      "text": "Find more apps for Slack in GitHub Marketplace:
+<https://github.com/marketplace/category/chat|Browse GitHub Marketplace →>",
+    },
+    Object {
       "color": "",
       "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
@@ -227,6 +231,10 @@ Object {
 \`/github deploy owner/repository list\`",
     },
     Object {
+      "text": "Find more apps for Slack in GitHub Marketplace:
+<https://github.com/marketplace/category/chat|Browse GitHub Marketplace →>",
+    },
+    Object {
       "color": "",
       "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
@@ -357,6 +365,10 @@ Object {
       ],
       "text": "List deployments of a repo:
 \`/github deploy owner/repository list\`",
+    },
+    Object {
+      "text": "Find more apps for Slack in GitHub Marketplace:
+<https://github.com/marketplace/category/chat|Browse GitHub Marketplace →>",
     },
     Object {
       "color": "",

--- a/test/integration/__snapshots__/help.test.js.snap
+++ b/test/integration/__snapshots__/help.test.js.snap
@@ -96,7 +96,7 @@ Object {
     },
     Object {
       "color": "",
-      "footer": "<https://github.com/integrations/slack#readme|Learn More> — <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
+      "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "text": "",
     },
@@ -228,7 +228,7 @@ Object {
     },
     Object {
       "color": "",
-      "footer": "<https://github.com/integrations/slack#readme|Learn More> — <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
+      "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "text": "",
     },
@@ -360,7 +360,7 @@ Object {
     },
     Object {
       "color": "",
-      "footer": "<https://github.com/integrations/slack#readme|Learn More> — <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
+      "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "text": "",
     },

--- a/test/integration/__snapshots__/list-subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/list-subscriptions.test.js.snap
@@ -106,7 +106,7 @@ Object {
     },
     Object {
       "color": "",
-      "footer": "<https://github.com/integrations/slack#readme|Learn More> — <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
+      "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "text": "",
     },

--- a/test/integration/__snapshots__/list-subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/list-subscriptions.test.js.snap
@@ -105,6 +105,10 @@ Object {
 \`/github subscribe list\`",
     },
     Object {
+      "text": "Find more apps for Slack in GitHub Marketplace:
+<https://github.com/marketplace/category/chat|Browse GitHub Marketplace →>",
+    },
+    Object {
       "color": "",
       "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",

--- a/test/messages/flow/__snapshots__/help.test.js.snap
+++ b/test/messages/flow/__snapshots__/help.test.js.snap
@@ -96,7 +96,7 @@ Object {
     },
     Object {
       "color": "",
-      "footer": "<https://github.com/integrations/slack#readme|Learn More> — <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
+      "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "text": "",
     },

--- a/test/messages/flow/__snapshots__/help.test.js.snap
+++ b/test/messages/flow/__snapshots__/help.test.js.snap
@@ -95,6 +95,10 @@ Object {
 \`/github deploy owner/repository list\`",
     },
     Object {
+      "text": "Find more apps for Slack in GitHub Marketplace:
+<https://github.com/marketplace/category/chat|Browse GitHub Marketplace →>",
+    },
+    Object {
       "color": "",
       "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",


### PR DESCRIPTION
This PR adds a link to the GitHub Marketplace at the bottom of the `/github` command response. This should help users discover more tools for GitHub and Slack as well as generally promote the GitHub Marketplace. Listings include this integration, Pull Reminders, GitHub Actions, and new apps coming soon like https://getslashdeploy.com.

I also made a small change to the footer link formatting since it's been bothering me for awhile. I think a dash was grammatically confusing so I changed it to a dot separator.

Once I get local development running per https://github.com/integrations/slack/issues/767, a fun feature idea I've had is to add a `/github apps [search term]` command for discovering GitHub Marketplace Apps. This is inspired by Slack's own /apps command for searching for Slack Apps:

<img width="765" alt="screen shot 2019-01-17 at 11 40 03 pm" src="https://user-images.githubusercontent.com/50083/51370123-40320980-1ab3-11e9-8b52-a292ab0667d7.png">


