### PR TITLE
Update node version from 8 to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "8"
+  - "10"
 notifications:
   disabled: true
 env:

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "supertest": "^3.4.2"
   },
   "engines": {
-    "node": "8.x.x",
-    "npm": "6.x.x"
+    "node": "10.15.x",
+    "npm": "6.4.x"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
Currently the node engine is configured to be [version 8](https://github.com/integrations/slack/blob/master/package.json#L56-L59), which is in ["maintenance mode" as of April 2019](https://devcenter.heroku.com/articles/nodejs-support#supported-runtimes) and since Node 10 is already in "active mode" for more than 6 months and node 12 is not that far from becoming `active`, we should update the engine version to node 10.
All major dependencies like probot and octokit support node 10 and afaik even 12 already.

Closes #837