### PR TITLE
Gray line for Draft PRs

### DIFF
--- a/lib/activity/pull-requests.js
+++ b/lib/activity/pull-requests.js
@@ -20,6 +20,7 @@ async function pullRequestEvent(context, subscription, slack) {
     pullRequest = (await context.github.pullRequests.get(context.issue({
       headers: { accept: 'application/vnd.github.html+json' },
     }))).data;
+    pullRequest.draft = context.payload.pull_request.draft;
   }
 
   const eventType = `${context.event}.${context.payload.action}`;

--- a/lib/activity/pull-requests.js
+++ b/lib/activity/pull-requests.js
@@ -18,9 +18,10 @@ async function pullRequestEvent(context, subscription, slack) {
   if (context.payload.action === 'opened') {
     // need seperate api request to get labels, body_html, requested_reviewers and requested_teams
     pullRequest = (await context.github.pullRequests.get(context.issue({
-      headers: { accept: 'application/vnd.github.html+json' },
+      headers: {
+        accept: ['application/vnd.github.html+json', 'application/vnd.github.shadow-cat-preview'],
+      },
     }))).data;
-    pullRequest.draft = context.payload.pull_request.draft;
   }
 
   const eventType = `${context.event}.${context.payload.action}`;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -19,8 +19,9 @@ function arrayToFormattedString(array, key) {
   return output;
 }
 
-function getHexColorbyState(state, merged = false) {
+function getHexColorbyState(state, merged = false, draft = false) {
   if (state === 'open') {
+    if (draft) return constants.DRAFT_GRAY;
     return constants.OPEN_GREEN;
   } else if (state === 'closed' && merged === false) {
     return constants.CLOSED_RED;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -19,10 +19,9 @@ function arrayToFormattedString(array, key) {
   return output;
 }
 
-function getHexColorbyState(state, merged = false, draft = false) {
+function getHexColorByState(state, merged = false, draft = false) {
   if (state === 'open') {
-    if (draft) return constants.DRAFT_GRAY;
-    return constants.OPEN_GREEN;
+    return draft ? constants.DRAFT_GRAY : constants.OPEN_GREEN;
   } else if (state === 'closed' && merged === false) {
     return constants.CLOSED_RED;
   } else if (state === 'closed' && merged === true) {
@@ -42,6 +41,6 @@ function getStatusColor(status) {
 
 module.exports = {
   arrayToFormattedString,
-  getHexColorbyState,
+  getHexColorByState,
   getStatusColor,
 };

--- a/lib/messages/abstract-issue.js
+++ b/lib/messages/abstract-issue.js
@@ -1,5 +1,6 @@
 const moment = require('moment');
 const mrkdwn = require('html-to-mrkdwn');
+const { getHexColorByState } = require('../helpers');
 
 const {
   constants,
@@ -21,17 +22,6 @@ class AbstractIssue extends Message {
 
     if (constants.MAJOR_MESSAGES[this.eventType] || this.unfurlType === 'full') {
       this.major = true;
-    }
-  }
-
-  static getHexColorbyState(state, merged = false, draft = false) {
-    if (state === 'open') {
-      if (draft) return constants.DRAFT_GRAY;
-      return constants.OPEN_GREEN;
-    } else if (state === 'closed' && merged === false) {
-      return constants.CLOSED_RED;
-    } else if (state === 'closed' && merged === true) {
-      return constants.MERGED_PURPLE;
     }
   }
 
@@ -84,7 +74,7 @@ class AbstractIssue extends Message {
   getBaseMessage() {
     return {
       ...super.getBaseMessage(),
-      color: this.constructor.getHexColorbyState(
+      color: getHexColorByState(
         this.abstractIssue.state,
         this.abstractIssue.merged,
         this.abstractIssue.draft,

--- a/lib/messages/abstract-issue.js
+++ b/lib/messages/abstract-issue.js
@@ -24,8 +24,9 @@ class AbstractIssue extends Message {
     }
   }
 
-  static getHexColorbyState(state, merged = false) {
+  static getHexColorbyState(state, merged = false, draft = false) {
     if (state === 'open') {
+      if (draft) return constants.DRAFT_GRAY;
       return constants.OPEN_GREEN;
     } else if (state === 'closed' && merged === false) {
       return constants.CLOSED_RED;
@@ -86,6 +87,7 @@ class AbstractIssue extends Message {
       color: this.constructor.getHexColorbyState(
         this.abstractIssue.state,
         this.abstractIssue.merged,
+        this.abstractIssue.draft,
       ),
       ts: this.createdAt.unix(),
       mrkdwn_in: ['text'],

--- a/lib/messages/index.js
+++ b/lib/messages/index.js
@@ -9,6 +9,7 @@ const constants = {
   },
   MERGED_PURPLE: '#6f42c1',
   OPEN_GREEN: '#36a64f',
+  DRAFT_GRAY: '#6a737d',
   STATUS_FAILURE: '#cb2431',
   STATUS_PENDING: '#dbab09',
   STATUS_SUCCESS: '#28a745',

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -44,6 +44,14 @@ test('gets purple hex color on closed and merged state', () => {
   expect(getHexColorbyState('closed', true)).toBe(constants.MERGED_PURPLE);
 });
 
+test('gets gray hex color on opened draft pull requests', () => {
+  expect(getHexColorbyState('opened', false, true)).toBe(constants.DRAFT_GRAY);
+});
+
+test('gets red hex color on closed draft pull requests', () => {
+  expect(getHexColorbyState('closed', false, true)).toBe(constants.CLOSED_RED);
+});
+
 test('gets correct status color on success', () => {
   expect(getStatusColor('success')).toBe(constants.STATUS_SUCCESS);
 });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,6 +1,6 @@
 const {
   arrayToFormattedString,
-  getHexColorbyState,
+  getHexColorByState,
   getStatusColor,
 } = require('../lib/helpers');
 
@@ -33,23 +33,23 @@ test('formats assignee array into string (single)', () => {
 });
 
 test('gets green hex color on open state', () => {
-  expect(getHexColorbyState('open')).toBe(constants.OPEN_GREEN);
+  expect(getHexColorByState('open')).toBe(constants.OPEN_GREEN);
 });
 
 test('gets red hex color on closed state', () => {
-  expect(getHexColorbyState('closed', false)).toBe(constants.CLOSED_RED);
+  expect(getHexColorByState('closed', false)).toBe(constants.CLOSED_RED);
 });
 
 test('gets purple hex color on closed and merged state', () => {
-  expect(getHexColorbyState('closed', true)).toBe(constants.MERGED_PURPLE);
+  expect(getHexColorByState('closed', true)).toBe(constants.MERGED_PURPLE);
 });
 
 test('gets gray hex color on opened draft pull requests', () => {
-  expect(getHexColorbyState('opened', false, true)).toBe(constants.DRAFT_GRAY);
+  expect(getHexColorByState('opened', false, true)).toBe(constants.DRAFT_GRAY);
 });
 
 test('gets red hex color on closed draft pull requests', () => {
-  expect(getHexColorbyState('closed', false, true)).toBe(constants.CLOSED_RED);
+  expect(getHexColorByState('closed', false, true)).toBe(constants.CLOSED_RED);
 });
 
 test('gets correct status color on success', () => {

--- a/test/messages/abstract-issue.test.js
+++ b/test/messages/abstract-issue.test.js
@@ -1,5 +1,4 @@
 const { AbstractIssue } = require('../../lib/messages/abstract-issue');
-const { constants } = require('../../lib/messages');
 
 const fixtures = require('../fixtures');
 const issuesOpened = require('../fixtures/webhooks/issues.opened.json');
@@ -15,10 +14,6 @@ describe('AbstractIssue rendering', () => {
       unfurl: false,
       sender: issuesOpened.sender,
     });
-  });
-  test('works for getHexColorbyState', async () => {
-    const color = AbstractIssue.getHexColorbyState(issuesOpened.issue.state);
-    expect(color).toEqual(constants.OPEN_GREEN);
   });
 
   test('works for getAuthor', async () => {


### PR DESCRIPTION
This PR changes the highlight color for newly opened Draft PRs to be gray instead of green. I've added a test to ensure that closed Draft PRs are still red 🔴. **Note**: I haven't actually tried this in a real Slack environment as I don't have all the workspace stuff setup.

Also - @tcbyrd pointed me to [this `getHexColorbyState`](https://github.com/integrations/slack/blob/36098600529d7a416970ea8c783b3df984689151/lib/messages/abstract-issue.js#L27-L35), but there's [another exact duplicate in `helper.js`](https://github.com/integrations/slack/blob/36098600529d7a416970ea8c783b3df984689151/lib/helpers.js#L22-L30). As far as I can tell, only the former is ever used so I'm guessing this can be 🔪? Let me know if you'd like that in this PR!

Closes #788 