### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ other main workspace.
 #### Don't want threading?
 If you don't want threading functionality or not yet ready to adapt to
 new model, we want to give you the flexibility. You can disable/enable
-threading for Issues and Pull requests noitifications in your
+threading for Issues and Pull requests notifications in your
 channel. You can go to the channel where you don't need threading and
 run the following command.  `/github settings`
 


### PR DESCRIPTION
This applies simple cleanup to the README file:

- Delete trailing whitespace and wrap long lines, which should make future reviews easier.

- Fix the Markdown code so that pictures are in the proper spot within their ordered or unordered lists. This fixes visual rendering as well.

    Before (pictures are aligned too far left):

    <img alt="before" width="404" border="1" src="https://user-images.githubusercontent.com/3029165/226382541-161a15a6-48ad-4df9-adce-1a7a5a177d93.png"/>

    After:

    <img alt="after" width="404" border="1" src="https://user-images.githubusercontent.com/3029165/226382518-ab6962ed-e43c-4e1c-bd33-f163791384e7.png"/>

