### PR TITLE
Simplify signed params content

### DIFF
--- a/lib/commands/signin.js
+++ b/lib/commands/signin.js
@@ -8,6 +8,10 @@ module.exports = async (req, res) => {
 
   const state = new SignedParams({
     trigger_id: command.trigger_id,
+    teamSlackId: command.team_id,
+    userSlackId: command.user_id,
+    channelSlackId: command.channel_id,
+    replaySlashCommand: !command.text.startsWith('signin'),
   });
 
   const { protocol, host } = getProtocolAndHost(req);

--- a/lib/commands/signin.js
+++ b/lib/commands/signin.js
@@ -11,7 +11,7 @@ module.exports = async (req, res) => {
     teamSlackId: command.team_id,
     userSlackId: command.user_id,
     channelSlackId: command.channel_id,
-    replaySlashCommand: !command.subcommand.startsWith('signin'),
+    replaySlashCommand: !(command.subcommand.startsWith('signin') || command.subcommand.startsWith('signout')),
   });
 
   const { protocol, host } = getProtocolAndHost(req);

--- a/lib/commands/signin.js
+++ b/lib/commands/signin.js
@@ -11,7 +11,7 @@ module.exports = async (req, res) => {
     teamSlackId: command.team_id,
     userSlackId: command.user_id,
     channelSlackId: command.channel_id,
-    replaySlashCommand: !command.text.startsWith('signin'),
+    replaySlashCommand: !command.subcommand.startsWith('signin'),
   });
 
   const { protocol, host } = getProtocolAndHost(req);

--- a/lib/commands/signout.js
+++ b/lib/commands/signout.js
@@ -15,7 +15,10 @@ module.exports = async (req, res) => {
   await signout(robot, slackUser, slackWorkspace);
 
   const state = new SignedParams({
-    trigger_id: command.trigger_id,
+    teamSlackId: command.team_id,
+    userSlackId: command.user_id,
+    channelSlackId: command.channel_id,
+    replaySlashCommand: false,
   });
 
   const { protocol, host } = getProtocolAndHost(req);

--- a/lib/github/oauth.js
+++ b/lib/github/oauth.js
@@ -23,9 +23,17 @@ module.exports = (robot) => {
   });
 
   robot.route().get('/github/oauth/callback', async (req, res) => {
-    // @todo: handle condition where state is expired or has been tampered with
-    // Make sure there is a test for the condition where the state has been tampered with
-    const state = await SignedParams.load(req.query.state);
+    let state;
+    try {
+      state = await SignedParams.load(req.query.state);
+    } catch (err) {
+      if (err.name && err.name === 'JsonWebTokenError') {
+        return res.status(400).send(`Error: ${err.message}`);
+      } else if (err.name && err.name === 'TokenExpiredError') {
+        return res.status(400).send(`Error: ${err.message}`);
+      }
+      throw err;
+    }
 
     const { teamSlackId, userSlackId, channelSlackId } = state;
 
@@ -83,12 +91,16 @@ module.exports = (robot) => {
       attachments: [new SignInConfirm(userSlackId, user.html_url, user.login).getAttachment()],
     });
 
+    const redirectUrl = `https://slack.com/app_redirect?team=${teamSlackId}&channel=${channelSlackId}`;
+
     if (state.replaySlashCommand) {
       const command = await PendingCommand.find(state.trigger_id);
 
       if (!command) {
-        // FIXME: handle issue with expired command
-        throw new Error();
+        // In case it has been more than 30min since the user
+        // executed the initial command, we won't have it in the cache anymore
+        // so we just send them back to Slack without replaying the command
+        return res.redirect(redirectUrl);
       }
 
       return res.redirect(`/slack/command?trigger_id=${command.trigger_id}`);
@@ -98,8 +110,6 @@ module.exports = (robot) => {
       // attempt to fulfil request to unfurl link now that the user is connected
       await deliverAfterSignIn(state.actionCallbackId.replace('unfurl-', ''));
     }
-
-    const redirectUrl = `https://slack.com/app_redirect?team=${teamSlackId}&channel=${channelSlackId}`;
 
     return res.redirect(redirectUrl);
   });

