### PR TITLE
Add format option to subscriptions to only show condensed notification messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ And to turn it back off:
 /github unsubscribe owner/repo reviews comments
 ```
 
+#### The format of notification messages
+
+You can configure the format of notification messages with the `format` option:
+
+```
+/github subscribe owner/repo format=condensed
+```
+
+The value can be one of:
+* `full` - Full version message (default)
+* `condensed` - Condensed version message
+
 #### Filters
 
 Label filters allow filtering incoming events based on a whitelist of **required** labels.

--- a/lib/activity/issues.js
+++ b/lib/activity/issues.js
@@ -11,6 +11,7 @@ async function updateIssueMessage(messageMetaData, context, subscription, slack)
     issue,
     repository: context.payload.repository,
     eventType: 'issues.opened',
+    format: subscription.getFormatSetting(),
   });
 
   const { ts, channel } = messageMetaData;
@@ -48,6 +49,7 @@ async function issueEvent(context, subscription, slack) {
     repository: context.payload.repository,
     eventType,
     sender: context.payload.sender,
+    format: subscription.getFormatSetting(),
   });
 
   // 2nd argument is required in API wrapper, but not in API (We don't want to use it in this case)

--- a/lib/activity/pull-requests.js
+++ b/lib/activity/pull-requests.js
@@ -33,6 +33,7 @@ async function pullRequestEvent(context, subscription, slack) {
     eventType,
     sender: context.payload.sender,
     reviews,
+    format: subscription.getFormatSetting(),
   });
 
   const res = await slack.chat.postMessage({
@@ -136,6 +137,7 @@ async function onStatusOrCheckRun(context, subscription, slack) {
     statuses,
     checkRuns,
     reviews,
+    format: subscription.getFormatSetting(),
   });
 
   await updateSlackMessage(context, message, prMessage, slack);

--- a/lib/messages/abstract-issue.js
+++ b/lib/messages/abstract-issue.js
@@ -17,10 +17,11 @@ class AbstractIssue extends Message {
     this.eventType = constructorObject.eventType;
     this.unfurlType = constructorObject.unfurlType;
     this.sender = constructorObject.sender;
+    this.format = constructorObject.format;
 
     this.createdAt = moment(this.abstractIssue.created_at);
 
-    if (constants.MAJOR_MESSAGES[this.eventType] || this.unfurlType === 'full') {
+    if ((this.format === 'full' && constants.MAJOR_MESSAGES[this.eventType]) || this.unfurlType === 'full') {
       this.major = true;
     }
   }

--- a/lib/messages/issue.js
+++ b/lib/messages/issue.js
@@ -8,6 +8,7 @@ class Issue extends AbstractIssue {
     eventType,
     unfurlType,
     sender,
+    format,
   }) {
     super({
       abstractIssue: issue,
@@ -15,6 +16,7 @@ class Issue extends AbstractIssue {
       eventType,
       unfurlType,
       sender,
+      format,
     });
 
     this.issue = issue;

--- a/lib/messages/pull-request.js
+++ b/lib/messages/pull-request.js
@@ -13,6 +13,7 @@ class PullRequest extends AbstractIssue {
     statuses,
     checkRuns,
     reviews,
+    format,
   }) {
     super({
       abstractIssue: pullRequest,
@@ -20,6 +21,7 @@ class PullRequest extends AbstractIssue {
       eventType,
       unfurlType,
       sender,
+      format,
     });
 
     this.pullRequest = pullRequest;

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -29,6 +29,7 @@ module.exports = (sequelize, DataTypes) => {
     comments: false,
     branches: false,
     reviews: false,
+    format: 'full',
     required_labels: [],
   };
 
@@ -38,6 +39,7 @@ module.exports = (sequelize, DataTypes) => {
 
   const AllowValues = {
     commits: ['all'],
+    format: ['full', 'condensed'],
     required_labels: labelValuePattern(),
   };
 
@@ -106,11 +108,14 @@ module.exports = (sequelize, DataTypes) => {
     return validateSingle(key, value);
   }
 
-  // required_labels: ['foo', 'bar'], features: [comments: 'all', issues: boolean]
-  // => { features: [...], required_label: [...]}
-  function mergeLabelsAndFeatures(required_labels, features) {
-    const merged = required_labels.length ? Object.assign(features, { required_labels }) : features;
-    return merged;
+  // required_labels: ['foo', 'bar'], features: [comments: 'all', issues: boolean], format: 'full'
+  // => { features: [...], required_label: [...], format: 'full' }
+  function mergeSettings(required_labels, features, format) {
+    return Object.assign(
+      features,
+      required_labels.length ? { required_labels } : null,
+      format ? { format } : null,
+    );
   }
 
   const Subscription = sequelize.define('Subscription', {
@@ -226,9 +231,14 @@ module.exports = (sequelize, DataTypes) => {
       if (settings) {
         // TODO: Do we want to handle settings.invalids here?
         const features = parseFeatures(settings.features, true);
-        const mergedSettings = mergeLabelsAndFeatures(settings.required_labels, features);
+        const mergedSettings = mergeSettings(settings.required_labels, features, settings.format);
         this.enableFeatures(mergedSettings);
       }
+    },
+
+    getFormatSetting() {
+      const settings = Object.assign({}, DefaultSettings, this.settings, FixedSettings);
+      return settings.format;
     },
 
     getEnabledSettings() {
@@ -281,8 +291,9 @@ module.exports = (sequelize, DataTypes) => {
           } else {
             this.settings[name] = Array.from(newSettings);
           }
+        } else if (name === 'format') {
+          this.settings[name] = value;
         } else {
-          // are there non boolean cases to consider? defaults to restore, etc?
           this.settings[name] = false;
         }
       });
@@ -294,7 +305,7 @@ module.exports = (sequelize, DataTypes) => {
     disable(settings) {
       if (settings) {
         const features = parseFeatures(settings.features, false);
-        const mergedSettings = mergeLabelsAndFeatures(settings.required_labels, features);
+        const mergedSettings = mergeSettings(settings.required_labels, features, settings.format);
         // TODO special-case label without argument as: disable all labels?
         this.disableFeatures(mergedSettings);
       }
@@ -348,7 +359,7 @@ module.exports = (sequelize, DataTypes) => {
       const { settings, ...subscription } = attrs;
       if (settings) {
         const features = parseFeatures(settings.features, true);
-        const mergedSettings = mergeLabelsAndFeatures(settings.required_labels, features);
+        const mergedSettings = mergeSettings(settings.required_labels, features, settings.format);
         const data = Object.assign(subscription, { settings: mergedSettings });
 
         record = await this.create(data);

--- a/lib/settings-helper.js
+++ b/lib/settings-helper.js
@@ -11,9 +11,15 @@ function labelValuePattern() {
 // Allow alphanumerics and special characters and quoted spaces
 // Example:
 // label:foo label:teams/designers label:"foo bar" label:' bar baz'
-
 function labelPattern() {
   return /(?:\+label:(?:([A-Za-z0-9-:./]+)|["']([A-Za-z0-9-:./\s]+)["']) ?)+$/g;
+}
+
+// Allow "full" or "condensed"
+// Example:
+// format=full format=condensed
+function formatPattern() {
+  return /(?:format=(?:(full|condensed)) ?)+$/g;
 }
 
 // We want to split on label with quoted spaces or on space and comma.
@@ -29,9 +35,18 @@ function isProperLabelArg(arg) {
   return !!arg.match(labelPattern());
 }
 
+function isProperFormatArg(arg) {
+  return !!arg.match(formatPattern());
+}
+
 function extractLabelValue(arg) {
   const match = labelPattern().exec(arg);
   return match[1] || match[2];
+}
+
+function extractFormatValue(arg) {
+  const match = formatPattern().exec(arg);
+  return match[1];
 }
 
 function castInput(input) {
@@ -51,7 +66,18 @@ function parseSettings(commandInput) {
   const init = emptyResult();
 
   const parsed = commandArgs.reduce((result, arg) => {
-    if (arg.startsWith('+label')) {
+    if (arg.startsWith('format')) {
+      if (!isProperFormatArg(arg)) {
+        const error = {
+          raw: arg,
+          key: 'format',
+          val: arg.substr('format='.length),
+        };
+        return Object.assign(result, { invalids: result.invalids.concat(error) });
+      }
+      const value = extractFormatValue(arg);
+      return Object.assign(result, { format: value });
+    } else if (arg.startsWith('+label')) {
       if (!isProperLabelArg(arg)) {
         const error = {
           raw: arg,
@@ -70,20 +96,23 @@ function parseSettings(commandInput) {
     required_labels: uniq(parsed.required_labels),
     features: parsed.features,
     invalids: parsed.invalids,
+    ...(parsed.format ? { format: parsed.format } : null),
     // NOTE: hasValue needs to be true even if all arguments are invalid
     // This ensures that we don't accidentally delete subscrptions based on the
     // absense of values in `features` and `required_labels`.
     hasValues: [parsed.features, parsed.required_labels, parsed.invalids]
-      .some(arr => arr.length > 0),
+      .some(arr => arr.length > 0) || parsed.format !== undefined,
   };
 }
 
 // parse raw command inputs into an object.
-// +label:"wip" +label:"dont merge" pulls issues
+// +label:"wip" +label:"dont merge" pulls issues format=condensed
 // => {
 //       required_labels: ["wip", "dont merge"],
 //       features: ["pulls", "issues"],
-//       invalids: [], hasValue: true
+//       invalids: [],
+//       format: "condensed",
+//       hasValue: true
 //    }
 function parseSubscriptionArgString(argString) {
   const input = argString || '';

--- a/test/integration/__snapshots__/list-subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/list-subscriptions.test.js.snap
@@ -256,11 +256,11 @@ Object {
       "color": "#24292f",
       "fallback": "Subscribed to 2 repositories",
       "text": "<https://github.com/atom/atom|atom/atom>
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits:all\`, \`releases\`
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits:all\`, \`releases\`, \`format:full\`
 
 
 <https://github.com/kubernetes/kubernetes|kubernetes/kubernetes>
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`format:full\`
 
 ",
       "title": "Subscribed to the following repositories",
@@ -269,7 +269,7 @@ Object {
       "color": "#24292f",
       "fallback": "Subscribed to 1 account",
       "text": "<https://github.com/Microsoft|Microsoft>
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`format:full\`
 
 ",
       "title": "Subscribed to the following accounts",

--- a/test/integration/__snapshots__/subscriptions.test.js.snap
+++ b/test/integration/__snapshots__/subscriptions.test.js.snap
@@ -535,7 +535,7 @@ Object {
         "footer",
       ],
       "text": "This channel will get notifications from <https://github.com/bkeepers/dotenv|bkeepers/dotenv> for: 
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`",
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`format:full\`",
     },
   ],
   "response_type": "in_channel",
@@ -676,7 +676,7 @@ Object {
         "footer",
       ],
       "text": "This channel will get notifications from <https://github.com/bkeepers/dotenv|bkeepers/dotenv> for: 
-\`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`",
+\`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`format:full\`",
     },
   ],
   "response_type": "in_channel",
@@ -694,7 +694,7 @@ Object {
         "footer",
       ],
       "text": "This channel will get notifications from <https://github.com/bkeepers/dotenv|bkeepers/dotenv> for: 
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`",
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`format:full\`",
     },
   ],
   "response_type": "in_channel",

--- a/test/messages/Issue.test.js
+++ b/test/messages/Issue.test.js
@@ -30,6 +30,19 @@ describe('Issue rendering', () => {
       repository: issuesOpened.repository,
       eventType: 'issues.opened',
       sender: issuesOpened.sender,
+      format: 'full',
+    });
+    const rendered = issueMessage.getRenderedMessage();
+    expect(rendered).toMatchSnapshot();
+  });
+
+  test('works for condensed notification messages', async () => {
+    const issueMessage = new Issue({
+      issue: issuesOpened.issue,
+      repository: issuesOpened.repository,
+      eventType: 'issues.opened',
+      sender: issuesOpened.sender,
+      format: 'condensed',
     });
     const rendered = issueMessage.getRenderedMessage();
     expect(rendered).toMatchSnapshot();
@@ -41,6 +54,7 @@ describe('Issue rendering', () => {
       repository: issuesClosed.repository,
       eventType: 'issues.closed',
       sender: issuesClosed.sender,
+      format: 'full',
     });
     const rendered = issueMessage.getRenderedMessage();
     expect(rendered).toMatchSnapshot();
@@ -66,6 +80,7 @@ describe('Issue rendering', () => {
       },
       repository: issuesOpened.repository,
       eventType: 'issues.opened',
+      format: 'full',
     });
     expect(message.getRenderedMessage()).toMatchSnapshot();
   });

--- a/test/messages/__snapshots__/Issue.test.js.snap
+++ b/test/messages/__snapshots__/Issue.test.js.snap
@@ -74,6 +74,26 @@ https://media.giphy.com/media/5xtDarEbygs3Pu7p3jO/giphy.gif",
 }
 `;
 
