### PR TITLE
Simplify app startup

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
+brew "overmind"
 brew "node"
 brew "redis"
 brew "postgres"

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+ngrok: ngrok start -log=stdout slack
+slack: npm run dev

--- a/lib/run.js
+++ b/lib/run.js
@@ -14,7 +14,7 @@ const probot = createProbot({
   id: process.env.APP_ID,
   secret: process.env.WEBHOOK_SECRET,
   cert: findPrivateKey(),
-  port: process.env.PORT || 3000,
+  port: process.env.UGH_PORT || process.env.PORT || 3000,
   webhookPath: '/github/events',
   webhookProxy: process.env.WEBHOOK_PROXY_URL,
 });

--- a/ngrok.example.yml
+++ b/ngrok.example.yml
@@ -1,0 +1,7 @@
+authtoken: YOUR_TOKEN
+remote_management: null
+tunnels:
+  slack:
+    proto: http
+    addr: 4001
+    subdomain: YOUR_HANDLE-slack


### PR DESCRIPTION
In order to use run this integration locally, you need something like ngrok to make it accessible via the internet so webhooks from slack.com and github.com can be received. Prior to this change, developers needed to run ngrok and the server in different tabs.

This has downsides. When getting started, you need to learn a few things to get the app running. If you forget to start ngrok, things won’t work. If you forget to turn off ngrok after you’re done developing, a port on your computer is publicly accessible.

Now just run: `overmind start`

![image](https://user-images.githubusercontent.com/300976/62090064-5702a700-b220-11e9-9e22-fde7a9be349a.png)

This starts the `slack` ngrok tunnel and streams the logs along side the probot server. In order to use this, you need to store an ngrok tunnel. There’s a template you can use included in this commit:

1. `cp ngrok.example.yml ngrok.yml`
2. Update `ngrok.yml` with your token and your handle
3. `cp ngrok.yml ~/.ngrok2/ngrok.yml`