### PR TITLE
Add signin example to mentions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ And the best part is - you can now see the summary of GitHub notifications where
 
 
 #### How does mentions work?
-Mentions will work only if you login to GitHub app in your Slack workspace. When you login to GitHub app with your GitHub id, we map it with your Slack id and ping you in Slack whenever you are mentioned in any of the GitHub notifications.  
+Mentions will work only if you login to GitHub app in your Slack workspace (using the `/github signin` slash command). When you login to GitHub app with your GitHub id, we map it with your Slack id and ping you in Slack whenever you are mentioned in any of the GitHub notifications.  
 
 **Note**: If you have multiple Slack workspaces where you use GitHub app, mentions will work only in the workspace where you logged in to GitHub app most recently.
 


### PR DESCRIPTION
The mentions section explains that you need to login to the GitHub app in Slack, but doesn't explain how to do that. The `signin` command it only mentioned in once other place in the entire README and it's very easy to miss it.

Closes #1382.