### PR TITLE
Reduce production logging

### DIFF
--- a/db/config.json
+++ b/db/config.json
@@ -13,10 +13,11 @@
   },
   "production": {
     "use_env_variable": "DATABASE_URL",
+    "disable_sql_logging": true,
     "operatorsAliases": false,
     "ssl": true,
     "dialectOptions": {
-        "ssl": true
+      "ssl": true
     }
   }
 }

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -10,12 +10,14 @@ const logger = require('../logger');
 
 const db = { logger };
 
+const logging = config.disable_sql_logging
+  ? undefined
+  : (query, ms) => logger.debug({ ms }, query);
+
 Object.assign(config, {
   operatorsAliases: false,
   benchmark: true,
-  logging: (query, ms) => {
-    logger.debug({ ms }, query);
-  },
+  logging,
 });
 
 let sequelize;


### PR DESCRIPTION
cc https://github.com/github/ecosystem-primitives/issues/139

In order to reduce the volume of logs this PR disables logging SQL queries in production.