### PR TITLE
Update uses of deprecated methods

### DIFF
--- a/lib/activity/pull-requests.js
+++ b/lib/activity/pull-requests.js
@@ -3,7 +3,7 @@ const { PullRequest } = require('../messages/pull-request');
 const cache = require('../cache');
 
 async function getReviews(context, pullRequest) {
-  const reviews = await context.github.pullRequests.getReviews({
+  const reviews = await context.github.pullRequests.listReviews({
     owner: context.payload.repository.owner.login,
     repo: context.payload.repository.name,
     number: pullRequest.number,

--- a/lib/commands/issue-state.js
+++ b/lib/commands/issue-state.js
@@ -15,8 +15,8 @@ module.exports = state => async (req, res) => {
   });
 
   const { data: repository } = await gitHubUser.client.repos.get({ owner, repo });
-  const { data: sender } = await gitHubUser.client.users.get({});
-  const { data: issue } = await gitHubUser.client.issues.edit({
+  const { data: sender } = await gitHubUser.client.users.getAuthenticated({});
+  const { data: issue } = await gitHubUser.client.issues.update({
     owner,
     repo,
     number,

--- a/lib/commands/subscribe.js
+++ b/lib/commands/subscribe.js
@@ -21,7 +21,7 @@ module.exports = async (req, res) => {
   let from;
   try {
     if (resource.type === 'account') {
-      from = (await gitHubUser.client.users.getByUserName({
+      from = (await gitHubUser.client.users.getByUsername({
         username: resource.owner,
       })).data;
     } else {

--- a/lib/commands/subscribe.js
+++ b/lib/commands/subscribe.js
@@ -21,7 +21,7 @@ module.exports = async (req, res) => {
   let from;
   try {
     if (resource.type === 'account') {
-      from = (await gitHubUser.client.users.getForUser({
+      from = (await gitHubUser.client.users.getByUserName({
         username: resource.owner,
       })).data;
     } else {

--- a/lib/create/deployment.js
+++ b/lib/create/deployment.js
@@ -19,7 +19,7 @@ async function open(req, res) {
   const { owner, repo } = resource;
   const [{ data: repository }, { data: branches }, { data: tags }] = await Promise.all([
     gitHubUser.client.repos.get({ owner, repo }),
-    gitHubUser.client.repos.getBranches({ owner, repo }),
+    gitHubUser.client.repos.listBranches({ owner, repo }),
     gitHubUser.client.gitdata.getTags({ owner, repo }),
   ]);
 

--- a/lib/create/issue.js
+++ b/lib/create/issue.js
@@ -45,7 +45,7 @@ async function open(req, res) {
   const { owner, repo } = resource;
   const [{ data: repository }, { data: labels }] = await Promise.all([
     gitHubUser.client.repos.get({ owner, repo }),
-    gitHubUser.client.issues.getLabels({ owner, repo }),
+    gitHubUser.client.issues.listLabelsForRepo({ owner, repo }),
   ]);
 
   const template = await loadTemplate(gitHubUser, owner, repo, command);

--- a/lib/create/issue.js
+++ b/lib/create/issue.js
@@ -6,13 +6,13 @@ const createIssueDialog = require('../messages/create/create-issue-dialog');
 
 async function getTemplateContent(gitHubUser, owner, repo, template) {
   const { path } = template; // how do we let the user if there's more than one?
-  const content = await gitHubUser.client.repos.getContent({ owner, repo, path });
+  const content = await gitHubUser.client.repos.getContents({ owner, repo, path });
   return Buffer.from(content.data.content, 'base64').toString();
 }
 
 async function loadTemplate(gitHubUser, owner, repo, command) {
   try {
-    const { data: templates } = await gitHubUser.client.repos.getContent({ owner, repo, path: '.github/ISSUE_TEMPLATE' });
+    const { data: templates } = await gitHubUser.client.repos.getContents({ owner, repo, path: '.github/ISSUE_TEMPLATE' });
     if (templates.length === 1) {
       return await getTemplateContent(gitHubUser, owner, repo, templates[0]);
     } else if (templates.length > 1) {

--- a/lib/github/oauth.js
+++ b/lib/github/oauth.js
@@ -70,7 +70,7 @@ module.exports = (robot) => {
       type: 'token',
       token: accessToken,
     });
-    const user = (await github.users.get({})).data;
+    const user = (await github.users.getAuthenticated({})).data;
     const defaults = { accessToken, login: user.login };
 
     // store github user id and connect to slack user id

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ module.exports = (robot) => {
   // Fetch and cache info about the GitHub App
   robot.info = async function info() { // eslint-disable-line no-param-reassign
     const github = await this.auth();
-    const res = await github.apps.get({});
+    const res = await github.apps.getAuthenticated({});
 
     // Override info method with cached data
     this.info = async () => res.data;

--- a/lib/middleware/get-installation.js
+++ b/lib/middleware/get-installation.js
@@ -32,7 +32,7 @@ module.exports = async function getInstallation(req, res, next) {
 
   // Use user access token to resolve owner name to id
   try {
-    const owner = (await gitHubUser.client.users.getForUser({ username: resource.owner })).data;
+    const owner = (await gitHubUser.client.users.getByUsername({ username: resource.owner })).data;
 
     const state = new SignedParams({
       trigger_id: command.trigger_id,

--- a/lib/unfurls/account.js
+++ b/lib/unfurls/account.js
@@ -2,7 +2,7 @@ const { Account } = require('../messages/account');
 
 module.exports = async (params, github, unfurlType) => {
   const { owner } = params;
-  const account = (await github.users.getForUser({ username: owner })).data;
+  const account = (await github.users.getByUsername({ username: owner })).data;
   const accountMessage = new Account({ account, unfurlType });
   return accountMessage.getRenderedMessage();
 };

--- a/lib/unfurls/blob.js
+++ b/lib/unfurls/blob.js
@@ -4,7 +4,7 @@ module.exports = async (params, github, unfurlType) => {
   const {
     owner, repo, ref, path, line,
   } = params;
-  const blob = (await github.repos.getContent({
+  const blob = (await github.repos.getContents({
     owner, repo, path, ref,
   })).data;
   const repository = (await github.repos.get({ owner, repo })).data;

--- a/test/models/unfurl.test.js
+++ b/test/models/unfurl.test.js
@@ -25,7 +25,7 @@ describe('Unfurl getAttachment', () => {
         })),
       },
       repos: {
-        getContent: jest.fn().mockImplementation(() => Promise.resolve({
+        getContents: jest.fn().mockImplementation(() => Promise.resolve({
           data: fixtures.contents,
         })),
         get: jest.fn().mockImplementation(() => Promise.resolve({

--- a/test/models/unfurl.test.js
+++ b/test/models/unfurl.test.js
@@ -20,7 +20,7 @@ describe('Unfurl getAttachment', () => {
         })),
       },
       users: {
-        getForUser: jest.fn().mockImplementation(() => Promise.resolve({
+        getByUsername: jest.fn().mockImplementation(() => Promise.resolve({
           data: fixtures.user,
         })),
       },


### PR DESCRIPTION
This is a first step to upgrade the Slack app to the latest version of Probot.

The PR removes the method deprecation warnings I found while running the test suite, I'm going to look to see if there are more that I missed from the changelogs.