### PR TITLE
Update CONTRIBUTING with additional Slack App steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,17 @@ It will also need the following event subscriptions:
 
 1. On the **Interactive Components** tab, set **Request URL** to `https://DOMAIN/slack/actions`.
 
+1. Under **Interactive Components** under **Actions**, click **Create New Action**
+
+    ![](https://user-images.githubusercontent.com/2894107/60052628-6465c800-969b-11e9-943e-17ac8ef63302.png)
+    
+    - **Action Name**: `Comment on Issue or PR`
+    - **Short Description**: `Comment on an Issue or Pull Request with the content of a Slack message`
+    - **Callback ID**: `comment-action`
+    - Click **Create**
+    
+1. Under **Interactive Components** under **Message Menus**, set **Options Load URL** to `https://DOMAIN/slack/options`
+
 1. On the **Event Subscriptions** tab, set **Request URL** to `https://DOMAIN/slack/events`, replacing `YOUR-USERNAME` with the value that shows up when the server starts. Slack should show **Verified ✓** if all is well.
 
 1. Scroll down to **App Unfurl Domains**, click **Add Domain** and enter `github.com`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,8 @@ It will also need the following event subscriptions:
 
 1. Run `script/server` to start the server
 
+1. On the **Interactive Components** tab, set **Request URL** to `https://DOMAIN/slack/actions`.
+
 1. On the **Event Subscriptions** tab, set **Request URL** to `https://DOMAIN/slack/events`, replacing `YOUR-USERNAME` with the value that shows up when the server starts. Slack should show **Verified ✓** if all is well.
 
 1. Scroll down to **App Unfurl Domains**, click **Add Domain** and enter `github.com`


### PR DESCRIPTION
While running into some issues on my development environment, I found that the Slack app configuration steps were missing information surrounding the `Interactive Components` section (for message actions for example).

This PR:
- [X] Adds documentation to the `CONTRIBUTING.md` for the `/actions` endpoint needed for interactive components
- [x] Adds documentation to the `CONTRIBUTING.md` about setting up existing message actions to be handled by your app

This is ready for review! 🎉 