+exports[`Issue rendering works for condensed notification messages 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "color": "#36a64f",
+      "fallback": "[github-slack/public-test] Issue opened by wilhelmklopp",
+      "footer": "<https://github.com/github-slack/public-test|github-slack/public-test>",
+      "footer_icon": "https://github.githubassets.com/favicon.ico",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "pretext": "Issue opened by wilhelmklopp",
+      "title": "#1 Needs content",
+      "title_link": "https://github.com/github-slack/public-test/issues/1",
+      "ts": 1508171038,
+    },
+  ],
+}
+`;
+
 exports[`Issue rendering works for condensed unfurls 1`] = `
 Object {
   "attachments": Array [

--- a/test/messages/__snapshots__/pull-request.test.js.snap
+++ b/test/messages/__snapshots__/pull-request.test.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Pull request rendering works for condensed notification messages 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "color": "#36a64f",
+      "fallback": "[github-slack/app] #31 Add badges to readme",
+      "footer": "<https://github.com/github-slack/app|github-slack/app>",
+      "footer_icon": "https://github.githubassets.com/favicon.ico",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "pretext": "Pull request opened by wilhelmklopp",
+      "title": "#31 Add badges to readme",
+      "title_link": "https://github.com/github-slack/app/pull/31",
+      "ts": 1506092298,
+    },
+  ],
+}
+`;
+
 exports[`Pull request rendering works for condensed unfurls 1`] = `
 Object {
   "color": "#36a64f",

--- a/test/messages/__snapshots__/subscription-list.test.js.snap
+++ b/test/messages/__snapshots__/subscription-list.test.js.snap
@@ -7,11 +7,11 @@ Object {
       "color": "#24292f",
       "fallback": "Subscribed to 2 repositories",
       "text": "<https://github.com/atom/atom|atom/atom>
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`comments\`, \`reviews\`
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`comments\`, \`reviews\`, \`format:full\`
 
 
 <https://github.com/bkeepers/dotenv|bkeepers/dotenv>
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`format:full\`
 
 ",
       "title": "Subscribed to the following repositories",
@@ -20,11 +20,11 @@ Object {
       "color": "#24292f",
       "fallback": "Subscribed to 2 accounts",
       "text": "<https://github.com/atom|atom>
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`format:full\`
 
 
 <https://github.com/kubernetes|kubernetes>
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits:all\`, \`releases\`
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits:all\`, \`releases\`, \`format:full\`
 
 ",
       "title": "Subscribed to the following accounts",

--- a/test/messages/abstract-issue.test.js
+++ b/test/messages/abstract-issue.test.js
@@ -13,6 +13,7 @@ describe('AbstractIssue rendering', () => {
       eventType: 'issues.opened',
       unfurl: false,
       sender: issuesOpened.sender,
+      format: 'full',
     });
   });
 

--- a/test/messages/flow/__snapshots__/updated-settings.test.js.snap
+++ b/test/messages/flow/__snapshots__/updated-settings.test.js.snap
@@ -11,7 +11,7 @@ Object {
         "footer",
       ],
       "text": "This channel will get notifications from <https://github.com/bkeepers/dotenv|bkeepers/dotenv> for: 
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`",
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`format:full\`",
     },
   ],
   "response_type": "in_channel",
@@ -29,7 +29,7 @@ Object {
         "footer",
       ],
       "text": "This channel will get notifications from <https://github.com/bkeepers/dotenv|bkeepers/dotenv> for: 
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`",
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`format:full\`",
     },
   ],
   "response_type": "in_channel",
@@ -47,7 +47,7 @@ Object {
         "footer",
       ],
       "text": "This channel will get notifications from <https://github.com/bkeepers/dotenv|bkeepers/dotenv> for: 
-\`issues\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`",
+\`issues\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`format:full\`",
     },
   ],
   "response_type": "in_channel",
@@ -65,7 +65,7 @@ Object {
         "footer",
       ],
       "text": "This channel will get notifications from <https://github.com/bkeepers/dotenv|bkeepers/dotenv> for: 
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`label: ['todo', 'help wanted']\`",
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits\`, \`releases\`, \`format:full\`, \`label: ['todo', 'help wanted']\`",
     },
   ],
   "response_type": "in_channel",
@@ -83,7 +83,7 @@ Object {
         "footer",
       ],
       "text": "This channel will get notifications from <https://github.com/bkeepers/dotenv|bkeepers/dotenv> for: 
-\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits:all\`, \`releases\`",
+\`issues\`, \`pulls\`, \`deployments\`, \`statuses\`, \`public\`, \`commits:all\`, \`releases\`, \`format:full\`",
     },
   ],
   "response_type": "in_channel",

--- a/test/messages/pull-request.test.js
+++ b/test/messages/pull-request.test.js
@@ -26,6 +26,7 @@ describe('Pull request rendering', () => {
         { state: 'CHANGES_REQUESTED', user: { login: 'user2' } },
         { state: 'APPROVED', user: { login: 'user2' } },
       ],
+      format: 'full',
     });
     const rendered = prMessage.getRenderedMessage();
     expect(rendered).toMatchSnapshot();
@@ -43,6 +44,7 @@ describe('Pull request rendering', () => {
       unfurl: false,
       statuses: combinedStatus.statuses,
       sender: pullRequestOpened.sender,
+      format: 'full',
     });
     const rendered = prMessage.getRenderedMessage();
     expect(rendered).toMatchSnapshot();
@@ -60,6 +62,7 @@ describe('Pull request rendering', () => {
       unfurl: false,
       statuses: combinedStatusSomePassing.statuses,
       sender: pullRequestOpened.sender,
+      format: 'full',
     });
     const rendered = prMessage.getRenderedMessage();
     expect(rendered).toMatchSnapshot();
@@ -77,6 +80,7 @@ describe('Pull request rendering', () => {
       unfurl: false,
       statuses: combinedStatusAllPassing.statuses,
       sender: pullRequestOpened.sender,
+      format: 'full',
     });
     const rendered = prMessage.getRenderedMessage();
     expect(rendered).toMatchSnapshot();
@@ -94,6 +98,7 @@ describe('Pull request rendering', () => {
       unfurl: false,
       statuses: combinedStatusOneFailing.statuses,
       sender: pullRequestOpened.sender,
+      format: 'full',
     });
     const rendered = prMessage.getRenderedMessage();
     expect(rendered).toMatchSnapshot();
@@ -111,6 +116,32 @@ describe('Pull request rendering', () => {
       unfurl: false,
       checkRuns: check.check_runs,
       sender: pullRequestOpened.sender,
+      format: 'full',
+    });
+    const rendered = prMessage.getRenderedMessage();
+    expect(rendered).toMatchSnapshot();
+  });
+
+  test('works for condensed notification messages', async () => {
+    const pullRequest = {
+      ...pullRequestOpened.pull_request,
+      labels: [],
+      requested_reviewers: [{ login: 'user1' }],
+      requested_teams: [{ name: 'Test-team', slug: 'test-team' }],
+    };
+    const prMessage = new PullRequest({
+      pullRequest,
+      repository: pullRequestOpened.repository,
+      eventType: 'pull_request.opened',
+      unfurls: false,
+      statuses: combinedStatusOneFailing.statuses,
+      checkRuns: check.check_runs,
+      sender: pullRequestOpened.sender,
+      reviews: [
+        { state: 'CHANGES_REQUESTED', user: { login: 'user2' } },
+        { state: 'APPROVED', user: { login: 'user2' } },
+      ],
+      format: 'condensed',
     });
     const rendered = prMessage.getRenderedMessage();
     expect(rendered).toMatchSnapshot();
@@ -126,6 +157,7 @@ describe('Pull request rendering', () => {
       repository: pullRequestClosed.repository,
       eventType: 'pull_request.closed',
       sender: pullRequestClosed.sender,
+      format: 'full',
     });
     const rendered = prMessage.getRenderedMessage();
     expect(rendered).toMatchSnapshot();
@@ -176,6 +208,7 @@ describe('Pull request rendering', () => {
         { state: 'CHANGES_REQUESTED', user: { login: 'user2' } },
         { state: 'APPROVED', user: { login: 'user2' } },
       ],
+      format: 'full',
     });
     const rendered = prMessage.getRenderedMessage();
     expect(rendered).toMatchSnapshot();

--- a/test/settings-helper.test.js
+++ b/test/settings-helper.test.js
@@ -6,36 +6,56 @@ describe('parseSettings', () => {
     expect(parsed.required_labels).toEqual(['todo', 'wip']);
   });
 
+  test('detects format=full', () => {
+    const parsed = parseSettings('format=full');
+    expect(parsed.format).toEqual('full');
+  });
+
+  test('detects format=condensed', () => {
+    const parsed = parseSettings('format=condensed');
+    expect(parsed.format).toEqual('condensed');
+  });
+
   test('de-duplicates labels', () => {
     const parsed = parseSettings(['+label:todo', '+label:todo', '+label:wip']);
     expect(parsed.required_labels).toEqual(['todo', 'wip']);
+  });
+
+  test('de-duplicates format', () => {
+    const parsed = parseSettings(['format=full', 'format=condensed']);
+    expect(parsed.format).toEqual('condensed');
+    expect(parsed.invalids).toEqual([]);
   });
 
   test('discards label without delimiter', () => {
     const parsed = parseSettings(['+label', '+label:todo', '+label:wip']);
     expect(parsed.required_labels).toEqual(['todo', 'wip']);
     expect(parsed.features).toEqual([]);
+    expect(parsed.format).toEqual(undefined);
   });
 
   test('discards label without value', () => {
     const parsed = parseSettings(['+label:', '+label:todo', '+label:wip']);
     expect(parsed.required_labels).toEqual(['todo', 'wip']);
     expect(parsed.features).toEqual([]);
+    expect(parsed.format).toEqual(undefined);
   });
 
   test('handles quoted spaces', () => {
     const parsed = parseSettings(['+label:"Help wanted"', '+label:todo', '+label:wip']);
     expect(parsed.required_labels).toEqual(['Help wanted', 'todo', 'wip']);
     expect(parsed.features).toEqual([]);
+    expect(parsed.format).toEqual(undefined);
   });
 
   test('handles colons in label values', () => {
     const parsed = parseSettings(['+label:priority:HIGH', '+label:todo', '+label:wip']);
     expect(parsed.required_labels).toEqual(['priority:HIGH', 'todo', 'wip']);
     expect(parsed.features).toEqual([]);
+    expect(parsed.format).toEqual(undefined);
   });
 
-  test('extracts invalid entries correctly', () => {
+  test('extracts invalid label entries correctly', () => {
     const parsed = parseSettings([
       '+label:priority:HIGH',
       '+label:todo',
@@ -45,10 +65,20 @@ describe('parseSettings', () => {
 
     expect(parsed.features).toEqual([]);
     expect(parsed.required_labels).toEqual(['priority:HIGH', 'todo', 'wip']);
+    expect(parsed.format).toEqual(undefined);
     expect(parsed.invalids.length).toEqual(1);
   });
 
-  test('extracts rich error information ', () => {
+  test('extracts invalid format entry correctly', () => {
+    const parsed = parseSettings('format=simple');
+
+    expect(parsed.features).toEqual([]);
+    expect(parsed.required_labels).toEqual([]);
+    expect(parsed.format).toEqual(undefined);
+    expect(parsed.invalids.length).toEqual(1);
+  });
+
+  test('extracts rich label error information', () => {
     const parsed = parseSettings(['+label:wip', '+label:not,wanted']);
     const expectedError = {
       raw: '+label:not,wanted',
@@ -59,59 +89,74 @@ describe('parseSettings', () => {
     expect(parsed.required_labels).toEqual(['wip']);
     expect(parsed.invalids).toEqual([expectedError]);
   });
+
+  test('extracts rich format error information', () => {
+    const parsed = parseSettings('format=simple');
+    const expectedError = {
+      raw: 'format=simple',
+      key: 'format',
+      val: 'simple',
+    };
+    expect(parsed.format).toEqual(undefined);
+    expect(parsed.invalids).toEqual([expectedError]);
+  });
 });
 
 describe('hasValue', () => {
-  test('hasValue if a label is present', () => {
+  test('hasValue is true if a label is present', () => {
     const parsed = parseSettings(['+label:wip']);
-
     expect(parsed.hasValues).toBeTruthy();
   });
 
-  test('hasValue if a feature is present', () => {
+  test('hasValue is true if a feature is present', () => {
     const parsed = parseSettings(['comments']);
+    expect(parsed.hasValues).toBeTruthy();
+  });
 
+  test('hasValue is true if a format is present', () => {
+    const parsed = parseSettings('format:full');
     expect(parsed.hasValues).toBeTruthy();
   });
 
   test('hasValue is true if only a invalid label is present', () => {
     const parsed = parseSettings(['+label:wip,,,,']);
-
     expect(parsed.hasValues).toBeTruthy();
   });
 
   test('hasValue is true if a valid and an invalid label is present', () => {
     const parsed = parseSettings(['+label:invalid,,,,', '+label:valid']);
-
     expect(parsed.hasValues).toBeTruthy();
   });
 
   test('hasValue is true if an invalid label and a feature is present', () => {
     const parsed = parseSettings(['+label:invalid,,,,', 'issues']);
-
     expect(parsed.hasValues).toBeTruthy();
   });
 });
 
 describe('parseSettingsArgs', () => {
   test('knows if values are present ', () => {
-    const parsed = parseSubscriptionArgString('github/hub pulls issues +label:ready-to-review');
+    const parsed = parseSubscriptionArgString('github/hub pulls issues +label:ready-to-review format=full');
     expect(parsed.hasValues).toBeTruthy();
   });
+
   test('features extracted unparsed', () => {
     const parsed = parseSubscriptionArgString('github/hub pulls issues commits:all +label:ready-to-review');
-
     expect(parsed.features).toEqual(['pulls', 'issues', 'commits:all']);
   });
+
   test('labels are parsed', () => {
     const parsed = parseSubscriptionArgString('github/hub pulls issues commits:all +label:ready-to-review');
-
     expect(parsed.required_labels).toEqual(['ready-to-review']);
+  });
+
+  test('format is parsed', () => {
+    const parsed = parseSubscriptionArgString('github/hub pulls issues commits:all +label:ready-to-review format=condensed');
+    expect(parsed.format).toEqual('condensed');
   });
 
   test('extracts the resource', () => {
     const parsed = parseSubscriptionArgString('github/hub pulls issues commits:all +label:ready-to-review');
-
     expect(parsed.resource).toEqual('github/hub');
   });
 });


### PR DESCRIPTION
Close #162

This PR adds format option to subscriptions to only show condensed notification messages.

#### Usage 
```
/github subscribe owner/repo format=[full|condensed]
```

The value can be one of:
* `full` - Full version message (default)
* `condensed` - Condensed version message