### PR TITLE
Add note that private Slack channels are no longer supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This app officially supports GitHub.com (which includes our GitHub Enterprise cl
 
 <p align="center"><img width="450" alt="auth" src="https://user-images.githubusercontent.com/3877742/36522927-f1d596b6-1753-11e8-9f85-2495e657b16b.png"></p>
 
+**Note:** At this time this integration only works with public Slack channels. While a private Slack channel can subscribe to a repository, it will not post notifications.
+
 After the app is installed, and once you've added the GitHub integration to the relevant channels using `/invite @github`, you will see previews of links to GitHub issues, pull-requests, and code rendered as rich text in your workspace.
 
 <p align="center"><img width="550" alt="unfurl_convo" src="https://user-images.githubusercontent.com/3877742/36522313-c0cdbd08-1750-11e8-8dbe-b5a3a2f93549.png"></p>


### PR DESCRIPTION
After contacting GitHub and Slack support they have reported back that private channels will no longer receive notifications.

Private channels integrated before this bug was introduced may still work, but are not guaranteed to continue working.

[See this issue and conversation w/GitHub and Slack](https://github.com/integrations/slack/issues/774#issuecomment-816751146)