### PR TITLE
Use deployment-status ref instead of sha

### DIFF
--- a/lib/activity/deployments.js
+++ b/lib/activity/deployments.js
@@ -1,14 +1,14 @@
 const cache = require('../cache');
 const { DeploymentStatus } = require('../messages/deployment-status');
 
-async function trackDeployment(context) {
+async function trackDeploymentStatus(context) {
   const { ref, sha } = context.payload.deployment;
   const hasCustomRef = ref && ref !== sha;
   context.log({ hasCustomRef, ref, sha }, 'Processing deployment status');
 }
 
 async function deploymentStatus(context, subscription, slack) {
-  trackDeployment(context);
+  trackDeploymentStatus(context);
 
   const deploymentStatusMessage = new DeploymentStatus({
     deploymentStatus: context.payload.deployment_status,

--- a/lib/activity/deployments.js
+++ b/lib/activity/deployments.js
@@ -1,7 +1,15 @@
 const cache = require('../cache');
 const { DeploymentStatus } = require('../messages/deployment-status');
 
+async function trackDeployment(context) {
+  const { ref, sha } = context.payload.deployment;
+  const hasCustomRef = ref && ref !== sha;
+  context.log({ hasCustomRef, ref, sha }, 'Processing deployment status');
+}
+
 async function deploymentStatus(context, subscription, slack) {
+  trackDeployment(context);
+
   const deploymentStatusMessage = new DeploymentStatus({
     deploymentStatus: context.payload.deployment_status,
     deployment: context.payload.deployment,

--- a/lib/messages/deployment-status.js
+++ b/lib/messages/deployment-status.js
@@ -14,21 +14,17 @@ class DeploymentStatus extends Message {
     this.deploymentStatus = deploymentStatus;
     this.deployment = deployment;
     this.repository = repository;
+
+    const { ref, sha } = deployment;
+    this.shortSha = sha.substr(0, 7);
+    this.prettyRef = ref && ref !== sha ? `${ref} (${this.shortSha})` : this.shortSha;
     this.commitLink = `${this.repository.html_url}/commit/${this.deployment.sha}`;
   }
 
-  prettyRef() {
-    return this.deployment.ref && this.deployment.ref !== this.deployment.sha
-      ? this.deployment.ref
-      : this.deployment.sha.substr(0, 7);
-  }
-
   getCore() {
-    // @todo show ref instead of sha if one exists
-    // let center = `${this.shortSha}`;
-    let center = `${this.prettyRef()}`;
+    let center = `${this.prettyRef}`;
 
-    let centerWithLink = `<${this.commitLink}|\`${this.prettyRef()}\`>`;
+    let centerWithLink = `<${this.commitLink}|\`${this.prettyRef}\`>`;
     if (this.deployment.environment) {
       center += ` to ${this.deployment.environment}`;
       centerWithLink += this.deploymentStatus.target_url

--- a/lib/messages/deployment-status.js
+++ b/lib/messages/deployment-status.js
@@ -10,7 +10,6 @@ class DeploymentStatus extends Message {
         htmlURL: deployment.creator.html_url,
       },
       footer: `<${repository.html_url}|${repository.full_name}>`,
-
     });
     this.deploymentStatus = deploymentStatus;
     this.deployment = deployment;
@@ -18,10 +17,10 @@ class DeploymentStatus extends Message {
     this.commitLink = `${this.repository.html_url}/commit/${this.deployment.sha}`;
   }
 
-  prettyRef(){
-    return (this.deployment.ref && this.deployment.ref !== this.deployment.sha) ?
-    this.deployment.ref :
-    this.deployment.sha.substr(0, 7);
+  prettyRef() {
+    return this.deployment.ref && this.deployment.ref !== this.deployment.sha
+      ? this.deployment.ref
+      : this.deployment.sha.substr(0, 7);
   }
 
   getCore() {
@@ -32,9 +31,9 @@ class DeploymentStatus extends Message {
     let centerWithLink = `<${this.commitLink}|\`${this.prettyRef()}\`>`;
     if (this.deployment.environment) {
       center += ` to ${this.deployment.environment}`;
-      centerWithLink += this.deploymentStatus.target_url ?
-        ` to <${this.deploymentStatus.target_url}|${this.deployment.environment}>` :
-        ` to ${this.deployment.environment}`;
+      centerWithLink += this.deploymentStatus.target_url
+        ? ` to <${this.deploymentStatus.target_url}|${this.deployment.environment}>`
+        : ` to ${this.deployment.environment}`;
     }
     if (this.deploymentStatus.state === 'pending') {
       return {

--- a/lib/messages/deployment-status.js
+++ b/lib/messages/deployment-status.js
@@ -15,14 +15,21 @@ class DeploymentStatus extends Message {
     this.deploymentStatus = deploymentStatus;
     this.deployment = deployment;
     this.repository = repository;
-    this.shortSha = this.deployment.sha.substr(0, 7);
     this.commitLink = `${this.repository.html_url}/commit/${this.deployment.sha}`;
+  }
+
+  prettyRef(){
+    return (this.deployment.ref && this.deployment.ref !== this.deployment.sha) ?
+    this.deployment.ref :
+    this.deployment.sha.substr(0, 7);
   }
 
   getCore() {
     // @todo show ref instead of sha if one exists
-    let center = `${this.shortSha}`;
-    let centerWithLink = `<${this.commitLink}|\`${this.shortSha}\`>`;
+    // let center = `${this.shortSha}`;
+    let center = `${this.prettyRef()}`;
+
+    let centerWithLink = `<${this.commitLink}|\`${this.prettyRef()}\`>`;
     if (this.deployment.environment) {
       center += ` to ${this.deployment.environment}`;
       centerWithLink += this.deploymentStatus.target_url ?

--- a/test/messages/__snapshots__/deployment-status.test.js.snap
+++ b/test/messages/__snapshots__/deployment-status.test.js.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Deployment status rendering uses ref instead of sha, when ref is not the sha 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "author_icon": "https://avatars1.githubusercontent.com/u/7718702?v=4",
+      "author_link": "https://github.com/wilhelmklopp",
+      "author_name": "wilhelmklopp",
+      "color": "#28a745",
+      "fallback": "[github-slack/app] Successfully deployed master to github-slack-app",
+      "footer": "<https://github.com/github-slack/app|github-slack/app>",
+      "footer_icon": "https://github.githubassets.com/favicon.ico",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`master\`> to <https://dashboard.heroku.com/apps/github-slack-app/activity/builds/056df7bf-83c4-4ac1-911b-c8642413eef0|github-slack-app>",
+    },
+  ],
+}
+`;
+
+exports[`Deployment status rendering uses short sha if ref is unequal but null 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "author_icon": "https://avatars1.githubusercontent.com/u/7718702?v=4",
+      "author_link": "https://github.com/wilhelmklopp",
+      "author_name": "wilhelmklopp",
+      "color": "#28a745",
+      "fallback": "[github-slack/app] Successfully deployed 3dce5c8 to github-slack-app",
+      "footer": "<https://github.com/github-slack/app|github-slack/app>",
+      "footer_icon": "https://github.githubassets.com/favicon.ico",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to <https://dashboard.heroku.com/apps/github-slack-app/activity/builds/056df7bf-83c4-4ac1-911b-c8642413eef0|github-slack-app>",
+    },
+  ],
+}
+`;
+
 exports[`Deployment status rendering works for error status 1`] = `
 Object {
   "attachments": Array [

--- a/test/messages/__snapshots__/deployment-status.test.js.snap
+++ b/test/messages/__snapshots__/deployment-status.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Deployment status rendering uses ref instead of sha, when ref is not the sha 1`] = `
+exports[`Deployment status rendering uses ref and the short sha, when ref differs from the sha 1`] = `
 Object {
   "attachments": Array [
     Object {
@@ -8,13 +8,13 @@ Object {
       "author_link": "https://github.com/wilhelmklopp",
       "author_name": "wilhelmklopp",
       "color": "#28a745",
-      "fallback": "[github-slack/app] Successfully deployed master to github-slack-app",
+      "fallback": "[github-slack/app] Successfully deployed master (3dce5c8) to github-slack-app",
       "footer": "<https://github.com/github-slack/app|github-slack/app>",
       "footer_icon": "https://github.githubassets.com/favicon.ico",
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`master\`> to <https://dashboard.heroku.com/apps/github-slack-app/activity/builds/056df7bf-83c4-4ac1-911b-c8642413eef0|github-slack-app>",
+      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`master (3dce5c8)\`> to <https://dashboard.heroku.com/apps/github-slack-app/activity/builds/056df7bf-83c4-4ac1-911b-c8642413eef0|github-slack-app>",
     },
   ],
 }

--- a/test/messages/deployment-status.test.js
+++ b/test/messages/deployment-status.test.js
@@ -87,7 +87,7 @@ describe('Deployment status rendering', () => {
     };
     const deploymentStatusMessage = new DeploymentStatus({
       deploymentStatus: deploymentStatusSuccessFixture.deployment_status,
-      deployment: deployment,
+      deployment,
       repository: deploymentStatusSuccessFixture.repository,
     });
 
@@ -102,7 +102,7 @@ describe('Deployment status rendering', () => {
     };
     const deploymentStatusMessage = new DeploymentStatus({
       deploymentStatus: deploymentStatusSuccessFixture.deployment_status,
-      deployment: deployment,
+      deployment,
       repository: deploymentStatusSuccessFixture.repository,
     });
 

--- a/test/messages/deployment-status.test.js
+++ b/test/messages/deployment-status.test.js
@@ -80,7 +80,7 @@ describe('Deployment status rendering', () => {
     });
     expect(deploymentStatusMessage.toJSON()).toMatchSnapshot();
   });
-  test('uses ref instead of sha, when ref is not the sha', () => {
+  test('uses ref and the short sha, when ref differs from the sha', () => {
     const deployment = {
       ...deploymentStatusSuccessFixture.deployment,
       ref: 'master',
@@ -92,7 +92,7 @@ describe('Deployment status rendering', () => {
     });
 
     const message = deploymentStatusMessage.toJSON().attachments[0].text;
-    expect(message).toMatch(/successfully deployed.*master.*/i);
+    expect(message).toMatch(/successfully deployed.*master.*\(3dce5c8\)/i);
     expect(deploymentStatusMessage.toJSON()).toMatchSnapshot();
   });
   test('uses short sha if ref is unequal but null', () => {

--- a/test/messages/deployment-status.test.js
+++ b/test/messages/deployment-status.test.js
@@ -80,4 +80,34 @@ describe('Deployment status rendering', () => {
     });
     expect(deploymentStatusMessage.toJSON()).toMatchSnapshot();
   });
+  test('uses ref instead of sha, when ref is not the sha', () => {
+    const deployment = {
+      ...deploymentStatusSuccessFixture.deployment,
+      ref: 'master',
+    };
+    const deploymentStatusMessage = new DeploymentStatus({
+      deploymentStatus: deploymentStatusSuccessFixture.deployment_status,
+      deployment: deployment,
+      repository: deploymentStatusSuccessFixture.repository,
+    });
+
+    const message = deploymentStatusMessage.toJSON().attachments[0].text;
+    expect(message).toMatch(/successfully deployed.*master.*/i);
+    expect(deploymentStatusMessage.toJSON()).toMatchSnapshot();
+  });
+  test('uses short sha if ref is unequal but null', () => {
+    const deployment = {
+      ...deploymentStatusSuccessFixture.deployment,
+      ref: null,
+    };
+    const deploymentStatusMessage = new DeploymentStatus({
+      deploymentStatus: deploymentStatusSuccessFixture.deployment_status,
+      deployment: deployment,
+      repository: deploymentStatusSuccessFixture.repository,
+    });
+
+    const message = deploymentStatusMessage.toJSON().attachments[0].text;
+    expect(message).toMatch(/successfully deployed.*3dce5c8.*/i);
+    expect(deploymentStatusMessage.toJSON()).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

When the integrator that created the deployment status provided a ref,
that is different from the commit sha, that ref is now displayed instead
of the short sha.
This addresses the issue discussed in #98 and #85.
I think the next step would be doing an actual API request to fetch the
branches, but his change is a 0-cost improvement and (almost) 0-effort
improvement that allows us to gather metrics about custom ref adoption
and maybe this already solves the problem.

## Screenshots

Before

![depoyment-status-before](https://user-images.githubusercontent.com/3408791/63428128-165d0e80-c417-11e9-972a-30c285b509ad.png)

After

![deployment-status-after](https://user-images.githubusercontent.com/3408791/63428137-19f09580-c417-11e9-8e6f-057785ae7017.png)

Closes #85, #98