### PR TITLE
Clarifies GitHub Enterprise cloud-hosted and self-hosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The GitHub integration for Slack gives you and your teams full visibility into y
 --------
 ## Installing the GitHub integration for Slack
 ### Requirements
-This app officially supports GitHub.com and Slack.com but the team plans to support GitHub Enterprise and Slack Enterprise Grid in the future.
+This app officially supports GitHub.com (which includes our GitHub Enterprise cloud-hosted offering) and Slack.com, but the team plans to support GitHub Enterprise Server (our self-hosted product) and Slack Enterprise Grid in the future.
 
 ### Installation
 [Install the GitHub integration for Slack](https://slack.com/apps/A8GBNUWU8-github). After you've signed in to your Slack workspace, you will be prompted to give the app access:


### PR DESCRIPTION
Helps clarify which GitHub products are supported. I used the same notation as our documentation here: https://docs.github.com/en/github/getting-started-with-github/githubs-products#github-enterprise