### PR TITLE
Additional debugging for some destroyed subscriptions

### DIFF
--- a/lib/activity/router.js
+++ b/lib/activity/router.js
@@ -80,7 +80,7 @@ module.exports = function route(callback) {
           await callback(context, subscription, slack);
         } catch (err) {
           if (isPermanentError(err)) {
-            context.log.info({ err }, 'Permanent error from Slack. Removing subscription');
+            context.log.info({ err, subscription, payload: context.payload }, 'Permanent error from Slack. Removing subscription');
             await subscription.destroy();
           } else {
             throw err;

--- a/lib/activity/router.js
+++ b/lib/activity/router.js
@@ -80,7 +80,11 @@ module.exports = function route(callback) {
           await callback(context, subscription, slack);
         } catch (err) {
           if (isPermanentError(err)) {
-            context.log.info({ err, subscription, payload: context.payload }, 'Permanent error from Slack. Removing subscription');
+            const { repository } = context.payload;
+            const info = {
+              err, subscription, eventType, repo: repository.full_name,
+            };
+            context.log.info(info, 'Permanent error from Slack. Removing subscription');
             await subscription.destroy();
           } else {
             throw err;


### PR DESCRIPTION
Add additional debugging information when destroying a subscription for a permanent error. This way we will be able to investigate issues some users are reporting.

We are getting too many logs of this type:

> Error: An API error occurred: no_permission

and

> Error: An API error occurred: is_archived

@wilhelmklopp I'm wondering if we could have more detailed information from Slack about the error. Any idea?