### PR TITLE
Update GHES integration requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ Starting with GHES 3.8, we are shipping a dedicated ChatOps service bundled alon
 All your subscriptions info and any other metadata stays within your GHES setup. So, you don't have to worry about data flowing to any external service.
 
 2. Bidirectional connectivity between GHES and Slack:
-Our GHES integration is not just a notification service. It will also enable you to perform actions directly from chat. So, the only prerequisite you need to ensure your GHES instance is accessible from Slack. 
+Our GHES integration is not just a notification service. It will also enable you to perform actions directly from chat. So, the only prerequisite you need to ensure your GHES instance is accessible from Slack. With Socked mode enabled, only inbound access from Slack is required.
 
 ### Configuration steps
 The existing GitHub app you see in the app store can only be used for GHEC (hosted GitHub) integration. To integrate your GHES instance with Slack, you need to configure a private GHES app. Here are the steps to integrate with GHES.


### PR DESCRIPTION
Hello team 👋 

Bidirectional connectivity between GHES and Slack is only required for GHES integration with Socket mode disabled. With socked mode enabled, only inbound access from Slack is required.

So I will add the description for network requirement for the case with Socket mode enabled in this PR.

Thanks!