### PR TITLE
Add support for unicode quotes in commands

### DIFF
--- a/lib/slack/command.js
+++ b/lib/slack/command.js
@@ -3,11 +3,22 @@ const { parseSubscriptionArgString } = require('../settings-helper');
 
 const SUBCOMMAND = /^(\w+) *(.*)$/;
 
+function normalizeQuotes(text) {
+  return text
+    .replace(/\u00AB/g, '"')
+    .replace(/\u00BB/g, '"')
+    .replace(/\u201C/g, '"')
+    .replace(/\u201D/g, '"')
+    .replace(/\u201E/g, '"')
+    .replace(/\u201F/g, '"');
+}
+
 module.exports = class Command {
   constructor(body, callback) {
     Object.assign(this, body);
     this.callback = callback;
 
+    this.text = normalizeQuotes(this.text);
     // Check for subcommand in the command text
     const match = this.text.match(SUBCOMMAND);
 

--- a/test/slack/command.test.js
+++ b/test/slack/command.test.js
@@ -39,4 +39,48 @@ describe('Command class', () => {
       'area/api',
     ]);
   });
+
+  describe('normalizes unicode quotes', () => {
+    test("supports '\u00AB'", () => {
+      const command = new Command({
+        text: 'subscribe integration/jira +label:«help wanted«',
+      });
+      expect(command.text).toEqual('integration/jira +label:"help wanted"');
+    });
+
+    test("supports '\u00BB'", () => {
+      const command = new Command({
+        text: 'subscribe integration/jira +label:»help wanted»',
+      });
+      expect(command.text).toEqual('integration/jira +label:"help wanted"');
+    });
+
+    test("supports '\u201C'", () => {
+      const command = new Command({
+        text: 'subscribe integration/jira +label:“help wanted“',
+      });
+      expect(command.text).toEqual('integration/jira +label:"help wanted"');
+    });
+
+    test("supports '\u201D'", () => {
+      const command = new Command({
+        text: 'subscribe integration/jira +label:”help wanted”',
+      });
+      expect(command.text).toEqual('integration/jira +label:"help wanted"');
+    });
+
+    test("supports '\u201E'", () => {
+      const command = new Command({
+        text: 'subscribe integration/jira +label:„help wanted„',
+      });
+      expect(command.text).toEqual('integration/jira +label:"help wanted"');
+    });
+
+    test("supports '\u201F'", () => {
+      const command = new Command({
+        text: 'subscribe integration/jira +label:‟help wanted‟',
+      });
+      expect(command.text).toEqual('integration/jira +label:"help wanted"');
+    });
+  });
 });

--- a/test/slack/command.test.js
+++ b/test/slack/command.test.js
@@ -82,5 +82,12 @@ describe('Command class', () => {
       });
       expect(command.text).toEqual('integration/jira +label:"help wanted"');
     });
+
+    test('supports combining multiple types of quotes in one command', () => {
+      const command = new Command({
+        text: 'subscribe integration/jira +label:»help wanted«',
+      });
+      expect(command.text).toEqual('integration/jira +label:"help wanted"');
+    });
   });
 });


### PR DESCRIPTION
Quoting spaces in required-label filters is possible via `"` (ASCII 34) and `'` (ASCII 39). 
This already led to some confusion, when users typed `“` (3-byte Unicode).
(Reported issue: https://github.com/integrations/slack/issues/384#issuecomment-525796952)
`@wilhelmklopp` anticipated this and we already discussed a solution that is implemented in this PR.

**TL;DR**
We now support multiple common Unicode-quotes by converting them into double quotes (ASCII-34).

```
✓ supports '«'
✓ supports '»'
✓ supports '“'
✓ supports '”'
✓ supports '„'
✓ supports '‟'
```

`cc` @wilhelmklopp "quotes" for fun and profit 😆 🥇 