### PR TITLE
Fix signout suggestions

### DIFF
--- a/lib/activity/signout.js
+++ b/lib/activity/signout.js
@@ -1,4 +1,5 @@
 const getRepositories = require('../github/get-repositories');
+const getAccounts = require('../github/get-accounts');
 const { Subscription } = require('../models');
 const ReEnableMultipleSubscriptions = require('../messages/flow/re-enable-multiple-subscriptions');
 
@@ -10,9 +11,12 @@ module.exports = async (robot, slackUser, slackWorkspace) => {
 
     await Promise.all(Object.keys(subscriptionsByChannel).map(async (channel) => {
       const subscriptions = subscriptionsByChannel[channel];
-      const repositories = await getRepositories(subscriptions, robot);
-      if (repositories) {
-        const attachment = new ReEnableMultipleSubscriptions(repositories, slackUser.slackId, 'disconnected their GitHub account').getAttachment();
+      const repositoriesPromise = getRepositories(subscriptions.filter(s => s.type === 'repo'), robot);
+      const accountsPromise = getAccounts(subscriptions.filter(s => s.type === 'account'), robot);
+      const repositories = await repositoriesPromise;
+      const accounts = await accountsPromise;
+      if (repositories.length > 0 || accounts.length > 0) {
+        const attachment = new ReEnableMultipleSubscriptions(repositories, accounts, slackUser.slackId, 'disconnected their GitHub account').getAttachment();
         return slackWorkspace.client.chat.postMessage({
           channel,
           attachments: [attachment],

--- a/lib/messages/flow/re-enable-multiple-subscriptions.js
+++ b/lib/messages/flow/re-enable-multiple-subscriptions.js
@@ -1,25 +1,35 @@
 const { Message } = require('..');
 
 module.exports = class ReEnableMultipleSubscriptions extends Message {
-  constructor(subscribedRepositories, creator, reason) {
+  constructor(subscribedRepositories, subscribedAccounts, creator, reason) {
     super({});
-    this.plural = subscribedRepositories.length !== 1;
+    const total = subscribedRepositories.length + subscribedAccounts.length;
+    this.plural = total !== 1;
     this.repositories = subscribedRepositories;
+    this.accounts = subscribedAccounts;
     this.creator = creator;
     this.reason = reason;
   }
 
   get introduction() {
-    return `${this.plural ? 'Subscriptions' : 'The subscription'} to ` +
-     `${this.repositories.length} ${this.plural ? 'repositories have' : 'repository has'} been disabled, ` +
+    const message = [
+      this.repositories.length > 0 ? `${this.repositories.length} ${this.repositories.length > 1 ? 'repositories' : 'repository'}` : null,
+      this.accounts.length > 0 ? `${this.accounts.length} ${this.accounts.length > 1 ? 'accounts' : 'account'}` : null,
+    ].filter(Boolean).join(' and ');
+    return `${this.plural ? 'Subscriptions' : 'The subscription'} to ${message} ${this.plural ? 'have' : 'has'} been disabled ` +
       `because <@${this.creator}>, who originally set ${this.plural ? 'them' : 'it'} up, has ${this.reason}.\n` +
       `Use the following slash command${this.plural ? 's' : ''} to re-enable the subscription${this.plural ? 's' : ''}:`;
   }
 
   get commands() {
-    return this.repositories.map(repository => (
-      `/github subscribe ${repository.full_name}`
-    )).join('\n');
+    return [
+      ...this.repositories.map(repository => (
+        `/github subscribe ${repository.full_name}`
+      )),
+      ...this.accounts.map(account => (
+        `/github subscribe ${account.login}`
+      )),
+    ].join('\n');
   }
 
   getAttachment() {

--- a/test/integration/__snapshots__/github-app-authorization-revoked.test.js.snap
+++ b/test/integration/__snapshots__/github-app-authorization-revoked.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 1`] = `
 Object {
-  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"Subscriptions to 2 repositories have been disabled, because <@U2147483697>, who originally set them up, has disconnected their GitHub account.\\\\nUse the following slash commands to re-enable the subscriptions:\\\\n/github subscribe atom/atom\\\\n/github subscribe kubernetes/kubernetes\\"}]",
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"Subscriptions to 2 repositories have been disabled because <@U2147483697>, who originally set them up, has disconnected their GitHub account.\\\\nUse the following slash commands to re-enable the subscriptions:\\\\n/github subscribe atom/atom\\\\n/github subscribe kubernetes/kubernetes\\"}]",
   "channel": "C2147483705",
   "token": "xoxp-token",
 }
@@ -10,7 +10,7 @@ Object {
 
 exports[`Integration: github_app_authorization.revoked works for a user  who has connected their GitHub account to one Slack workspace 2`] = `
 Object {
-  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled, because <@U2147483697>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe integrations/slack\\"}]",
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled because <@U2147483697>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe integrations/slack\\"}]",
   "channel": "C12345",
   "token": "xoxp-token",
 }
@@ -22,7 +22,7 @@ exports[`Integration: github_app_authorization.revoked works for a user  who has
 
 exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 1`] = `
 Object {
-  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"Subscriptions to 2 repositories have been disabled, because <@U2147483697>, who originally set them up, has disconnected their GitHub account.\\\\nUse the following slash commands to re-enable the subscriptions:\\\\n/github subscribe atom/atom\\\\n/github subscribe kubernetes/kubernetes\\"}]",
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"Subscriptions to 2 repositories have been disabled because <@U2147483697>, who originally set them up, has disconnected their GitHub account.\\\\nUse the following slash commands to re-enable the subscriptions:\\\\n/github subscribe atom/atom\\\\n/github subscribe kubernetes/kubernetes\\"}]",
   "channel": "C2147483705",
   "token": "xoxp-token",
 }
@@ -30,7 +30,7 @@ Object {
 
 exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 2`] = `
 Object {
-  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled, because <@U2147483697>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe integrations/slack\\"}]",
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled because <@U2147483697>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe integrations/slack\\"}]",
   "channel": "C12345",
   "token": "xoxp-token",
 }
@@ -38,7 +38,7 @@ Object {
 
 exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 3`] = `
 Object {
-  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled, because <@U123456>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe integrations/slack\\"}]",
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled because <@U123456>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe integrations/slack\\"}]",
   "channel": "C12121212",
   "token": "xoxp-token",
 }
@@ -46,7 +46,7 @@ Object {
 
 exports[`Integration: github_app_authorization.revoked works for a user who has connected their GitHub account to multiple Slack workspaces 4`] = `
 Object {
-  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled, because <@U123456>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe kubernetes/kubernetes\\"}]",
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled because <@U123456>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe kubernetes/kubernetes\\"}]",
   "channel": "C9999999",
   "token": "xoxp-token",
 }

--- a/test/integration/__snapshots__/signout.test.js.snap
+++ b/test/integration/__snapshots__/signout.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Integration: signout a signed in user is successfully signed out and relevant subscriptions are deleted 1`] = `
 Object {
-  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"Subscriptions to 2 repositories have been disabled, because <@U2147483697>, who originally set them up, has disconnected their GitHub account.\\\\nUse the following slash commands to re-enable the subscriptions:\\\\n/github subscribe atom/atom\\\\n/github subscribe kubernetes/kubernetes\\"}]",
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"Subscriptions to 2 repositories have been disabled because <@U2147483697>, who originally set them up, has disconnected their GitHub account.\\\\nUse the following slash commands to re-enable the subscriptions:\\\\n/github subscribe atom/atom\\\\n/github subscribe kubernetes/kubernetes\\"}]",
   "channel": "C2147483705",
   "token": "xoxp-token",
 }
@@ -10,7 +10,7 @@ Object {
 
 exports[`Integration: signout a signed in user is successfully signed out and relevant subscriptions are deleted 2`] = `
 Object {
-  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 repository has been disabled, because <@U2147483697>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe integrations/slack\\"}]",
+  "attachments": "[{\\"color\\":\\"#24292f\\",\\"mrkdwn_in\\":[\\"text\\"],\\"text\\":\\"The subscription to 1 account has been disabled because <@U2147483697>, who originally set it up, has disconnected their GitHub account.\\\\nUse the following slash command to re-enable the subscription:\\\\n/github subscribe github\\"}]",
   "channel": "C12345",
   "token": "xoxp-token",
 }

--- a/test/integration/signout.test.js
+++ b/test/integration/signout.test.js
@@ -69,7 +69,7 @@ describe('Integration: signout', async () => {
       installationId: installation2.id,
       slackWorkspaceId: workspace.id,
       creatorId: slackUser.id,
-      type: 'repo',
+      type: 'account',
     });
   });
   test('a signed out user is prompted to sign in first', async () => {
@@ -121,8 +121,8 @@ describe('Integration: signout', async () => {
       full_name: 'kubernetes/kubernetes',
     });
 
-    nock('https://api.github.com').get('/repositories/3').reply(200, {
-      full_name: 'integrations/slack',
+    nock('https://api.github.com').get('/user/3').reply(200, {
+      login: 'github',
     });
 
     nock('https://slack.com').post('/api/chat.postMessage', (body) => {

--- a/test/messages/flow/__snapshots__/re-enable-multiple-subscriptions.test.js.snap
+++ b/test/messages/flow/__snapshots__/re-enable-multiple-subscriptions.test.js.snap
@@ -6,11 +6,43 @@ Object {
   "mrkdwn_in": Array [
     "text",
   ],
-  "text": "Subscriptions to 4 repositories have been disabled, because <@U12345>, who originally set them up, has disconnected their GitHub account.
+  "text": "Subscriptions to 4 repositories and 3 accounts have been disabled because <@U12345>, who originally set them up, has disconnected their GitHub account.
+Use the following slash commands to re-enable the subscriptions:
+/github subscribe kubernetes/kubernetes
+/github subscribe facebook/react
+/github subscribe django/django
+/github subscribe microsoft/typescript
+/github subscribe kubernetes
+/github subscribe django
+/github subscribe microsoft",
+}
+`;
+
+exports[`ReEnableMultipleSubscriptions message rendering works with empty account subscriptions 1`] = `
+Object {
+  "color": "#24292f",
+  "mrkdwn_in": Array [
+    "text",
+  ],
+  "text": "Subscriptions to 4 repositories have been disabled because <@U12345>, who originally set them up, has disconnected their GitHub account.
 Use the following slash commands to re-enable the subscriptions:
 /github subscribe kubernetes/kubernetes
 /github subscribe facebook/react
 /github subscribe django/django
 /github subscribe microsoft/typescript",
+}
+`;
+
+exports[`ReEnableMultipleSubscriptions message rendering works with empty repository subscriptions 1`] = `
+Object {
+  "color": "#24292f",
+  "mrkdwn_in": Array [
+    "text",
+  ],
+  "text": "Subscriptions to 3 accounts have been disabled because <@U12345>, who originally set them up, has disconnected their GitHub account.
+Use the following slash commands to re-enable the subscriptions:
+/github subscribe kubernetes
+/github subscribe django
+/github subscribe microsoft",
 }
 `;

--- a/test/messages/flow/re-enable-multiple-subscriptions.test.js
+++ b/test/messages/flow/re-enable-multiple-subscriptions.test.js
@@ -16,8 +16,67 @@ describe('ReEnableMultipleSubscriptions message rendering', () => {
         full_name: 'microsoft/typescript',
       },
     ];
+    const subscribedAccounts = [
+      {
+        login: 'kubernetes',
+      },
+      {
+        login: 'django',
+      },
+      {
+        login: 'microsoft',
+      },
+    ];
     const message = new ReEnableMultipleSubscriptions(
       subscribedRepositories,
+      subscribedAccounts,
+      'U12345',
+      'disconnected their GitHub account',
+    );
+    expect(message.getAttachment()).toMatchSnapshot();
+  });
+
+  test('works with empty repository subscriptions', async () => {
+    const subscribedRepositories = [];
+    const subscribedAccounts = [
+      {
+        login: 'kubernetes',
+      },
+      {
+        login: 'django',
+      },
+      {
+        login: 'microsoft',
+      },
+    ];
+    const message = new ReEnableMultipleSubscriptions(
+      subscribedRepositories,
+      subscribedAccounts,
+      'U12345',
+      'disconnected their GitHub account',
+    );
+    expect(message.getAttachment()).toMatchSnapshot();
+  });
+
+  test('works with empty account subscriptions', async () => {
+    const subscribedRepositories = [
+      {
+        full_name: 'kubernetes/kubernetes',
+      },
+      {
+        full_name: 'facebook/react',
+      },
+      {
+        full_name: 'django/django',
+      },
+      {
+        full_name: 'microsoft/typescript',
+      },
+    ];
+    const subscribedAccounts = [];
+    const message = new ReEnableMultipleSubscriptions(
+      subscribedRepositories,
+      subscribedAccounts,
       'U12345',
       'disconnected their GitHub account',
     );


### PR DESCRIPTION
The signout message that explains how to re-enable subscriptions assumes that all subscriptions are repositories. This PR changes the code to correctly show both types of subscriptions (repo and account).

cc https://github.com/github/ecosystem-primitives/issues/156