### PR TITLE
remove open-source claims from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitHub + integration for Slack
 ## About
 
-The GitHub integration for Slack gives you and your teams full visibility into your GitHub projects right in Slack channels, where you can generate ideas, triage issues and collaborate with other teams to move projects forward. This integration is an open source project, built and maintained by GitHub.
+The GitHub integration for Slack gives you and your teams full visibility into your GitHub projects right in Slack channels, where you can generate ideas, triage issues and collaborate with other teams to move projects forward. The code for this integration is not open-source, and is not available in this repo.
 
 ## Table of Contents
 - [Installing the GitHub integration for Slack](#installing-the-github-integration-for-slack)


### PR DESCRIPTION
I know there's a notice in the penultimate paragraph just after the licence, however there's also this claim in the first block. This doesn't look to have been true for 6 years now? 