### PR TITLE
Update `env.sample` with additional context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ SLACK_ROOT_URL="https://slack.com"
 # SUBDOMAIN=
 
 # Redis
-REDIS_URL=“redis://localhost:6379”
+REDIS_URL="redis://localhost:6379"
 
 # Token for unfurling public URLs and getting installations (temporary)
 GITHUB_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ GITHUB_TOKEN=
 STORAGE_SECRET=
 
 # Session secret used for signing cookies in the web interface
+# Generate a new key with: $ openssl rand -hex 32
 SESSION_SECRET=
 
 # Comma separated list of channel ids with early access to new features

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ SLACK_ROOT_URL="https://slack.com"
 # Subdomain to use for localtunnel server. Defaults to your local username.
 # SUBDOMAIN=
 
+# Redis
+REDIS_URL=“redis://localhost:6379”
+
 # Token for unfurling public URLs and getting installations (temporary)
 GITHUB_TOKEN=
 

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ dump.rdb
 dist
 
 .DS_Store
+
+.idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,8 @@ Follow the [Probot docs for configuring up a GitHub App](https://probot.github.i
 - **Setup URL**: `https://DOMAIN/github/setup`
 - **Webhook URL**: `https://DOMAIN/github/events`
 
-Add in a `STORAGE_SECRET` to your `.env` file, running `openssl rand -hex 32` should provide a suitable secret.
-Add in a `SESSION_SECRET` to your `.env` file, running `openssl rand -hex 32` should provide a suitable secret.
+- Add in a `STORAGE_SECRET` to your `.env` file, running `openssl rand -hex 32` should provide a suitable secret.
+- Add in a `SESSION_SECRET` to your `.env` file, running `openssl rand -hex 32` should provide a suitable secret.
 
 #### Configuring a Slack App
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,7 @@ Follow the [Probot docs for configuring up a GitHub App](https://probot.github.i
 - **Webhook URL**: `https://DOMAIN/github/events`
 
 Add in a `STORAGE_SECRET` to your `.env` file, running `openssl rand -hex 32` should provide a suitable secret.
+Add in a `SESSION_SECRET` to your `.env` file, running `openssl rand -hex 32` should provide a suitable secret.
 
 #### Configuring a Slack App
 


### PR DESCRIPTION
### Changes introduced

- This PR updates the `env.sample` file with additional context and an additional value that needs to be set for Redis to work properly with `keyv`.
- Additionally, I added information about the `SESSION_SECRET` generation to the `CONTRIBUTING.md` file as well to match context with `STORAGE_SECRET`
- Finally, I added `.idea` to the `.gitignore` to ensure no workspace items from an editor such as `WebStorm` from JetBrains would be committed.

### Review request

@gimenete and @wilhelmklopp, as main contributors to this I'd like to have your input before merging. @imjohnbo and I paired on this in the morning.