### PR TITLE
fix(release): fallback to tag_name when release name is null

### DIFF
--- a/lib/messages/release.js
+++ b/lib/messages/release.js
@@ -17,11 +17,12 @@ class Release extends Message {
   getRenderedMessage() {
     const { release, repository } = this;
     const { author } = release;
+    const releaseName = release.name || release.tag_name;
 
     const message = {
       ...super.getBaseMessage(),
-      title: `Release - ${release.name}`,
-      fallback: `[${repository.full_name}] Release - ${release.name}`,
+      title: `Release - ${releaseName}`,
+      fallback: `[${repository.full_name}] Release - ${releaseName}`,
       title_link: release.html_url,
       author_name: author.login,
       author_link: author.html_url,


### PR DESCRIPTION
We have often this kind of message:

<img width="625" alt="Screen Shot 2021-02-25 at 10 06 36" src="https://user-images.githubusercontent.com/19857479/109130156-b228b280-7751-11eb-9576-5102a4859e67.png">

This is because the user do not fill the release name. IN the github UI display the tag name in this case.
Align slack integration with this