### PR TITLE
Notify issues.labeled required_labels

### DIFF
--- a/lib/activity/index.js
+++ b/lib/activity/index.js
@@ -2,6 +2,7 @@ const route = require('./router');
 
 const {
   matchMetaDataStatetoIssueMessage,
+  issueLabeledEvent,
   issueEvent,
 } = require('./issues');
 
@@ -24,8 +25,9 @@ const { releaseEvent } = require('./releases');
 module.exports = (robot) => {
   robot.on(['issues.opened', 'issues.closed', 'issues.reopened'], route(issueEvent));
 
+  robot.on(['issues.labeled'], route(issueLabeledEvent));
+
   robot.on([
-    'issues.labeled',
     'issues.unlabeled',
     'issues.assigned',
     'issues.unassigned',

--- a/lib/activity/issues.js
+++ b/lib/activity/issues.js
@@ -30,6 +30,34 @@ async function matchMetaDataStatetoIssueMessage(context, subscription, slack) {
   }
 }
 
+async function issueLabeledEvent(context, subscription, slack) {
+  if (!Array.isArray(subscription.settings.required_labels) ||
+      subscription.settings.required_labels.length === 0) {
+    await matchMetaDataStatetoIssueMessage(context, subscription, slack);
+  } else {
+    const issue = {
+      ...context.payload.issue,
+    };
+
+    const eventType = `${context.event}.${context.payload.action}`;
+
+    const issueMessage = new Issue({
+      issue,
+      repository: context.payload.repository,
+      eventType,
+      sender: context.payload.sender,
+    });
+
+    const res = await slack.chat.postMessage({
+      channel: subscription.channelId,
+      ...issueMessage.getRenderedMessage(),
+    });
+    context.log(res, 'Posted Slack message');
+
+    return res;
+  }
+}
+
 async function issueEvent(context, subscription, slack) {
   let issue = {
     ...context.payload.issue,
@@ -73,5 +101,6 @@ async function issueEvent(context, subscription, slack) {
 
 module.exports = {
   matchMetaDataStatetoIssueMessage,
+  issueLabeledEvent,
   issueEvent,
 };

--- a/test/integration/__snapshots__/notifications.test.js.snap
+++ b/test/integration/__snapshots__/notifications.test.js.snap
@@ -402,6 +402,59 @@ Array [
 ]
 `;
 
+exports[`Integration: notifications to a subscribed channel issues.labeled posts issue message 1`] = `
+Object {
+  "attachments": "[{\\"color\\":\\"#36a64f\\",\\"footer\\":\\"<https://github.com/github-slack/public-test|github-slack/public-test>\\",\\"footer_icon\\":\\"https://github.githubassets.com/favicon.ico\\",\\"ts\\":1508171038,\\"mrkdwn_in\\":[\\"text\\"],\\"title\\":\\"#1 Needs content\\",\\"title_link\\":\\"https://github.com/github-slack/public-test/issues/1\\",\\"fallback\\":\\"[github-slack/public-test] Issue labeled by wilhelmklopp\\",\\"pretext\\":\\"Issue labeled by wilhelmklopp\\"}]",
+  "channel": "C001",
+  "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issues.labeled posts issue message 2`] = `
+Array [
+  "creator-access#1:107153132",
+]
+`;
+
+exports[`Integration: notifications to a subscribed channel issues.labeled posts issue message 3`] = `
+Array [
+  Array [
+    "creator-access#1:107153132",
+    true,
+  ],
+]
+`;
+
+exports[`Integration: notifications to a subscribed channel issues.labeled updates issue message 1`] = `
+Object {
+  "attachments": "[{\\"fields\\":[{\\"title\\":\\"Comments\\",\\"value\\":126,\\"short\\":true}],\\"color\\":\\"#cb2431\\",\\"footer\\":\\"<https://github.com/github-slack/public-test|github-slack/public-test>\\",\\"footer_icon\\":\\"https://github.githubassets.com/favicon.ico\\",\\"ts\\":1500156238,\\"mrkdwn_in\\":[\\"text\\"],\\"author_name\\":\\"wohali\\",\\"author_link\\":\\"https://github.com/wohali\\",\\"author_icon\\":\\"https://avatars2.githubusercontent.com/u/112292?v=4\\",\\"title\\":\\"#10191 Consider re-licensing to AL v2.0, as RocksDB has just done\\",\\"title_link\\":\\"https://github.com/facebook/react/issues/10191\\",\\"fallback\\":\\"[github-slack/public-test] Issue opened by wohali\\",\\"text\\":\\"Hi there,\\\\r\\\\n\\\\r\\\\nThe Apache Software Foundation Legal Affairs Committee [has announced][1] that the so-called 'Facebook BSD+Patents License' is no longer allowed to be used as a direct dependency in Apache projects.\\\\r\\\\n\\\\r\\\\nThis has lead to a lot of upset and frustration in the Apache community, especially from projects requiring similarly-licensed code as direct dependencies - the chief of these being RocksDB.\\\\r\\\\n\\\\r\\\\nHowever, we (the Apache Software Foundation) have just received word that [RocksDB will be re-licensing their code under the dual Apache License v2.0 and GPL 2 licenses][2]. \\\\r\\\\n\\\\r\\\\nAs a user of React.JS in an ASF top-level project (Apache CouchDB), please consider re-licensing React.JS under similar terms. Otherwise, many ASF projects such as our own will have to stop relying on and building with React.\\\\r\\\\n\\\\r\\\\nA previous bug (#9760) suggested I mention @lacker in this issue when asking licensing questions, so I'm doing so.\\\\r\\\\n\\\\r\\\\nThank you kindly for your consideration.\\\\r\\\\n\\\\r\\\\n[1]: https://issues.apache.org/jira/browse/LEGAL-303?focusedCommentId=16088663&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16088663\\\\r\\\\n[2]: https://issues.apache.org/jira/browse/LEGAL-303?focusedCommentId=16088730&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16088730\\",\\"pretext\\":\\"Issue opened by wohali\\"}]",
+  "token": "test",
+}
+`;
+
+exports[`Integration: notifications to a subscribed channel issues.labeled updates issue message 2`] = `
+Array [
+  "channel#9523#C001:issue#265831302",
+  "creator-access#1:107153132",
+]
+`;
+
+exports[`Integration: notifications to a subscribed channel issues.labeled updates issue message 3`] = `
+Array [
+  Array [
+    "channel#9523#C001:issue#265831302",
+    Object {
+      "channel": undefined,
+      "ts": undefined,
+    },
+  ],
+  Array [
+    "creator-access#1:107153132",
+    true,
+  ],
+]
+`;
+
 exports[`Integration: notifications to a subscribed channel message still gets delivered if no creatorId is set on Subscription 1`] = `
 Object {
   "attachments": "[{\\"fields\\":[{\\"title\\":\\"Comments\\",\\"value\\":3,\\"short\\":true},{\\"title\\":\\"Reviewers\\",\\"value\\":\\"thomasjo, fosslinux\\",\\"short\\":true}],\\"color\\":\\"#6f42c1\\",\\"footer\\":\\"<https://github.com/github-slack/app|github-slack/app>\\",\\"footer_icon\\":\\"https://github.githubassets.com/favicon.ico\\",\\"ts\\":1502411430,\\"mrkdwn_in\\":[\\"text\\"],\\"author_name\\":\\"e-beach\\",\\"author_link\\":\\"https://github.com/e-beach\\",\\"author_icon\\":\\"https://avatars1.githubusercontent.com/u/13651458?v=4\\",\\"title\\":\\"#1535 Make fork command idempotent\\",\\"title_link\\":\\"https://github.com/github/hub/pull/1535\\",\\"fallback\\":\\"[github-slack/app] #1535 Make fork command idempotent\\",\\"text\\":\\"Fixes #1499.\\\\r\\\\n\\\\r\\\\nThis PR makes \`hub fork\` succeed, with no operation, if a remote pointing to the forked repository already exists.\\\\r\\\\n \\",\\"pretext\\":\\"Pull request merged by wilhelmklopp\\"}]",


### PR DESCRIPTION
Fixes https://github.com/integrations/slack/issues/965 
Fixes https://github.com/integrations/slack/issues/963

This PR allows to notify `issues.labeled` events when we use labels filter.
Here is the behavior.

### Before

1. We subscribes `issues` events by using labels filter like `/github subscribe org/repo +label:enhancement`
2. We add the required_label `enhancement` to existing issue, but the integration does not notify this.

### After

1. Same as the above
2. We add the required_label `enhancement` to existing issue, then the integration notifies this.

Note,
if we do not use the labels filter, the integration behaves same as before.