### PR TITLE
Increase jest timeouts to stablize unfurl CI tests

### DIFF
--- a/test/integration/unfurl.test.js
+++ b/test/integration/unfurl.test.js
@@ -30,6 +30,10 @@ describe('Integration: unfurls', () => {
   });
 
   describe('public unfurls', () => {
+    beforeEach(async () => {
+      jest.setTimeout(10000);
+    });
+
     test('issue', async () => {
       nock('https://api.github.com').get('/repos/bkeepers/dotenv').times(2).reply(
         200,


### PR DESCRIPTION
Actions CI tests run into the jest default timeout of 5 seconds on
almost all builds. This increases the value to 10 seconds, similarly to
other integration tests we have.

GitHub CI is ✅ . It works 👏 