### PR TITLE
Remove slackEvent case from signed params OAuth handling

### DIFF
--- a/lib/github/oauth.js
+++ b/lib/github/oauth.js
@@ -40,10 +40,6 @@ module.exports = (robot) => {
       teamSlackId = command.team_id;
       channelSlackId = command.channel_id;
       userSlackId = command.user_id;
-    } else if (state.slackEvent) {
-      teamSlackId = state.slackEvent.team_id;
-      userSlackId = state.slackEvent.event.user;
-      channelSlackId = state.slackEvent.event.channel;
     } else if (state.slackAction) {
       teamSlackId = state.slackAction.team.id;
       userSlackId = state.slackAction.user.id;


### PR DESCRIPTION
I just discovered that these lines are no longer in use as of https://github.com/integrations/slack/pull/598 so we should be able to get rid of them