### PR TITLE
Add message to Slack when Draft PR is marked Ready for Review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ dist
 .DS_Store
 
 .idea/
+build/

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Settings are configured with the `/github` slash command:
 These are enabled by default, and can be disabled with the `/github unsubscribe owner/repo [feature]` command:
 
 - `issues` - Opened or closed issues
-- `pulls` - New or merged pull requests
+- `pulls` - New or merged pull requests, as well as draft pull requests marked "Ready for Review"
 - `statuses` - Statuses on pull requests
 - `commits` - New commits on the default branch (usually `master`)
 - `deployments` - Updated status on deployments

--- a/lib/activity/index.js
+++ b/lib/activity/index.js
@@ -33,7 +33,7 @@ module.exports = (robot) => {
     'issues.edited',
   ], route(matchMetaDataStatetoIssueMessage));
 
-  robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened'], route(pullRequestEvent));
+  robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened', 'pull_request.ready_for_review'], route(pullRequestEvent));
   robot.on(['pull_request.opened', 'pull_request.synchronize'], storePRMapping);
   robot.on('status', route(onStatus));
   robot.on('deployment_status', route(deploymentStatus));

--- a/lib/activity/pull-requests.js
+++ b/lib/activity/pull-requests.js
@@ -15,7 +15,7 @@ async function pullRequestEvent(context, subscription, slack) {
   let pullRequest = {
     ...context.payload.pull_request,
   };
-  if (context.payload.action === 'opened') {
+  if (context.payload.action !== 'closed') {
     // need seperate api request to get labels, body_html, requested_reviewers and requested_teams
     pullRequest = (await context.github.pullRequests.get(context.issue({
       headers: {
@@ -46,7 +46,7 @@ async function pullRequestEvent(context, subscription, slack) {
     ts: res.ts,
     context: context.issue(),
   };
-  if (eventType === 'pull_request.opened') {
+  if (eventType === 'pull_request.opened' || eventType === 'pull_request.ready_for_review') {
     // store PR id so that the PR can be mapped to the slack message
     const cacheKey = subscription.cacheKey(`pull#${context.payload.pull_request.id}`);
     cache.set(cacheKey, messageMetaData);

--- a/lib/activity/pull-requests.js
+++ b/lib/activity/pull-requests.js
@@ -15,7 +15,7 @@ async function pullRequestEvent(context, subscription, slack) {
   let pullRequest = {
     ...context.payload.pull_request,
   };
-  if (context.payload.action !== 'closed') {
+  if (!['closed', 'reopened'].includes(context.payload.action)) {
     // need seperate api request to get labels, body_html, requested_reviewers and requested_teams
     pullRequest = (await context.github.pullRequests.get(context.issue({
       headers: {

--- a/lib/messages/abstract-issue.js
+++ b/lib/messages/abstract-issue.js
@@ -47,7 +47,7 @@ class AbstractIssue extends Message {
     } else {
       actor = this.abstractIssue.user.login;
     }
-    return `${subject} ${predicate} by ${actor}`;
+    return `${subject} ${predicate.replace(/_/g, ' ')} by ${actor}`; // e.g. replace 'ready for review' with 'ready_for_review'
   }
 
   getCore() {

--- a/lib/messages/abstract-issue.js
+++ b/lib/messages/abstract-issue.js
@@ -47,7 +47,7 @@ class AbstractIssue extends Message {
     } else {
       actor = this.abstractIssue.user.login;
     }
-    return `${subject} ${predicate.replace(/_/g, ' ')} by ${actor}`; // e.g. replace 'ready for review' with 'ready_for_review'
+    return `${subject} ${predicate.replace(/_/g, ' ')} by ${actor}`; // e.g. replace 'ready_for_review' with 'ready for review'
   }
 
   getCore() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,7 +2064,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2085,12 +2086,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2105,17 +2108,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2232,7 +2238,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2244,6 +2251,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2258,6 +2266,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -2265,12 +2274,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -2289,6 +2300,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -2369,7 +2381,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -2381,6 +2394,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -2466,7 +2480,8 @@
             "safe-buffer": {
               "version": "5.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -2502,6 +2517,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -2521,6 +2537,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -2564,12 +2581,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -4466,7 +4485,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4487,12 +4507,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4507,17 +4529,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4634,7 +4659,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4646,6 +4672,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4660,6 +4687,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4667,12 +4695,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4691,6 +4721,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4771,7 +4802,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4783,6 +4815,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4868,7 +4901,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4904,6 +4938,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4923,6 +4958,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4966,12 +5002,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/integration/__snapshots__/notifications.test.js.snap
+++ b/test/integration/__snapshots__/notifications.test.js.snap
@@ -468,6 +468,36 @@ Map {
 }
 `;
 
+exports[`Integration: notifications to a subscribed channel pull request ready_for_review 1`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#cb2431\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1500156238,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\",\\"title_link\\":\\"https://github.com/facebook/react/issues/10191\\",\\"fallback\\":\\"[github-slack/app] #10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\",\\"pretext\\":\\"Pull request ready for review by wilhelmklopp\\"}]",
+  "channel": "C001",
+  "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request ready_for_review 2`] = `
+Set {
+  "creator-access#1:100427737",
+  "channel#9523#C001:pull#142600109",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel pull request ready_for_review 3`] = `
+Map {
+  "creator-access#1:100427737" => true,
+  "channel#9523#C001:pull#142600109" => Object {
+    "channel": undefined,
+    "context": Object {
+      "number": 31,
+      "owner": "github-slack",
+      "repo": "app",
+    },
+    "ts": undefined,
+  },
+}
+`;
+
 exports[`Integration: notifications to a subscribed channel pull request reopened does not make an API call to issues endpoint 1`] = `
 Object {
   "attachments": "[{\\"color\\":\\"#36a64f\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1506092298,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#31 Add badges to readme\\",\\"title_link\\":\\"https://github.com/github-slack/app/pull/31\\",\\"fallback\\":\\"[github-slack/app] #31 Add badges to readme\\",\\"pretext\\":\\"Pull request reopened by wilhelmklopp\\"}]",

--- a/test/messages/__snapshots__/pull-request.test.js.snap
+++ b/test/messages/__snapshots__/pull-request.test.js.snap
@@ -62,7 +62,7 @@ Object {
 }
 `;
 
-exports[`Pull request rendering works for notifcation messages 1`] = `
+exports[`Pull request rendering works for notification messages 1`] = `
 Object {
   "attachments": Array [
     Object {
@@ -99,7 +99,7 @@ Object {
 }
 `;
 
-exports[`Pull request rendering works for notifcation messages with all statuses passing 1`] = `
+exports[`Pull request rendering works for notification messages with all statuses passing 1`] = `
 Object {
   "attachments": Array [
     Object {
@@ -137,7 +137,7 @@ Object {
 }
 `;
 
-exports[`Pull request rendering works for notifcation messages with one status failing 1`] = `
+exports[`Pull request rendering works for notification messages with one status failing 1`] = `
 Object {
   "attachments": Array [
     Object {
@@ -179,7 +179,7 @@ Object {
 }
 `;
 
-exports[`Pull request rendering works for notifcation messages with some statuses passing 1`] = `
+exports[`Pull request rendering works for notification messages with some statuses passing 1`] = `
 Object {
   "attachments": Array [
     Object {
@@ -237,7 +237,7 @@ Object {
 }
 `;
 
-exports[`Pull request rendering works for notifcation messages with statuses 1`] = `
+exports[`Pull request rendering works for notification messages with statuses 1`] = `
 Object {
   "attachments": Array [
     Object {

--- a/test/messages/__snapshots__/pull-request.test.js.snap
+++ b/test/messages/__snapshots__/pull-request.test.js.snap
@@ -308,3 +308,23 @@ Object {
   ],
 }
 `;
+
+exports[`Pull request rendering works for ready_for_review messages 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "color": "#36a64f",
+      "fallback": "[github-slack/app] #31 Add badges to readme",
+      "footer": "<https://github.com/github-slack/app|github-slack/app>",
+      "footer_icon": "https://assets-cdn.github.com/favicon.ico",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "pretext": "Pull request ready for review by wilhelmklopp",
+      "title": "#31 Add badges to readme",
+      "title_link": "https://github.com/github-slack/app/pull/31",
+      "ts": 1506092298,
+    },
+  ],
+}
+`;

--- a/test/messages/pull-request.test.js
+++ b/test/messages/pull-request.test.js
@@ -139,4 +139,26 @@ describe('Pull request rendering', () => {
     const rendered = prMessage.getRenderedMessage();
     expect(rendered).toMatchSnapshot();
   });
+
+  test('works for ready_for_review messages', async () => {
+    const pullRequest = {
+      ...pullRequestOpened.pull_request,
+      action: 'ready_for_review',
+      labels: [],
+      requested_reviewers: [{ login: 'user1' }],
+      requested_teams: [{ name: 'Test-team', slug: 'test-team' }],
+    };
+    const prMessage = new PullRequest({
+      pullRequest,
+      repository: pullRequestOpened.repository,
+      eventType: 'pull_request.ready_for_review',
+      sender: pullRequestOpened.sender,
+      reviews: [
+        { state: 'CHANGES_REQUESTED', user: { login: 'user2' } },
+        { state: 'APPROVED', user: { login: 'user2' } },
+      ],
+    });
+    const rendered = prMessage.getRenderedMessage();
+    expect(rendered).toMatchSnapshot();
+  });
 });

--- a/test/messages/pull-request.test.js
+++ b/test/messages/pull-request.test.js
@@ -8,7 +8,7 @@ const pullRequestOpened = require('../fixtures/webhooks/pull_request.opened.json
 const pullRequestClosed = require('../fixtures/webhooks/pull_request.closed.json');
 
 describe('Pull request rendering', () => {
-  test('works for notifcation messages', async () => {
+  test('works for notification messages', async () => {
     const pullRequest = {
       ...pullRequestOpened.pull_request,
       labels: [],
@@ -29,7 +29,7 @@ describe('Pull request rendering', () => {
     expect(rendered).toMatchSnapshot();
   });
 
-  test('works for notifcation messages with statuses', async () => {
+  test('works for notification messages with statuses', async () => {
     const pullRequest = {
       ...pullRequestOpened.pull_request,
       labels: [],
@@ -46,7 +46,7 @@ describe('Pull request rendering', () => {
     expect(rendered).toMatchSnapshot();
   });
 
-  test('works for notifcation messages with some statuses passing', async () => {
+  test('works for notification messages with some statuses passing', async () => {
     const pullRequest = {
       ...pullRequestOpened.pull_request,
       labels: [],
@@ -63,7 +63,7 @@ describe('Pull request rendering', () => {
     expect(rendered).toMatchSnapshot();
   });
 
-  test('works for notifcation messages with all statuses passing', async () => {
+  test('works for notification messages with all statuses passing', async () => {
     const pullRequest = {
       ...pullRequestOpened.pull_request,
       labels: [],
@@ -80,7 +80,7 @@ describe('Pull request rendering', () => {
     expect(rendered).toMatchSnapshot();
   });
 
-  test('works for notifcation messages with one status failing', async () => {
+  test('works for notification messages with one status failing', async () => {
     const pullRequest = {
       ...pullRequestOpened.pull_request,
       labels: [],


### PR DESCRIPTION
Closes #805

This PR introduces logic to handle what was described in #805. When a PR is marked "Ready for Review", we should post to the Slack channel to inform.

When a Draft PR is created, we currently post that a PR was opened:
> ![image](https://user-images.githubusercontent.com/2894107/59298635-9107f180-8c50-11e9-8a6a-491c81cdf4f4.png)

With this addition, we will now post the the PR was marked Ready for Review:

> ![image](https://user-images.githubusercontent.com/2894107/59298738-beed3600-8c50-11e9-8da5-04b1d1479349.png)

I added tests with the help of @gimenete ❤️ 