### PR TITLE
Add Indexes on Unfurls

### DIFF
--- a/db/migrations/20190913165643-add-indexes-to-unfurls-table.js
+++ b/db/migrations/20190913165643-add-indexes-to-unfurls-table.js
@@ -1,11 +1,26 @@
 module.exports = {
   up: (queryInterface) => Promise.all([
     queryInterface.addIndex('Unfurls', {
-      fields: ['channelSlackId', 'slackWorkspaceId', 'slackUserId', 'githubRepoId'],
-      name: 'unfurls_slack_channel_workspace_user_ids_github_repo_id_idx',
+      fields: ['channelSlackId'],
+      name: 'unfurls_channel_slack_id',
+    }),
+    queryInterface.addIndex('Unfurls', {
+      fields: ['slackWorkspaceId'],
+      name: 'unfurls_slack_workspace_id',
+    }),
+    queryInterface.addIndex('Unfurls', {
+      fields: ['slackUserId'],
+      name: 'unfurls_slack_user_id',
+    }),
+    queryInterface.addIndex('Unfurls', {
+      fields: ['githubRepoId'],
+      name: 'unfurls_github_repo_id',
     }),
   ]),
   down: (queryInterface) => Promise.all([
-    queryInterface.removeIndex('Unfurls', 'unfurls_channel_slack_id_slack_workspace_id_slack_user_id_github_repo_id'),
+    queryInterface.removeIndex('Unfurls', 'unfurls_channel_slack_id'),
+    queryInterface.removeIndex('Unfurls', 'unfurls_slack_workspace_id'),
+    queryInterface.removeIndex('Unfurls', 'unfurls_slack_user_id'),
+    queryInterface.removeIndex('Unfurls', 'unfurls_github_repo_id'),
   ]),
 };

--- a/db/migrations/20190913165643-add-indexes-to-unfurls-table.js
+++ b/db/migrations/20190913165643-add-indexes-to-unfurls-table.js
@@ -2,7 +2,7 @@ module.exports = {
   up: (queryInterface) => Promise.all([
     queryInterface.addIndex('Unfurls', {
       fields: ['channelSlackId', 'slackWorkspaceId', 'slackUserId', 'githubRepoId'],
-      name: 'unfurls_channel_slack_id_slack_workspace_id_slack_user_id_github_repo_id',
+      name: 'unfurls_slack_channel_workspace_user_ids_github_repo_id_idx',
     }),
   ]),
   down: (queryInterface) => Promise.all([

--- a/db/migrations/20190913165643-add-indexes-to-unfurls-table.js
+++ b/db/migrations/20190913165643-add-indexes-to-unfurls-table.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: (queryInterface) => Promise.all([
+    queryInterface.addIndex('Unfurls', {
+      fields: ['channelSlackId', 'slackWorkspaceId', 'slackUserId', 'githubRepoId'],
+      name: 'unfurls_channel_slack_id_slack_workspace_id_slack_user_id_github_repo_id',
+    }),
+  ]),
+  down: (queryInterface) => Promise.all([
+    queryInterface.removeIndex('Unfurls', 'unfurls_channel_slack_id_slack_workspace_id_slack_user_id_github_repo_id'),
+  ]),
+};


### PR DESCRIPTION
Fixes #869 

Adds indexes on the `channelSlackId`, `slackWorkspaceId`, `slackUserId` and `githubRepoId` columns on the Unfurls table.