### PR TITLE
Force colorized jest output

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "scripts": {
     "start": "node --max-semi-space-size=64 ./lib/run.js",
-    "test": "node --expose-gc --max-old-space-size=4096 ./node_modules/.bin/jest --coverage --runInBand --logHeapUsage --bail --forceExit",
+    "test": "node --expose-gc --max-old-space-size=4096 ./node_modules/.bin/jest --coverage --runInBand --logHeapUsage --color --bail --forceExit",
     "test:watch": "node --expose-gc --max-old-space-size=4096 ./node_modules/.bin/jest --runInBand --logHeapUsage --forceExit --watch --notify",
     "posttest": "npm run lint",
     "lint": "eslint lib test",


### PR DESCRIPTION
Actions CI does not show jest test colors.
In order to check if jest has colorized output in GitHub Actions, I have added the `--color` flag.

It works 🌈 👏 