### PR TITLE
Improve integration test stability

### DIFF
--- a/test/integration/__snapshots__/slack-uninstall.test.js.snap
+++ b/test/integration/__snapshots__/slack-uninstall.test.js.snap
@@ -23,13 +23,13 @@ Object {
 
 exports[`Uninstalling the slack app deletes all corresponding subscriptions 2`] = `
 Object {
-  "channelId": "C0234",
+  "channelId": "C0012",
   "createdAt": Any<Date>,
   "creatorId": "1",
   "deletedAt": Any<Date>,
-  "githubId": "4321",
-  "githubName": "foo/repo2",
-  "id": "2",
+  "githubId": "5678",
+  "githubName": "foo/repo3",
+  "id": "3",
   "installationId": "1",
   "reason": "slack app uninstalled",
   "settings": Object {
@@ -44,13 +44,13 @@ Object {
 
 exports[`Uninstalling the slack app deletes all corresponding subscriptions 3`] = `
 Object {
-  "channelId": "C0012",
+  "channelId": "C0234",
   "createdAt": Any<Date>,
   "creatorId": "1",
   "deletedAt": Any<Date>,
-  "githubId": "5678",
-  "githubName": "foo/repo3",
-  "id": "3",
+  "githubId": "4321",
+  "githubName": "foo/repo2",
+  "id": "2",
   "installationId": "1",
   "reason": "slack app uninstalled",
   "settings": Object {

--- a/test/integration/__snapshots__/unfurl.test.js.snap
+++ b/test/integration/__snapshots__/unfurl.test.js.snap
@@ -583,31 +583,30 @@ Array [
 `;
 
 exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 1`] = `
-Object {
-  "channel": "C74M",
-  "token": "xoxa-token",
-  "ts": "1510704981.000364",
-  "unfurls": "{\\"https://github.com/facebook/react/issues/10191\\":{\\"color\\":\\"#cb2431\\",\\"footer\\":\\"<https://github.com/bkeepers/dotenv|bkeepers/dotenv>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1500156238,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\",\\"title_link\\":\\"https://github.com/facebook/react/issues/10191\\",\\"fallback\\":\\"[bkeepers/dotenv] #10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\"}}",
-}
+Array [
+  Object {
+    "channel": "C74M",
+    "token": "xoxa-token",
+    "ts": "1510704981.000364",
+    "unfurls": "{\\"https://github.com/facebook/react/issues/10191\\":{\\"color\\":\\"#cb2431\\",\\"footer\\":\\"<https://github.com/bkeepers/dotenv|bkeepers/dotenv>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1500156238,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\",\\"title_link\\":\\"https://github.com/facebook/react/issues/10191\\",\\"fallback\\":\\"[bkeepers/dotenv] #10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\"}}",
+  },
+  Object {
+    "channel": "C74M",
+    "token": "xoxa-token",
+    "ts": "1510704981.000364",
+    "unfurls": "{\\"https://github.com/atom/atom/issues/16292\\":{\\"color\\":\\"#cb2431\\",\\"footer\\":\\"<https://github.com/bkeepers/dotenv|bkeepers/dotenv>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1500156238,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\",\\"title_link\\":\\"https://github.com/facebook/react/issues/10191\\",\\"fallback\\":\\"[bkeepers/dotenv] #10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\"}}",
+  },
+]
 `;
 
 exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 2`] = `
-Object {
-  "channel": "C74M",
-  "token": "xoxa-token",
-  "ts": "1510704981.000364",
-  "unfurls": "{\\"https://github.com/atom/atom/issues/16292\\":{\\"color\\":\\"#cb2431\\",\\"footer\\":\\"<https://github.com/bkeepers/dotenv|bkeepers/dotenv>\\",\\"footer_icon\\":\\"https://assets-cdn.github.com/favicon.ico\\",\\"ts\\":1500156238,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\",\\"title_link\\":\\"https://github.com/facebook/react/issues/10191\\",\\"fallback\\":\\"[bkeepers/dotenv] #10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\"}}",
-}
-`;
-
-exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 3`] = `
 Array [
   "unfurl-eligibility#T000A:C74M:https://github.com/atom/atom/issues/16292",
   "unfurl-eligibility#T000A:C74M:https://github.com/facebook/react/issues/10191",
 ]
 `;
 
-exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 4`] = `
+exports[`Integration: unfurls public unfurls does minor unfurl if 2 links are shared 3`] = `
 Array [
   Array [
     "unfurl-eligibility#T000A:C74M:https://github.com/atom/atom/issues/16292",

--- a/test/integration/slack-uninstall.test.js
+++ b/test/integration/slack-uninstall.test.js
@@ -70,7 +70,7 @@ describe('Uninstalling the slack app', () => {
       .expect(200);
 
     expect(await Subscription.count()).toBe(0);
-    const deletedSubscriptions = await DeletedSubscription.findAll({ where: { reason: 'slack app uninstalled' } });
+    const deletedSubscriptions = await DeletedSubscription.findAll({ where: { reason: 'slack app uninstalled' }, order: ['channelId'] });
     expect(deletedSubscriptions).toHaveLength(3);
     expect(deletedSubscriptions[0].dataValues).toMatchSnapshot({
       createdAt: expect.any(Date),


### PR DESCRIPTION
Concurrent unfurl bodies are tested in a non-deterministic way, by
running it in combination with `times`. This In most cases the
first unfurl will be a little bit earlier so that in more than 50% of
the time, the current snapshot will match. However, if the second
request happens earlier (depends on scheduler timing), both snapshots
comparisons will fail, because the first is compared to the second and
visa Versa. For a full explanation see: https://github.com/integrations/slack/issues/903#issuecomment-520333620

Refs: #903