### PR TITLE
Allow underscore label

### DIFF
--- a/lib/settings-helper.js
+++ b/lib/settings-helper.js
@@ -13,7 +13,7 @@ function labelValuePattern() {
 // label:foo label:teams/designers label:"foo bar" label:' bar baz'
 
 function labelPattern() {
-  return /(?:\+label:(?:([A-Za-z0-9-:./]+)|["']([A-Za-z0-9-:./\s]+)["']) ?)+$/g;
+  return /(?:\+label:(?:([A-Za-z0-9-_:./]+)|["']([A-Za-z0-9-_:./\s]+)["']) ?)+$/g;
 }
 
 // We want to split on label with quoted spaces or on space and comma.

--- a/test/settings-helper.test.js
+++ b/test/settings-helper.test.js
@@ -59,6 +59,12 @@ describe('parseSettings', () => {
     expect(parsed.required_labels).toEqual(['wip']);
     expect(parsed.invalids).toEqual([expectedError]);
   });
+
+  test('handles underscore in label values', () => {
+    const parsed = parseSettings(['+label:something_with_underscore']);
+    expect(parsed.required_labels).toEqual(['something_with_underscore']);
+    expect(parsed.features).toEqual([]);
+  });
 });
 
 describe('hasValue', () => {


### PR DESCRIPTION
Related issue: https://github.com/integrations/slack/issues/970

I get an error +label:something_with_underscores is not a valid argument, when trying to filter the subscription by a label with an underscore.

I read "Valid filters" section in README, there is no mention of underscore.

Then I checked `labelPattern` regex rule in `settings-helper.js`, underscore is not allowed in label pattern.

Is it possible to add an underscore to it?

Thank you for reading.
