### PR TITLE
Deployment notification includes environment_url on successful deployment

### DIFF
--- a/lib/messages/deployment-status.js
+++ b/lib/messages/deployment-status.js
@@ -27,9 +27,15 @@ class DeploymentStatus extends Message {
     let centerWithLink = `<${this.commitLink}|\`${this.prettyRef}\`>`;
     if (this.deployment.environment) {
       center += ` to ${this.deployment.environment}`;
-      centerWithLink += this.deploymentStatus.target_url
-        ? ` to <${this.deploymentStatus.target_url}|${this.deployment.environment}>`
-        : ` to ${this.deployment.environment}`;
+      if (this.deploymentStatus.state === 'success') {
+        centerWithLink += this.deploymentStatus.environment_url
+          ? ` to <${this.deploymentStatus.environment_url}|${this.deployment.environment}>`
+          : ` to ${this.deployment.environment}`;
+      } else {
+        centerWithLink += this.deploymentStatus.target_url
+          ? ` to <${this.deploymentStatus.target_url}|${this.deployment.environment}>`
+          : ` to ${this.deployment.environment}`;
+      }
     }
     if (this.deploymentStatus.state === 'pending') {
       return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4177,7 +4177,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4198,12 +4199,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4218,17 +4221,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4345,7 +4351,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4357,6 +4364,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4371,6 +4379,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4378,12 +4387,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4402,6 +4413,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4482,7 +4494,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4494,6 +4507,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4579,7 +4593,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4615,6 +4630,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4634,6 +4650,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4677,12 +4694,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10771,7 +10790,7 @@
         "bottleneck": "^1.16.0",
         "commander": "^2.12.2",
         "fs-path": "0.0.23",
-        "puppeteer": "^0.13.0",
+        "puppeteer": "^1.13.0",
         "recursive-readdir": "^2.2.1",
         "relaxed-json": "^1.0.1"
       },

--- a/test/fixtures/webhooks/deployment/status_pending.json
+++ b/test/fixtures/webhooks/deployment/status_pending.json
@@ -23,6 +23,7 @@
       "site_admin": false
     },
     "description": "",
+    "environment_url": "https://dashboard.heroku.com/apps/github-slack-app",
     "target_url": "https://dashboard.heroku.com/apps/github-slack-app",
     "created_at": "2017-11-05T11:14:43Z",
     "updated_at": "2017-11-05T11:14:43Z",

--- a/test/fixtures/webhooks/deployment/status_success.json
+++ b/test/fixtures/webhooks/deployment/status_success.json
@@ -23,6 +23,7 @@
       "site_admin": false
     },
     "description": "",
+    "environment_url": "https://dashboard.heroku.com/apps/github-slack-app",
     "target_url": "https://dashboard.heroku.com/apps/github-slack-app/activity/builds/056df7bf-83c4-4ac1-911b-c8642413eef0",
     "created_at": "2017-11-05T11:15:09Z",
     "updated_at": "2017-11-05T11:15:09Z",

--- a/test/integration/__snapshots__/notifications.test.js.snap
+++ b/test/integration/__snapshots__/notifications.test.js.snap
@@ -187,7 +187,7 @@ Object {
 
 exports[`Integration: notifications to a subscribed channel deployment_status event 2`] = `
 Object {
-  "attachments": "[{\\"color\\":\\"#28a745\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://github.githubassets.com/favicon.ico\\",\\"author_name\\":\\"wilhelmklopp\\",\\"author_icon\\":\\"https://avatars1.githubusercontent.com/u/7718702?v=4\\",\\"author_link\\":\\"https://github.com/wilhelmklopp\\",\\"fallback\\":\\"[github-slack/app] Successfully deployed 3dce5c8 to github-slack-app\\",\\"text\\":\\"Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to <https://dashboard.heroku.com/apps/github-slack-app/activity/builds/056df7bf-83c4-4ac1-911b-c8642413eef0|github-slack-app>\\",\\"mrkdwn_in\\":[\\"text\\"]}]",
+  "attachments": "[{\\"color\\":\\"#28a745\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://github.githubassets.com/favicon.ico\\",\\"author_name\\":\\"wilhelmklopp\\",\\"author_icon\\":\\"https://avatars1.githubusercontent.com/u/7718702?v=4\\",\\"author_link\\":\\"https://github.com/wilhelmklopp\\",\\"fallback\\":\\"[github-slack/app] Successfully deployed 3dce5c8 to github-slack-app\\",\\"text\\":\\"Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to <https://dashboard.heroku.com/apps/github-slack-app|github-slack-app>\\",\\"mrkdwn_in\\":[\\"text\\"]}]",
   "token": "test",
 }
 `;

--- a/test/messages/__snapshots__/deployment-status.test.js.snap
+++ b/test/messages/__snapshots__/deployment-status.test.js.snap
@@ -14,7 +14,7 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`master (3dce5c8)\`> to <https://dashboard.heroku.com/apps/github-slack-app/activity/builds/056df7bf-83c4-4ac1-911b-c8642413eef0|github-slack-app>",
+      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`master (3dce5c8)\`> to <https://dashboard.heroku.com/apps/github-slack-app|github-slack-app>",
     },
   ],
 }
@@ -34,7 +34,7 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to <https://dashboard.heroku.com/apps/github-slack-app/activity/builds/056df7bf-83c4-4ac1-911b-c8642413eef0|github-slack-app>",
+      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to <https://dashboard.heroku.com/apps/github-slack-app|github-slack-app>",
     },
   ],
 }
@@ -154,7 +154,7 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to github-slack-app",
+      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to <https://dashboard.heroku.com/apps/github-slack-app|github-slack-app>",
     },
   ],
 }
@@ -174,7 +174,7 @@ Object {
       "mrkdwn_in": Array [
         "text",
       ],
-      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to <https://dashboard.heroku.com/apps/github-slack-app/activity/builds/056df7bf-83c4-4ac1-911b-c8642413eef0|github-slack-app>",
+      "text": "Successfully deployed <https://github.com/github-slack/app/commit/3dce5c8488afc87a1ffbb840fc33b4a8331a1034|\`3dce5c8\`> to <https://dashboard.heroku.com/apps/github-slack-app|github-slack-app>",
     },
   ],
 }


### PR DESCRIPTION
Close #1041 

In case of successful deployment, the slack notification will embed the `environment_url` specified in the DeploymentStatus object instead of the `target_url` used for debugging deployments.

This way, a developer can access quickly their newly deployed environment by interacting with the  slack notification.

PR contains:
- Logic to change link when deployment is successful
- Test update
- Package-lock.json update