### PR TITLE
Allow dependabot to check node dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This change configures dependabot to check any node dependencies on a weekly basis and submit automatic pull requests with version bumps in order to keep packages up-to-date.

It appears that this project is already making use of the bot, but I believe this was before it was natively integrated into GitHub.

https://github.com/integrations/slack/pulls?q=is%3Apr+is%3Aopen+label%3Adependencies