--- a/lib/github/oauth.js
+++ b/lib/github/oauth.js
@@ -24,29 +24,12 @@ module.exports = (robot) => {
 
   robot.route().get('/github/oauth/callback', async (req, res) => {
     // @todo: handle condition where state is expired or has been tampered with
+    // Make sure there is a test for the condition where the state has been tampered with
     const state = await SignedParams.load(req.query.state);
 
-    let command;
-    let teamSlackId;
-    let channelSlackId;
-    let userSlackId;
-    if (state.trigger_id) {
-      command = await PendingCommand.find(state.trigger_id);
+    const { teamSlackId, userSlackId, channelSlackId } = state;
 
-      if (!command) {
-        // FIXME: handle issue with expired command
-        throw new Error();
-      }
-      teamSlackId = command.team_id;
-      channelSlackId = command.channel_id;
-      userSlackId = command.user_id;
-    } else if (state.slackAction) {
-      teamSlackId = state.slackAction.team.id;
-      userSlackId = state.slackAction.user.id;
-      channelSlackId = state.slackAction.channel.id;
-    }
-
-    req.log({ state, command }, 'Restoring state to authenticate user');
+    req.log({ state }, 'Restoring state to authenticate user');
 
     // complete OAuth dance
     const accessTokenResponse = await axios.post(
@@ -94,31 +77,30 @@ module.exports = (robot) => {
 
     robot.log({ gitHubUser, slackUser }, 'Linked User');
 
-    req.session.slackUserId = slackUser.id;
-
-    const redirectUrl = `https://slack.com/app_redirect?team=${teamSlackId}&channel=${channelSlackId}`;
-    if (command) {
-      await axios.post(command.response_url, {
-        response_type: 'ephemeral',
-        attachments: [new SignInConfirm(userSlackId, user.html_url, user.login).getAttachment()],
-      });
-
-      if (command.text.startsWith('signin')) {
-        return res.redirect(redirectUrl);
-      } else if (command.text.startsWith('signout')) {
-        return res.redirect(redirectUrl);
-      }
-      return res.redirect(`/slack/command?trigger_id=${command.trigger_id}`);
-    }
     await workspace.client.chat.postEphemeral({
       channel: channelSlackId,
       user: userSlackId,
       attachments: [new SignInConfirm(userSlackId, user.html_url, user.login).getAttachment()],
     });
-    if (state.slackAction && /unfurl-\d+/.test(state.slackAction.callback_id)) {
-      // attempt to fulfil request to unfurl link now that the user is connected
-      await deliverAfterSignIn(state.slackAction.callback_id.replace('unfurl-', ''));
+
+    if (state.replaySlashCommand) {
+      const command = await PendingCommand.find(state.trigger_id);
+
+      if (!command) {
+        // FIXME: handle issue with expired command
+        throw new Error();
+      }
+
+      return res.redirect(`/slack/command?trigger_id=${command.trigger_id}`);
     }
+
+    if (state.actionCallbackId && /unfurl-\d+/.test(state.actionCallbackId)) {
+      // attempt to fulfil request to unfurl link now that the user is connected
+      await deliverAfterSignIn(state.actionCallbackId.replace('unfurl-', ''));
+    }
+
+    const redirectUrl = `https://slack.com/app_redirect?team=${teamSlackId}&channel=${channelSlackId}`;
+
     return res.redirect(redirectUrl);
   });
 

--- a/lib/middleware/get-installation.js
+++ b/lib/middleware/get-installation.js
@@ -36,6 +36,10 @@ module.exports = async function getInstallation(req, res, next) {
 
     const state = new SignedParams({
       trigger_id: command.trigger_id,
+      replaySlashCommand: true,
+      teamSlackId: command.team_id,
+      userSlackId: command.user_id,
+      channelSlackId: command.channel_id,
     });
 
     const { protocol, host } = getProtocolAndHost(req);

--- a/lib/middleware/require-github-user.js
+++ b/lib/middleware/require-github-user.js
@@ -11,7 +11,12 @@ module.exports = async function requireGitHubUser(req, res, next) {
   const { slackUser } = res.locals;
 
   if (!slackUser.GitHubUser) {
-    const state = new SignedParams({ slackAction: { ...req.body, token: undefined } });
+    const state = new SignedParams({
+      actionCallbackId: req.body.callback_id,
+      teamSlackId: req.body.team.id,
+      userSlackId: req.body.user.id,
+      channelSlackId: req.body.channel.id,
+    });
     const { protocol, host } = getProtocolAndHost(req);
     const message = new SignIn(`${protocol}://${host}/github/oauth/login?state=${await state.stringify()}`);
 

--- a/lib/unfurls/show-rich-preview.js
+++ b/lib/unfurls/show-rich-preview.js
@@ -38,7 +38,12 @@ async function deliverUnfurl(req, res) {
 
   await slackUser.reload({ include: [GitHubUser] });
   if (!slackUser.GitHubUser) {
-    const state = new SignedParams({ slackAction: { ...req.body, token: undefined } });
+    const state = new SignedParams({
+      actionCallbackId: req.body.callback_id,
+      teamSlackId: req.body.team.id,
+      userSlackId: req.body.user.id,
+      channelSlackId: req.body.channel.id,
+    });
     const { protocol, host } = getProtocolAndHost(req);
     return res.send({
       delete_original: true,

--- a/test/integration/__snapshots__/signin.test.js.snap
+++ b/test/integration/__snapshots__/signin.test.js.snap
@@ -1,18 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate 1`] = `
-Object {
-  "attachments": Array [
-    Object {
-      "color": "#24292f",
-      "mrkdwn_in": Array [
-        "text",
-      ],
-      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
-    },
-  ],
-  "response_type": "ephemeral",
-}
+Array [
+  Object {
+    "color": "#24292f",
+    "mrkdwn_in": Array [
+      "text",
+    ],
+    "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+  },
+]
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate 2`] = `
@@ -52,18 +49,15 @@ Map {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "close https://github.com/owner/repo/issues/123" 1`] = `
-Object {
-  "attachments": Array [
-    Object {
-      "color": "#24292f",
-      "mrkdwn_in": Array [
-        "text",
-      ],
-      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
-    },
-  ],
-  "response_type": "ephemeral",
-}
+Array [
+  Object {
+    "color": "#24292f",
+    "mrkdwn_in": Array [
+      "text",
+    ],
+    "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+  },
+]
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "close https://github.com/owner/repo/issues/123" 2`] = `
@@ -93,18 +87,15 @@ Map {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "reopen https://github.com/owner/repo/issues/123" 1`] = `
-Object {
-  "attachments": Array [
-    Object {
-      "color": "#24292f",
-      "mrkdwn_in": Array [
-        "text",
-      ],
-      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
-    },
-  ],
-  "response_type": "ephemeral",
-}
+Array [
+  Object {
+    "color": "#24292f",
+    "mrkdwn_in": Array [
+      "text",
+    ],
+    "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+  },
+]
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "reopen https://github.com/owner/repo/issues/123" 2`] = `
@@ -134,18 +125,15 @@ Map {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes" 1`] = `
-Object {
-  "attachments": Array [
-    Object {
-      "color": "#24292f",
-      "mrkdwn_in": Array [
-        "text",
-      ],
-      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
-    },
-  ],
-  "response_type": "ephemeral",
-}
+Array [
+  Object {
+    "color": "#24292f",
+    "mrkdwn_in": Array [
+      "text",
+    ],
+    "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+  },
+]
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes" 2`] = `
@@ -175,18 +163,15 @@ Map {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes/kubernetes" 1`] = `
-Object {
-  "attachments": Array [
-    Object {
-      "color": "#24292f",
-      "mrkdwn_in": Array [
-        "text",
-      ],
-      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
-    },
-  ],
-  "response_type": "ephemeral",
-}
+Array [
+  Object {
+    "color": "#24292f",
+    "mrkdwn_in": Array [
+      "text",
+    ],
+    "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+  },
+]
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "subscribe kubernetes/kubernetes" 2`] = `
@@ -216,18 +201,15 @@ Map {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes" 1`] = `
-Object {
-  "attachments": Array [
-    Object {
-      "color": "#24292f",
-      "mrkdwn_in": Array [
-        "text",
-      ],
-      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
-    },
-  ],
-  "response_type": "ephemeral",
-}
+Array [
+  Object {
+    "color": "#24292f",
+    "mrkdwn_in": Array [
+      "text",
+    ],
+    "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+  },
+]
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes" 2`] = `
@@ -257,18 +239,15 @@ Map {
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes/kubernetes" 1`] = `
-Object {
-  "attachments": Array [
-    Object {
-      "color": "#24292f",
-      "mrkdwn_in": Array [
-        "text",
-      ],
-      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
-    },
-  ],
-  "response_type": "ephemeral",
-}
+Array [
+  Object {
+    "color": "#24292f",
+    "mrkdwn_in": Array [
+      "text",
+    ],
+    "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+  },
+]
 `;
 
 exports[`Integration: signin unauthenticated user is prompted to authenticate for slash command "unsubscribe kubernetes/kubernetes" 2`] = `

--- a/test/integration/__snapshots__/signin.test.js.snap
+++ b/test/integration/__snapshots__/signin.test.js.snap
@@ -276,6 +276,66 @@ Map {
 }
 `;
 
+exports[`Integration: signin unauthenticated user is redirected to Slack directly if command cannot be replayed 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
+
+exports[`Integration: signin unauthenticated user is redirected to Slack directly if command cannot be replayed 2`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "subscribe kubernetes/kubernetes",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
+
+exports[`Integration: signin unauthenticated user with expired state cannot sign in 1`] = `
+Set {
+  "pending-command#13345224609.738474920.8088930838d88f008e0",
+}
+`;
+
+exports[`Integration: signin unauthenticated user with expired state cannot sign in 2`] = `
+Map {
+  "pending-command#13345224609.738474920.8088930838d88f008e0" => Object {
+    "channel_id": "C2147483705",
+    "channel_name": "test",
+    "command": "/github",
+    "enterprise_id": "E0001",
+    "enterprise_name": "Globular%20Construct%20Inc",
+    "response_url": "https://hooks.slack.com/commands/1234/5678",
+    "team_domain": "example",
+    "team_id": "T0001",
+    "text": "signin",
+    "token": "secret",
+    "trigger_id": "13345224609.738474920.8088930838d88f008e0",
+    "user_id": "U2147483697",
+    "user_name": "Steve",
+  },
+}
+`;
+
+exports[`Integration: signin unauthenticated user with invalid state cannot sign in 1`] = `Set {}`;
+
+exports[`Integration: signin unauthenticated user with invalid state cannot sign in 2`] = `Map {}`;
+
+exports[`Integration: signin unauthenticated user with tampered state cannot sign in 1`] = `Set {}`;
+
+exports[`Integration: signin unauthenticated user with tampered state cannot sign in 2`] = `Map {}`;
+
 exports[`Integration: signin with a pending subscription redirects to install app and creates subscription 1`] = `
 Object {
   "attachments": Array [

--- a/test/integration/__snapshots__/signout.test.js.snap
+++ b/test/integration/__snapshots__/signout.test.js.snap
@@ -48,18 +48,15 @@ Map {
 `;
 
 exports[`Integration: signout a signed out user is prompted to sign in first 1`] = `
-Object {
-  "attachments": Array [
-    Object {
-      "color": "#24292f",
-      "mrkdwn_in": Array [
-        "text",
-      ],
-      "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
-    },
-  ],
-  "response_type": "ephemeral",
-}
+Array [
+  Object {
+    "color": "#24292f",
+    "mrkdwn_in": Array [
+      "text",
+    ],
+    "text": ":white_check_mark: Success! <@U2147483697> is now connected to <https://github.com/wilhelmklopp|@wilhelmklopp>",
+  },
+]
 `;
 
 exports[`Integration: signout a signed out user is prompted to sign in first 2`] = `

--- a/test/integration/signin.test.js
+++ b/test/integration/signin.test.js
@@ -48,10 +48,12 @@ describe('Integration: signin', () => {
       nock('https://api.github.com').get('/user')
         .reply(200, fixtures.user);
 
-      nock('https://hooks.slack.com').post('/commands/1234/5678', (body) => {
-        expect(body).toMatchSnapshot();
+      nock('https://slack.com').post('/api/chat.postEphemeral', (body) => {
+        expect(body.user).toBe('U2147483697');
+        expect(body.channel).toBe('C2147483705');
+        expect(JSON.parse(body.attachments)).toMatchSnapshot();
         return true;
-      }).reply(200);
+      }).reply(200, { ok: true });
 
       await request(probot.server).get('/github/oauth/callback').query({ state })
         .expect(302)
@@ -106,10 +108,12 @@ describe('Integration: signin', () => {
       nock('https://api.github.com').get('/user')
         .reply(200, fixtures.user);
 
-      nock('https://hooks.slack.com').post('/commands/1234/5678', (body) => {
-        expect(body).toMatchSnapshot();
+      nock('https://slack.com').post('/api/chat.postEphemeral', (body) => {
+        expect(body.user).toBe('U2147483697');
+        expect(body.channel).toBe('C2147483705');
+        expect(JSON.parse(body.attachments)).toMatchSnapshot();
         return true;
-      }).reply(200);
+      }).reply(200, { ok: true });
 
       await request(probot.server).get('/github/oauth/callback').query({ state })
         .expect(302);
@@ -144,7 +148,11 @@ describe('Integration: signin', () => {
         .reply(200, fixtures.user);
 
       // Post confirmation of signin
-      nock('https://hooks.slack.com').post('/commands/1234/5678').reply(200);
+      nock('https://slack.com').post('/api/chat.postEphemeral', (body) => {
+        expect(body.user).toBe('U2147483697');
+        expect(body.channel).toBe('C2147483705');
+        return true;
+      }).reply(200, { ok: true });
 
 
       await agent.get('/github/oauth/callback').query({ state })

--- a/test/integration/signin.test.js
+++ b/test/integration/signin.test.js
@@ -1,8 +1,12 @@
 const request = require('supertest');
 const nock = require('nock');
+const { promisify } = require('util');
+const jwt = require('jsonwebtoken');
 
+const sign = promisify(jwt.sign);
 const { probot, slackbot, models } = require('.');
 const fixtures = require('../fixtures');
+const cache = require('../../lib/cache');
 
 const { SlackWorkspace, GitHubUser } = models;
 
@@ -116,7 +120,112 @@ describe('Integration: signin', () => {
       }).reply(200, { ok: true });
 
       await request(probot.server).get('/github/oauth/callback').query({ state })
-        .expect(302);
+        .expect(302)
+        .expect(
+          'Location',
+          '/slack/command?trigger_id=13345224609.738474920.8088930838d88f008e0',
+        );
+    });
+
+    test('with invalid state cannot sign in', async () => {
+      await request(probot.server).get('/github/oauth/callback').query({ state: 'i-am-not-valid' })
+        .expect(400)
+        .expect('Error: jwt malformed');
+    });
+
+    test('with tampered state cannot sign in', async () => {
+      const fakeSecret = `${process.env.GITHUB_CLIENT_SECRET}-fake`;
+      const payload = {
+        teamSlackId: 'T01234',
+        userSlackId: 'U01234',
+        channelSlackId: 'C01234',
+      };
+      const tamperedState = await sign(payload, fakeSecret, { expiresIn: '1h' });
+
+      await request(probot.server).get('/github/oauth/callback').query({ state: tamperedState })
+        .expect(400)
+        .expect('Error: invalid signature');
+    });
+
+    test('with expired state cannot sign in', async () => {
+      const command = fixtures.slack.command({
+        text: 'signin',
+      });
+      const res = await request(probot.server).post('/slack/command')
+        .use(slackbot)
+        .send(command)
+        .expect(200);
+
+      // User is shown ephemeral prompt to authenticate
+      const { text, url } = res.body.attachments[0].actions[0];
+      expect(text).toMatch('Connect GitHub account');
+      expect(url).toMatch(promptUrl);
+
+      // User follows link to OAuth
+      const [, link, state] = url.match(promptUrl);
+
+      const loginRequest = request(probot.server).get(link);
+      await loginRequest.expect(302).expect(
+        'Location',
+        `https://github.com/login/oauth/authorize?client_id=&state=${state}`,
+      );
+
+      // Set date to current date + 2 hours
+      const now = new Date();
+      const dateSpy = jest.spyOn(Date, 'now').mockImplementation(() => now.setHours(now.getHours() + 2));
+
+      await request(probot.server).get('/github/oauth/callback').query({ state })
+        .expect(400)
+        .expect('Error: jwt expired');
+
+      // Reset date
+      dateSpy.mockRestore();
+    });
+
+    test('is redirected to Slack directly if command cannot be replayed', async () => {
+      const command = fixtures.slack.command({
+        text: 'subscribe kubernetes/kubernetes',
+      });
+      const res = await request(probot.server).post('/slack/command')
+        .use(slackbot)
+        .send(command)
+        .expect(200);
+
+      // User is shown ephemeral prompt to authenticate
+      const { text, url } = res.body.attachments[0].actions[0];
+      expect(text).toMatch('Connect GitHub account');
+      expect(url).toMatch(promptUrl);
+
+      // User follows link to OAuth
+      const [, link, state] = url.match(promptUrl);
+
+      const loginRequest = request(probot.server).get(link);
+      await loginRequest.expect(302).expect(
+        'Location',
+        `https://github.com/login/oauth/authorize?client_id=&state=${state}`,
+      );
+
+      // Clear cache to remove pending command that we have stored there now
+      await cache.clear();
+
+      // GitHub redirects back, authenticates user and process subscription
+      nock('https://github.com').post('/login/oauth/access_token')
+        .reply(200, fixtures.github.oauth);
+      nock('https://api.github.com').get('/user')
+        .reply(200, fixtures.user);
+
+      nock('https://slack.com').post('/api/chat.postEphemeral', (body) => {
+        expect(body.user).toBe('U2147483697');
+        expect(body.channel).toBe('C2147483705');
+        return true;
+      }).reply(200, { ok: true });
+
+      await request(probot.server).get('/github/oauth/callback').query({ state })
+        .expect(302)
+        .expect(
+          'Location',
+          `https://slack.com/app_redirect?team=${command.team_id}&channel=${command.channel_id}`,
+        );
     });
   });
 

--- a/test/integration/signout.test.js
+++ b/test/integration/signout.test.js
@@ -97,10 +97,12 @@ describe('Integration: signout', async () => {
     nock('https://api.github.com').get('/user')
       .reply(200, fixtures.user);
 
-    nock('https://hooks.slack.com').post('/commands/1234/5678', (body) => {
-      expect(body).toMatchSnapshot();
+    nock('https://slack.com').post('/api/chat.postEphemeral', (body) => {
+      expect(body.user).toBe('U2147483697');
+      expect(body.channel).toBe('C2147483705');
+      expect(JSON.parse(body.attachments)).toMatchSnapshot();
       return true;
-    }).reply(200);
+    }).reply(200, { ok: true });
 
     await request(probot.server).get('/github/oauth/callback').query({ state })
       .expect(302)


### PR DESCRIPTION
Simplifying and refactoring signed params that are used for completing the GitHub OAuth flow.

Based on the suggestion here: https://github.com/integrations/slack/pull/568#discussion_r186723249


Closes https://github.com/github/ecosystem-primitives/issues/228
