### PR TITLE
Add githubName to deleted subscription model

### DIFF
--- a/lib/models/deleted-subscription.js
+++ b/lib/models/deleted-subscription.js
@@ -1,6 +1,8 @@
 module.exports = (sequelize, DataTypes) => {
   const DeletedSubscription = sequelize.define('DeletedSubscription', {
     githubId: DataTypes.BIGINT,
+    // Storing only for debugging purposes. Do not use for querying data since it might change
+    githubName: DataTypes.STRING,
     channelId: DataTypes.STRING,
     type: DataTypes.STRING,
     settings: DataTypes.JSON,

--- a/test/integration/__snapshots__/slack-uninstall.test.js.snap
+++ b/test/integration/__snapshots__/slack-uninstall.test.js.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Uninstalling the slack app deletes all corresponding subscriptions 1`] = `Set {}`;
+exports[`Uninstalling the slack app deletes all corresponding subscriptions 1`] = `
+Object {
+  "channelId": "C0012",
+  "createdAt": 2019-03-26T10:44:06.646Z,
+  "creatorId": "1",
+  "deletedAt": 2019-03-26T10:44:06.709Z,
+  "githubId": "1234",
+  "githubName": "foo/repo1",
+  "id": "1",
+  "installationId": "1",
+  "reason": "slack app uninstalled",
+  "settings": Object {
+    "commits": true,
+    "pulls": true,
+  },
+  "slackWorkspaceId": "1",
+  "type": "repo",
+  "updatedAt": 2019-03-26T10:44:06.719Z,
+}
+`;
 
-exports[`Uninstalling the slack app deletes all corresponding subscriptions 2`] = `Map {}`;
+exports[`Uninstalling the slack app deletes all corresponding subscriptions 2`] = `
+Object {
+  "channelId": "C0234",
+  "createdAt": 2019-03-26T10:44:06.653Z,
+  "creatorId": "1",
+  "deletedAt": 2019-03-26T10:44:06.712Z,
+  "githubId": "4321",
+  "githubName": "foo/repo2",
+  "id": "2",
+  "installationId": "1",
+  "reason": "slack app uninstalled",
+  "settings": Object {
+    "commits": true,
+    "pulls": true,
+  },
+  "slackWorkspaceId": "1",
+  "type": "repo",
+  "updatedAt": 2019-03-26T10:44:06.722Z,
+}
+`;
+
+exports[`Uninstalling the slack app deletes all corresponding subscriptions 3`] = `
+Object {
+  "channelId": "C0012",
+  "createdAt": 2019-03-26T10:44:06.656Z,
+  "creatorId": "1",
+  "deletedAt": 2019-03-26T10:44:06.714Z,
+  "githubId": "5678",
+  "githubName": "foo/repo3",
+  "id": "3",
+  "installationId": "1",
+  "reason": "slack app uninstalled",
+  "settings": Object {
+    "commits": true,
+    "pulls": true,
+  },
+  "slackWorkspaceId": "1",
+  "type": "repo",
+  "updatedAt": 2019-03-26T10:44:06.724Z,
+}
+`;
+
+exports[`Uninstalling the slack app deletes all corresponding subscriptions 4`] = `Set {}`;
+
+exports[`Uninstalling the slack app deletes all corresponding subscriptions 5`] = `Map {}`;

--- a/test/integration/__snapshots__/slack-uninstall.test.js.snap
+++ b/test/integration/__snapshots__/slack-uninstall.test.js.snap
@@ -3,9 +3,9 @@
 exports[`Uninstalling the slack app deletes all corresponding subscriptions 1`] = `
 Object {
   "channelId": "C0012",
-  "createdAt": 2019-03-26T10:44:06.646Z,
+  "createdAt": Any<Date>,
   "creatorId": "1",
-  "deletedAt": 2019-03-26T10:44:06.709Z,
+  "deletedAt": Any<Date>,
   "githubId": "1234",
   "githubName": "foo/repo1",
   "id": "1",
@@ -17,16 +17,16 @@ Object {
   },
   "slackWorkspaceId": "1",
   "type": "repo",
-  "updatedAt": 2019-03-26T10:44:06.719Z,
+  "updatedAt": Any<Date>,
 }
 `;
 
 exports[`Uninstalling the slack app deletes all corresponding subscriptions 2`] = `
 Object {
   "channelId": "C0234",
-  "createdAt": 2019-03-26T10:44:06.653Z,
+  "createdAt": Any<Date>,
   "creatorId": "1",
-  "deletedAt": 2019-03-26T10:44:06.712Z,
+  "deletedAt": Any<Date>,
   "githubId": "4321",
   "githubName": "foo/repo2",
   "id": "2",
@@ -38,16 +38,16 @@ Object {
   },
   "slackWorkspaceId": "1",
   "type": "repo",
-  "updatedAt": 2019-03-26T10:44:06.722Z,
+  "updatedAt": Any<Date>,
 }
 `;
 
 exports[`Uninstalling the slack app deletes all corresponding subscriptions 3`] = `
 Object {
   "channelId": "C0012",
-  "createdAt": 2019-03-26T10:44:06.656Z,
+  "createdAt": Any<Date>,
   "creatorId": "1",
-  "deletedAt": 2019-03-26T10:44:06.714Z,
+  "deletedAt": Any<Date>,
   "githubId": "5678",
   "githubName": "foo/repo3",
   "id": "3",
@@ -59,7 +59,7 @@ Object {
   },
   "slackWorkspaceId": "1",
   "type": "repo",
-  "updatedAt": 2019-03-26T10:44:06.724Z,
+  "updatedAt": Any<Date>,
 }
 `;
 

--- a/test/integration/slack-uninstall.test.js
+++ b/test/integration/slack-uninstall.test.js
@@ -72,8 +72,20 @@ describe('Uninstalling the slack app', () => {
     expect(await Subscription.count()).toBe(0);
     const deletedSubscriptions = await DeletedSubscription.findAll({ where: { reason: 'slack app uninstalled' } });
     expect(deletedSubscriptions).toHaveLength(3);
-    expect(deletedSubscriptions[0].dataValues).toMatchSnapshot();
-    expect(deletedSubscriptions[1].dataValues).toMatchSnapshot();
-    expect(deletedSubscriptions[2].dataValues).toMatchSnapshot();
+    expect(deletedSubscriptions[0].dataValues).toMatchSnapshot({
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+      deletedAt: expect.any(Date),
+    });
+    expect(deletedSubscriptions[1].dataValues).toMatchSnapshot({
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+      deletedAt: expect.any(Date),
+    });
+    expect(deletedSubscriptions[2].dataValues).toMatchSnapshot({
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+      deletedAt: expect.any(Date),
+    });
   });
 });


### PR DESCRIPTION
I realized that the `githubName` column was created in a migration, but since was not added to the model it was not being saved 🤦‍♂️ 

This PR fixes that and makes sure that deleted subscriptions have all fields using snapshot testing.