### PR TITLE
Add GitHub Marketplace link to footer

### DIFF
--- a/lib/messages/flow/help.js
+++ b/lib/messages/flow/help.js
@@ -68,7 +68,8 @@ module.exports = class Help extends Message {
       footer: [
         '<https://github.com/integrations/slack#readme|Learn More>',
         `<${supportLink()}|Contact Support>`,
-      ].join(' — '),
+        '<https://github.com/marketplace?query=slack|Browse other Slack integrations>'
+      ].join(' · '),
     });
     this.command = command;
     this.subcommand = subcommand;

--- a/lib/messages/flow/help.js
+++ b/lib/messages/flow/help.js
@@ -68,7 +68,7 @@ module.exports = class Help extends Message {
       footer: [
         '<https://github.com/integrations/slack#readme|Learn More>',
         `<${supportLink()}|Contact Support>`,
-        '<https://github.com/marketplace?query=slack|Browse other Slack integrations>'
+        '<https://github.com/marketplace?query=slack|Browse other Slack integrations>',
       ].join(' · '),
     });
     this.command = command;

--- a/test/integration/__snapshots__/help.test.js.snap
+++ b/test/integration/__snapshots__/help.test.js.snap
@@ -96,7 +96,7 @@ Object {
     },
     Object {
       "color": "",
-      "footer": "<https://github.com/integrations/slack#readme|Learn More> — <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
+      "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support> · <https://github.com/marketplace?query=slack|Browse other Slack integrations>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "text": "",
     },
@@ -228,7 +228,7 @@ Object {
     },
     Object {
       "color": "",
-      "footer": "<https://github.com/integrations/slack#readme|Learn More> — <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
+      "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support> · <https://github.com/marketplace?query=slack|Browse other Slack integrations>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "text": "",
     },
@@ -360,7 +360,7 @@ Object {
     },
     Object {
       "color": "",
-      "footer": "<https://github.com/integrations/slack#readme|Learn More> — <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
+      "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support> · <https://github.com/marketplace?query=slack|Browse other Slack integrations>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "text": "",
     },

--- a/test/integration/__snapshots__/list-subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/list-subscriptions.test.js.snap
@@ -106,7 +106,7 @@ Object {
     },
     Object {
       "color": "",
-      "footer": "<https://github.com/integrations/slack#readme|Learn More> — <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
+      "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support> · <https://github.com/marketplace?query=slack|Browse other Slack integrations>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "text": "",
     },

--- a/test/messages/flow/__snapshots__/help.test.js.snap
+++ b/test/messages/flow/__snapshots__/help.test.js.snap
@@ -96,7 +96,7 @@ Object {
     },
     Object {
       "color": "",
-      "footer": "<https://github.com/integrations/slack#readme|Learn More> — <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support>",
+      "footer": "<https://github.com/integrations/slack#readme|Learn More> · <https://github.com/contact?form%5Bsubject%5D=GitHub%2BSlack%20integration|Contact Support> · <https://github.com/marketplace?query=slack|Browse other Slack integrations>",
       "footer_icon": "https://assets-cdn.github.com/favicon.ico",
       "text": "",
     },


### PR DESCRIPTION
## tldr

This is a new pull request based on feedback in https://github.com/integrations/slack/pull/768. The changes in this PR are:

* This PR adds a subtle "Browse other Slack integrations" link to the *footer* beside the support links.
* The link in this pull request uses a search query for Slack so as to not include any non-Slack integrations.

## Description

Every user has unique needs and preferences for Slack integration, and no single tool can solve them all. The GitHub Marketplace Actions<sup>1</sup> and Apps for Slack that enable a lot of custom functionality.

It's evident that users lack awareness of Marketplace, Actions, etc since this repo receives a lot of specific requests that could be solved with Actions<sup>2</sup> and Apps like Pull Reminders https://github.com/integrations/slack/issues/789.

Adding a link to Marketplace will help create awareness of more solutions, benefiting both end-users and GitHub by:

1. Steering users toward solutions so they don't get stuck or frustrated
2. Reducing support tickets for this project, many of which pertain to specific needs that can be addressed with GitHub Actions or Apps
3. Encouraging users to discover and get their hands dirty with Actions and Apps

<sup>[1]</sup> @nholden's [recent blog post](https://dev.to/nholden/how-i-replaced-a-rails-app-with-a-few-dozen-lines-of-ruby-3l1m) is a great example how an entire custom Slack bot can be re-implemented as a simple GitHub Action.
<sup>[2]</sup> In response to feature requests from Pull Reminders users, I have been recommending GitHub Actions and the results have been 💯 

## Screenshots

<img width="469" alt="screen shot 2019-02-25 at 12 42 57 pm" src="https://user-images.githubusercontent.com/50083/53364665-8ffac080-38fc-11e9-9236-d25a681b436d.png">

<img width="450" alt="screen shot 2019-02-25 at 12 40 32 pm" src="https://user-images.githubusercontent.com/50083/53364700-a012a000-38fc-11e9-9f7a-97502faa7ec8.png">