### PR TITLE
Improve displaying deployments with beta statuses

### DIFF
--- a/lib/messages/deployment-status.js
+++ b/lib/messages/deployment-status.js
@@ -34,6 +34,16 @@ class DeploymentStatus extends Message {
         fallback: `[${this.repository.full_name}] Deploying ${center}`,
         text: `Deploying ${centerWithLink}`,
       };
+    } else if (this.deploymentStatus.state == 'in_progress') {
+      return {
+        fallback: `[$(this.repository.full_name}] Deployment in progress for ${center}`,
+        text: `Deployment in progress ${centerWithLink}`
+      };
+    } else if (this.deploymentStatus.state == 'queued') {
+      return {
+        fallback: `[$(this.repository.full_name}] Deployment queued for ${center}`,
+        text: `Deployment queued ${centerWithLink}`
+      };
     } else if (this.deploymentStatus.state === 'success') {
       return {
         fallback: `[${this.repository.full_name}] Successfully deployed ${center}`,

--- a/lib/messages/deployment-status.js
+++ b/lib/messages/deployment-status.js
@@ -34,12 +34,12 @@ class DeploymentStatus extends Message {
         fallback: `[${this.repository.full_name}] Deploying ${center}`,
         text: `Deploying ${centerWithLink}`,
       };
-    } else if (this.deploymentStatus.state == 'in_progress') {
+    } else if (this.deploymentStatus.state === 'in_progress') {
       return {
         fallback: `[${this.repository.full_name}] Deployment in progress for ${center}`,
         text: `Deployment in progress ${centerWithLink}`,
       };
-    } else if (this.deploymentStatus.state == 'queued') {
+    } else if (this.deploymentStatus.state === 'queued') {
       return {
         fallback: `[${this.repository.full_name}] Deployment queued for ${center}`,
         text: `Deployment queued ${centerWithLink}`,

--- a/lib/messages/deployment-status.js
+++ b/lib/messages/deployment-status.js
@@ -37,12 +37,12 @@ class DeploymentStatus extends Message {
     } else if (this.deploymentStatus.state == 'in_progress') {
       return {
         fallback: `[${this.repository.full_name}] Deployment in progress for ${center}`,
-        text: `Deployment in progress ${centerWithLink}`
+        text: `Deployment in progress ${centerWithLink}`,
       };
     } else if (this.deploymentStatus.state == 'queued') {
       return {
         fallback: `[${this.repository.full_name}] Deployment queued for ${center}`,
-        text: `Deployment queued ${centerWithLink}`
+        text: `Deployment queued ${centerWithLink}`,
       };
     } else if (this.deploymentStatus.state === 'success') {
       return {

--- a/lib/messages/deployment-status.js
+++ b/lib/messages/deployment-status.js
@@ -36,12 +36,12 @@ class DeploymentStatus extends Message {
       };
     } else if (this.deploymentStatus.state == 'in_progress') {
       return {
-        fallback: `[$(this.repository.full_name}] Deployment in progress for ${center}`,
+        fallback: `[${this.repository.full_name}] Deployment in progress for ${center}`,
         text: `Deployment in progress ${centerWithLink}`
       };
     } else if (this.deploymentStatus.state == 'queued') {
       return {
-        fallback: `[$(this.repository.full_name}] Deployment queued for ${center}`,
+        fallback: `[${this.repository.full_name}] Deployment queued for ${center}`,
         text: `Deployment queued ${centerWithLink}`
       };
     } else if (this.deploymentStatus.state === 'success') {

--- a/lib/messages/status.js
+++ b/lib/messages/status.js
@@ -12,7 +12,7 @@ class Status extends Message {
   static getStatusColor(status) {
     if (status === 'success') {
       return constants.STATUS_SUCCESS;
-    } else if (status === 'pending') {
+    } else if (status === 'pending' || status === 'in_progress' || status === 'queued') {
       return constants.STATUS_PENDING;
     } else if (status === 'failure' || status === 'error') {
       return constants.STATUS_FAILURE;

--- a/test/messages/__snapshots__/deployment-status.test.js.snap
+++ b/test/messages/__snapshots__/deployment-status.test.js.snap
@@ -48,7 +48,7 @@ Object {
       "author_link": "https://github.com/wilhelmklopp",
       "author_name": "wilhelmklopp",
       "color": "#dbab09",
-      "fallback": "[$(this.repository.full_name}] Deployment in progress for 3dce5c8 to github-slack-app",
+      "fallback": "[github-slack/app] Deployment in progress for 3dce5c8 to github-slack-app",
       "footer": "<https://github.com/github-slack/app|github-slack/app>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "mrkdwn_in": Array [
@@ -88,7 +88,7 @@ Object {
       "author_link": "https://github.com/wilhelmklopp",
       "author_name": "wilhelmklopp",
       "color": "#dbab09",
-      "fallback": "[$(this.repository.full_name}] Deployment queued for 3dce5c8 to github-slack-app",
+      "fallback": "[github-slack/app] Deployment queued for 3dce5c8 to github-slack-app",
       "footer": "<https://github.com/github-slack/app|github-slack/app>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "mrkdwn_in": Array [

--- a/test/messages/__snapshots__/deployment-status.test.js.snap
+++ b/test/messages/__snapshots__/deployment-status.test.js.snap
@@ -40,6 +40,26 @@ Object {
 }
 `;
 
+exports[`Deployment status rendering works for in_progress status 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "author_icon": "https://avatars1.githubusercontent.com/u/7718702?v=4",
+      "author_link": "https://github.com/wilhelmklopp",
+      "author_name": "wilhelmklopp",
+      "color": "#dbab09",
+      "fallback": "[$(this.repository.full_name}] Deployment in progress for 3dce5c8 to github-slack-app",
+      "footer": "<https://github.com/github-slack/app|github-slack/app>",
+      "footer_icon": "https://assets-cdn.github.com/favicon.ico",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Deployment in progress <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to <https://dashboard.heroku.com/apps/github-slack-app/activity/builds/056df7bf-83c4-4ac1-911b-c8642413eef0|github-slack-app>",
+    },
+  ],
+}
+`;
+
 exports[`Deployment status rendering works for pending status 1`] = `
 Object {
   "attachments": Array [
@@ -55,6 +75,26 @@ Object {
         "text",
       ],
       "text": "Deploying <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to <https://dashboard.heroku.com/apps/github-slack-app|github-slack-app>",
+    },
+  ],
+}
+`;
+
+exports[`Deployment status rendering works for queued status 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "author_icon": "https://avatars1.githubusercontent.com/u/7718702?v=4",
+      "author_link": "https://github.com/wilhelmklopp",
+      "author_name": "wilhelmklopp",
+      "color": "#dbab09",
+      "fallback": "[$(this.repository.full_name}] Deployment queued for 3dce5c8 to github-slack-app",
+      "footer": "<https://github.com/github-slack/app|github-slack/app>",
+      "footer_icon": "https://assets-cdn.github.com/favicon.ico",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Deployment queued <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to <https://dashboard.heroku.com/apps/github-slack-app/activity/builds/056df7bf-83c4-4ac1-911b-c8642413eef0|github-slack-app>",
     },
   ],
 }

--- a/test/messages/deployment-status.test.js
+++ b/test/messages/deployment-status.test.js
@@ -32,6 +32,30 @@ describe('Deployment status rendering', () => {
     });
     expect(deploymentStatusMessage.toJSON()).toMatchSnapshot();
   });
+  test('works for in_progress status', () => {
+    const deploymentStatus = {
+      ...deploymentStatusSuccessFixture.deployment_status,
+      state: 'in_progress',
+    };
+    const deploymentStatusMessage = new DeploymentStatus({
+      deploymentStatus,
+      deployment: deploymentStatusSuccessFixture.deployment,
+      repository: deploymentStatusSuccessFixture.repository,
+    });
+    expect(deploymentStatusMessage.toJSON()).toMatchSnapshot();
+  });
+  test('works for queued status', () => {
+    const deploymentStatus = {
+      ...deploymentStatusSuccessFixture.deployment_status,
+      state: 'queued',
+    };
+    const deploymentStatusMessage = new DeploymentStatus({
+      deploymentStatus,
+      deployment: deploymentStatusSuccessFixture.deployment,
+      repository: deploymentStatusSuccessFixture.repository,
+    });
+    expect(deploymentStatusMessage.toJSON()).toMatchSnapshot();
+  });
   test('works for error status', () => {
     const deploymentStatus = {
       ...deploymentStatusSuccessFixture.deployment_status,


### PR DESCRIPTION
👋 

This improves how deployments in the two new beta statuses (`queued` and `in_progress`) are displayed. More information available about these statuses in the [Deployment Status documentation](https://developer.github.com/v3/repos/deployments/#create-a-deployment-status).

This lumps the two statuses into the same color as `pending` which seems appropriate to me.