### PR TITLE
Do not post message to Slack for a Draft PR

### DIFF
--- a/lib/activity/pull-requests.js
+++ b/lib/activity/pull-requests.js
@@ -15,6 +15,10 @@ async function pullRequestEvent(context, subscription, slack) {
   let pullRequest = {
     ...context.payload.pull_request,
   };
+  if (pullRequest.draft) {
+    // do not process draft PRs; wait for ready_for_review event
+    return;
+  }
   if (!['closed', 'reopened'].includes(context.payload.action)) {
     // need seperate api request to get labels, body_html, requested_reviewers and requested_teams
     pullRequest = (await context.github.pullRequests.get(context.issue({

--- a/test/integration/notifications.test.js
+++ b/test/integration/notifications.test.js
@@ -195,6 +195,38 @@ describe('Integration: notifications', () => {
       });
     });
 
+    test('draft pull request opened', async () => {
+      await Subscription.subscribe({
+        githubId: pullRequestPayload.repository.id,
+        channelId: 'C001',
+        slackWorkspaceId: workspace.id,
+        installationId: installation.id,
+        creatorId: slackUser.id,
+        type: 'repo',
+      });
+
+      nock('https://api.github.com').get(`/repositories/${pullRequestPayload.repository.id}`).reply(200);
+      nock('https://api.github.com', {
+        reqHeaders: {
+          Accept: 'application/vnd.github.html+json',
+        },
+      }).get('/repos/github-slack/app/pulls/31').reply(200, { ...fixtures.pull, ...fixtures.issue, draft: true });
+      nock('https://api.github.com').get('/repos/github-slack/app/pulls/10191/reviews').reply(200, fixtures.reviews);
+
+      /*
+       * TODO: assert that these two interactions _DO NOT_ occur
+      nock('https://slack.com').post('/api/chat.postMessage', (body) => {
+        expect(body).toMatchSnapshot();
+        return true;
+      }).reply(200, { ok: true });
+
+      await probot.receive({
+        name: 'pull_request',
+        payload: pullRequestPayload,
+      });
+      */
+    });
+
     test('pull request opened', async () => {
       await Subscription.subscribe({
         githubId: pullRequestPayload.repository.id,


### PR DESCRIPTION
Closes https://github.com/integrations/slack/issues/795

Given that https://github.com/integrations/slack/issues/805 introduces a notification when a Draft is marked Ready for Review, the initial Slack notification seems extraneous.

TODO:
* [ ] Add test case
* [ ] Update README
* [ ] Consider if this can be an optional behavior