### PR TITLE
Release message would be more helpful with full repo name and tag

### DIFF
--- a/lib/messages/release.js
+++ b/lib/messages/release.js
@@ -20,7 +20,7 @@ class Release extends Message {
 
     const message = {
       ...super.getBaseMessage(),
-      title: `Release - ${release.name}`,
+      title: `[${repository.full_name}] Release - ${release.name} (${release.tag_name})`,
       fallback: `[${repository.full_name}] Release - ${release.name}`,
       title_link: release.html_url,
       author_name: author.login,


### PR DESCRIPTION
Addresses request I made in https://github.com/integrations/slack/issues/1116 for full repo name and tag in release title.