### PR TITLE
Manual find-or-create for installations

### DIFF
--- a/lib/models/installation.js
+++ b/lib/models/installation.js
@@ -52,15 +52,24 @@ module.exports = (sequelize, DataTypes) => {
     },
 
     async install(payload) {
-      const [installation, created] = await Installation.findOrCreate({
+      // We don't use findOrCreate here because sequelize crashes
+      // when trying to provide a meaningful error when there's
+      // a race condition and a record matching the "where" is inserted
+      // right after not finding it.
+      // This internal sequelize error happens becuase we have a unique
+      // constraint on two columns (ownerId and githubId) but we
+      // only use ownerId in the `where` clause
+      let installation = await Installation.findOne({
         where: { ownerId: payload.account.id },
-        defaults: { githubId: payload.id },
       });
-
-      if (!created) {
+      if (!installation) {
+        installation = await Installation.create({
+          ownerId: payload.account.id,
+          githubId: payload.id,
+        });
+      } else {
         await installation.update({ githubId: payload.id });
       }
-
       return installation;
     },
 


### PR DESCRIPTION
Installations have a unique constraint on two columns and where using `Sequelize.Model.findOrCreate` with only one column in the `where` clause. If a matching record is inserted between the _find_ and the _create_ sequelize fails to create a proper error message becuase one of the columns in the unique constraint is not used in the `where` clause. This produced:

```
TypeError: Cannot read property 'toString' of undefined
  File "/app/node_modules/sequelize/lib/model.js", line 2151, col 58, in _.each
    if (value.toString() !== options.where[name].toString()) {
```

Closes https://github.com/github/ecosystem-integrations/issues/57